### PR TITLE
Enqueue microtasks with the common runloop modes

### DIFF
--- a/src/NativeScript/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/NativeScript/GlobalObject.mm
@@ -309,7 +309,7 @@ ObjCProtocolWrapper* GlobalObject::protocolWrapperFor(Protocol* aProtocol) {
 }
 
 void GlobalObject::queueTaskToEventLoop(const JSGlobalObject* globalObject, WTF::PassRefPtr<Microtask> task) {
-    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
+    CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopCommonModes, ^{
             task->run(const_cast<JSGlobalObject*>(globalObject)->globalExec());
     });
 }


### PR DESCRIPTION
Promise reactions and other microtasks are executed on the current RunLoop in its default mode. Move this execution to the set of common modes to bump its priority.

Fixes #39