### PR TITLE
Drop all locks when calling out to native

### DIFF
--- a/src/NativeScript/NativeScript/FFICall.h
+++ b/src/NativeScript/NativeScript/FFICall.h
@@ -47,7 +47,8 @@ protected:
         return *static_cast<T*>(this->_arguments[index]);
     }
 
-    void executeFFICall(void (*function)(void)) {
+    void executeFFICall(JSC::ExecState* execState, void (*function)(void)) {
+        JSC::JSLock::DropAllLocks locksDropper(execState);
         ffi_call(this->_cif, function, this->_return, this->_arguments);
     }
 

--- a/src/NativeScript/NativeScript/FFIFunctionCall.mm
+++ b/src/NativeScript/NativeScript/FFIFunctionCall.mm
@@ -29,7 +29,7 @@ EncodedJSValue FFIFunctionCall::executeCall(ExecState* execState) {
         return JSValue::encode(jsUndefined());
     }
 
-    self->executeFFICall(FFI_FN(self->_functionPointer));
+    self->executeFFICall(execState, FFI_FN(self->_functionPointer));
 
     JSValue result = self->postCall(execState);
     if (self->retainsReturnedCocoaObjects()) {

--- a/src/NativeScript/NativeScript/ObjCBlockCall.mm
+++ b/src/NativeScript/NativeScript/ObjCBlockCall.mm
@@ -40,7 +40,7 @@ EncodedJSValue ObjCBlockCall::executeCall(ExecState* execState) {
         return JSValue::encode(jsUndefined());
     }
 
-    self->executeFFICall(FFI_FN(reinterpret_cast<BlockLiteral*>(self->_block.get())->invoke));
+    self->executeFFICall(execState, FFI_FN(reinterpret_cast<BlockLiteral*>(self->_block.get())->invoke));
 
     return JSValue::encode(self->postCall(execState));
 }

--- a/src/NativeScript/NativeScript/ObjCClassBuilder.mm
+++ b/src/NativeScript/NativeScript/ObjCClassBuilder.mm
@@ -50,6 +50,7 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
     IMP newAllocWithZone = imp_implementationWithBlock(^(id self, NSZone* nsZone) {
         id instance = allocWithZone(self, @selector(allocWithZone:), nsZone);
         VM& vm = globalObject->vm();
+        JSLockHolder lockHolder(vm);
 
         Structure* instancesStructure = globalObject->constructorFor(blockKlass)->instancesStructure();
         ObjCWrapperObject* derivedWrapper = ObjCWrapperObject::create(vm, instancesStructure, instance);
@@ -68,6 +69,7 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
     IMP newRetain = imp_implementationWithBlock(^(id self) {
         if ([self retainCount] == 1) {
             if (TNSValueWrapper* wrapper = objc_getAssociatedObject(self, globalObject->JSScope::vm())) {
+                JSLockHolder lockHolder(globalObject->vm());
                 gcProtect(wrapper.value);
             }
         }
@@ -80,6 +82,7 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
     IMP newRelease = imp_implementationWithBlock(^(id self) {
         if ([self retainCount] == 2) {
             if (TNSValueWrapper* wrapper = objc_getAssociatedObject(self, globalObject->JSScope::vm())) {
+                JSLockHolder lockHolder(globalObject->vm());
                 gcUnprotect(wrapper.value);
             }
         }

--- a/src/NativeScript/NativeScript/ObjCConstructorCall.mm
+++ b/src/NativeScript/NativeScript/ObjCConstructorCall.mm
@@ -39,7 +39,7 @@ EncodedJSValue JSC_HOST_CALL ObjCConstructorCall::executeCall(ExecState* execSta
 
     id instance = [self->_klass alloc];
     self->setArgument(0, instance);
-    self->executeFFICall(FFI_FN(&objc_msgSend));
+    self->executeFFICall(execState, FFI_FN(&objc_msgSend));
 
     JSValue result = self->postCall(execState);
     [instance release];

--- a/src/NativeScript/NativeScript/ObjCMethodCall.mm
+++ b/src/NativeScript/NativeScript/ObjCMethodCall.mm
@@ -77,14 +77,14 @@ EncodedJSValue JSC_HOST_CALL ObjCMethodCall::executeCall(ExecState* execState) {
         NSLog(@"> %@[%@(%@) %@]", isInstance ? @"-" : @"+", NSStringFromClass(targetClass), NSStringFromClass(super.super_class), NSStringFromSelector(self->getArgument<SEL>(1)));
 #endif
         self->setArgument(0, &super);
-        self->executeFFICall(FFI_FN(self->_msgSendSuper));
+        self->executeFFICall(execState, FFI_FN(self->_msgSendSuper));
     } else {
 #if DEBUG_OBJC_INVOCATION
         bool isInstance = !class_isMetaClass(targetClass);
         NSLog(@"> %@[%@ %@]", isInstance ? @"-" : @"+", NSStringFromClass(targetClass), NSStringFromSelector(self->getArgument<SEL>(1)));
 #endif
         self->setArgument(0, target);
-        self->executeFFICall(FFI_FN(self->_msgSend));
+        self->executeFFICall(execState, FFI_FN(self->_msgSend));
     }
 
     JSValue result = self->postCall(execState);


### PR DESCRIPTION
Turns out there's a nasty race condition waiting to happen if a thread other than the one that owns the VM tries to call into JavaScript using `FFICallback`. The guilty party is `ABAddressBookRequestAccessWithCompletion`, whose completion block is called on an arbitrary queue. This queue tries to acquire the VM's API lock, but fails because the VM owner thread is still holding on to it.

The answer is to temporarily drop all locks before calling a native API so that a worker thread spawned by the native API can have the chance to acquire the API lock.