### PR TITLE
Add a global uncaught error handler

### DIFF
--- a/build/project-template/__PROJECT_NAME__/main.m
+++ b/build/project-template/__PROJECT_NAME__/main.m
@@ -23,13 +23,8 @@ int main(int argc, char* argv[]) {
         id debuggingServer = [runtime enableDebuggingWithName:[NSBundle mainBundle].bundleIdentifier];
 #endif
 
-        JSValueRef error = NULL;
-        [runtime executeModule:@"./bootstrap" error:&error];
+        [runtime executeModule:@"./bootstrap"];
 
-        if (error) {
-            return -1;
-        } else {
-            return 0;
-        }
+        return 0;
     }
 }

--- a/examples/Gameraww/Gameraww/main.m
+++ b/examples/Gameraww/Gameraww/main.m
@@ -21,14 +21,9 @@ int main(int argc, char *argv[]) {
 #ifdef NATIVESCRIPT_DEBUGGING
         id debuggingServer = [runtime enableDebuggingWithName:[NSBundle mainBundle].bundleIdentifier];
 #endif
-        
-        JSValueRef error = NULL;
-        [runtime executeModule:@"./bootstrap" error:&error];
 
-        if (error) {
-            return -1;
-        } else {
-            return 0;
-        }
+        [runtime executeModule:@"./bootstrap"];
+
+        return 0;
     }
 }

--- a/examples/TNSApp/TNSApp/main.m
+++ b/examples/TNSApp/TNSApp/main.m
@@ -22,14 +22,8 @@ int main(int argc, char *argv[]) {
 #ifdef NATIVESCRIPT_DEBUGGING
         id debuggingServer = [runtime enableDebuggingWithName:[NSBundle mainBundle].bundleIdentifier];
 #endif
-        
-        JSValueRef error = NULL;
-        [runtime executeModule:@"./bootstrap" error:&error];
 
-        if (error) {
-            return -1;
-        } else {
-            return 0;
-        }
+        [runtime executeModule:@"./bootstrap"];
+        return 0;
     }
 }

--- a/src/NativeScript/NativeScript/TNSRuntime+Inspector.h
+++ b/src/NativeScript/NativeScript/TNSRuntime+Inspector.h
@@ -9,6 +9,8 @@
 #import "TNSRuntime.h"
 #import <Foundation/Foundation.h>
 
+FOUNDATION_EXPORT NSString* const TNSInspectorRunLoopMode;
+
 @interface TNSRuntimeInspector : NSObject
 
 + (BOOL)logsToSystemConsole;

--- a/src/NativeScript/NativeScript/TNSRuntime+Inspector.mm
+++ b/src/NativeScript/NativeScript/TNSRuntime+Inspector.mm
@@ -20,6 +20,8 @@
 using namespace JSC;
 using namespace NativeScript;
 
+NSString* const TNSInspectorRunLoopMode = @"com.apple.JavaScriptCore.remote-inspector-runloop-mode";
+
 class TNSRuntimeInspectorFrontendChannel : public Inspector::InspectorFrontendChannel {
 public:
     TNSRuntimeInspectorFrontendChannel(TNSRuntimeInspectorMessageHandler handler, ExecState* execState)

--- a/src/NativeScript/NativeScript/TNSRuntime+Private.h
+++ b/src/NativeScript/NativeScript/TNSRuntime+Private.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 г. Telerik. All rights reserved.
 //
 
-#include "TNSRuntime.h"
+#import "TNSRuntime.h"
 
 @interface TNSRuntime () {
 @package

--- a/src/NativeScript/NativeScript/TNSRuntime.h
+++ b/src/NativeScript/NativeScript/TNSRuntime.h
@@ -6,6 +6,13 @@
 //  Copyright (c) 2014 г. Telerik. All rights reserved.
 //
 
+#import <JavaScriptCore/JSBase.h>
+#import <Foundation/NSObjCRuntime.h>
+
+typedef void (*TNSUncaughtErrorHandler)(JSContextRef ctx, JSValueRef error);
+
+FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handler);
+
 @interface TNSRuntime : NSObject
 
 @property(nonatomic, retain) NSString* applicationPath;
@@ -14,6 +21,6 @@
 
 - (JSGlobalContextRef)globalContext;
 
-- (void)executeModule:(NSString*)entryPointModuleIdentifier error:(JSValueRef*)error;
+- (void)executeModule:(NSString*)entryPointModuleIdentifier;
 
 @end

--- a/src/NativeScript/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/NativeScript/TNSRuntime.mm
@@ -87,7 +87,7 @@ static JSC_HOST_CALL EncodedJSValue createModuleFunction(ExecState* execState) {
     return JSValue::encode(moduleFunction);
 }
 
-- (void)executeModule:(NSString*)entryPointModuleIdentifier error:(JSValueRef*)error {
+- (void)executeModule:(NSString*)entryPointModuleIdentifier {
     JSLockHolder lock(*self->_vm);
 
     JSValue exception;
@@ -98,10 +98,7 @@ static JSC_HOST_CALL EncodedJSValue createModuleFunction(ExecState* execState) {
 #endif
     JSValue requireFactory = evaluate(self->_globalObject->globalExec(), sourceCode, JSValue(), &exception);
     if (exception) {
-        self->_globalObject->inspectorController().reportAPIException(self->_globalObject->globalExec(), exception);
-        if (error) {
-            *error = toRef(self->_globalObject->globalExec(), exception);
-        }
+        reportFatalErrorBeforeShutdown(self->_globalObject->globalExec(), exception);
         return;
     }
 
@@ -112,10 +109,7 @@ static JSC_HOST_CALL EncodedJSValue createModuleFunction(ExecState* execState) {
     CallType requireFactoryCallType = requireFactory.asCell()->methodTable()->getCallData(requireFactory.asCell(), requireFactoryCallData);
     JSValue require = call(self->_globalObject->globalExec(), requireFactory.asCell(), requireFactoryCallType, requireFactoryCallData, jsNull(), requireFactoryArgs, &exception);
     if (exception) {
-        self->_globalObject->inspectorController().reportAPIException(self->_globalObject->globalExec(), exception);
-        if (error) {
-            *error = toRef(self->_globalObject->globalExec(), exception);
-        }
+        reportFatalErrorBeforeShutdown(self->_globalObject->globalExec(), exception);
         return;
     }
 
@@ -126,10 +120,7 @@ static JSC_HOST_CALL EncodedJSValue createModuleFunction(ExecState* execState) {
     CallType requireCallType = require.asCell()->methodTable()->getCallData(require.asCell(), requireCallData);
     call(self->_globalObject->globalExec(), require.asCell(), requireCallType, requireCallData, jsNull(), requireArgs, &exception);
     if (exception) {
-        self->_globalObject->inspectorController().reportAPIException(self->_globalObject->globalExec(), exception);
-        if (error) {
-            *error = toRef(self->_globalObject->globalExec(), exception);
-        }
+        reportFatalErrorBeforeShutdown(self->_globalObject->globalExec(), exception);
     }
 }
 

--- a/tests/NativeScriptTests/NativeScriptTests/Utilities.h
+++ b/tests/NativeScriptTests/NativeScriptTests/Utilities.h
@@ -9,4 +9,4 @@
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/JavaScript.h>
 
-NSString* toString(JSGlobalContextRef context, JSValueRef value);
+NSString* toString(JSContextRef context, JSValueRef value);

--- a/tests/NativeScriptTests/NativeScriptTests/Utilities.m
+++ b/tests/NativeScriptTests/NativeScriptTests/Utilities.m
@@ -8,7 +8,7 @@
 
 #import "Utilities.h"
 
-NSString *toString(JSGlobalContextRef context, JSValueRef value) {
+NSString *toString(JSContextRef context, JSValueRef value) {
     JSStringRef errorMessageRef = JSValueToStringCopy(context, value, NULL);
     size_t errorSize = JSStringGetMaximumUTF8CStringSize(errorMessageRef);
     char errorMessage[errorSize];


### PR DESCRIPTION
A general way to handle uncaught errors from the runtime. Expose the necessary APIs to let handlers spin up the inspector runloop.