### PR TITLE
Remove getOwnPropertyNames override of GlobalObject

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -253,14 +253,16 @@ module.exports = function (grunt) {
 
         shell: {
             buildXcodeProject: {
-                command: function (project, target, outputPath) {
+                command: function (project, target, outputPath, configuration) {
                     if (grunt.file.exists(outputPath)) {
                         grunt.file.delete(outputPath);
                     }
 
+                    configuration = configuration || 'Release';
+
                     outputPath = path.join('../../', outputPath);
 
-                    return util.format('xcodebuild -project %s -target %s -configuration Release -sdk iphoneos ARCHS=armv7 VALID_ARCHS=armv7 CONFIGURATION_BUILD_DIR="%s" clean build | xcpretty', project, target, outputPath);
+                    return util.format('xcodebuild -project %s -target %s -configuration %s -sdk iphoneos ARCHS=armv7 VALID_ARCHS=armv7 CONFIGURATION_BUILD_DIR="%s" clean build | xcpretty', project, target, configuration, outputPath);
                 }
             },
 
@@ -439,7 +441,7 @@ module.exports = function (grunt) {
         "jsc",
         "metadataTools",
         'test-metadata',
-        'shell:buildXcodeProject:tests/NativeScriptTests/NativeScriptTests.xcodeproj:NativeScriptTests:tests/NativeScriptTests/build/',
+        'shell:buildXcodeProject:tests/NativeScriptTests/NativeScriptTests.xcodeproj:NativeScriptTests:tests/NativeScriptTests/build/:Debug',
         util.format('shell:runTests:./tests/NativeScriptTests/build/NativeScriptTests.app:./junit-result.xml:%s', DEVICE_UDID)
     ]);
 

--- a/src/NativeScript/NativeScript/GlobalObject.h
+++ b/src/NativeScript/NativeScript/GlobalObject.h
@@ -44,7 +44,9 @@ public:
 
     static bool getOwnPropertySlot(JSC::JSObject* object, JSC::ExecState* execState, JSC::PropertyName propertyName, JSC::PropertySlot& propertySlot);
 
+#if DEBUG
     static void getOwnPropertyNames(JSC::JSObject* object, JSC::ExecState* execState, JSC::PropertyNameArray& propertyNames, JSC::EnumerationMode enumerationMode);
+#endif
 
     static void visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor);
 

--- a/src/NativeScript/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/NativeScript/GlobalObject.mm
@@ -248,6 +248,15 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     return false;
 }
 
+#if DEBUG
+// There are more then 10000+ global object properties. When the debugger is attached,
+// it calls this method on every breakpoint/step-in, which is *really* slow.
+// On devices with not enough free memory, it even crashes the running application.
+//
+// This method is used only for testing now.
+// It materializes all Objective-C classes and their methods and their parameter types.
+//
+// Once we start grouping declarations by modules, this can be safely restored.
 void GlobalObject::getOwnPropertyNames(JSObject* object, ExecState* execState, PropertyNameArray& propertyNames, EnumerationMode enumerationMode) {
     MetaFileReader* metadata = getMetadata();
     for (MetaIterator it = metadata->begin(); it != metadata->end(); ++it) {
@@ -256,6 +265,7 @@ void GlobalObject::getOwnPropertyNames(JSObject* object, ExecState* execState, P
 
     Base::getOwnPropertyNames(object, execState, propertyNames, enumerationMode);
 }
+#endif
 
 ObjCConstructorBase* GlobalObject::constructorFor(Class klass, Class fallback) {
     ASSERT(klass);


### PR DESCRIPTION
This commit speeds up the debugger and makes it usable.
Also fixes the crash on device.