### PR TITLE
The hostname of the WebSocket server will be the same as the web host that servers the web inspector pages

### DIFF
--- a/src/debugging/WebInspectorUI-600.1.4/UserInterface/Protocol/InspectorFrontendHostStub.js
+++ b/src/debugging/WebInspectorUI-600.1.4/UserInterface/Protocol/InspectorFrontendHostStub.js
@@ -168,7 +168,16 @@ if (!window.InspectorFrontendHost) {
     }
 
     InspectorFrontendHost = new WebInspector.InspectorFrontendHostStub();
-    var host = (window.location.hash) ? window.location.hash.substring(1, window.location.hash.length) : "localhost:8080";
+    
+    var host;
+    if (window.location.hash) {
+        host = window.location.hash.substring(1, window.location.hash.length);
+    } else if (window.location.protocol == "http:" || window.location.protocol == "https:") {
+        host = window.location.hostname + ":8080"
+    } else {
+        host = "localhost:8080";
+    }
+
     InspectorFrontendHost.initializeWebSocket("ws://" + host + "/", "TNSDebuggingProtocol");
     WebInspector.dontLocalizeUserInterface = true;
 }


### PR DESCRIPTION
When a webserver on the device hosts the inspector,
the WebSocket client should connect to the device.
Currently it connects to "localhost" which is the Mac or PC from where it is accessed.