### PR TITLE
Change TNSDebugging's transport encoding

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -71,7 +71,7 @@ startListening(TNSInspectorFrontendConnectedHandler connectedHandler) {
 
       TNSInspectorSendMessageBlock sender = ^(NSString *message) {
           NSData *messageData =
-              [message dataUsingEncoding:NSUTF8StringEncoding];
+              [message dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
           uint32_t length = htonl(messageData.length);
 
           NSMutableData *payload =
@@ -116,7 +116,7 @@ startListening(TNSInspectorFrontendConnectedHandler connectedHandler) {
 
               NSString *payload =
                   [[NSString alloc] initWithData:(NSData *)data
-                                        encoding:NSUTF8StringEncoding];
+                                        encoding:NSUTF16LittleEndianStringEncoding];
               handler(payload, nil);
 
               dispatch_io_read(io, 0, 4, queue, ioHandler);

--- a/src/debugging/debugger-proxy.js
+++ b/src/debugging/debugger-proxy.js
@@ -43,7 +43,7 @@ server.on("connection", function(webSocket) {
 	
 	packets.on("data", function (buffer) {
 		//console.log("DEVICE " + buffer.toString("utf8"));
-		webSocket.send(buffer.toString("utf8"), function (error) {
+		webSocket.send(buffer.toString("utf16le"), function (error) {
 			if (error) {
 				console.log("ERROR " + error);
 				process.exit(0);
@@ -53,10 +53,10 @@ server.on("connection", function(webSocket) {
 	
 	webSocket.on("message", function (message, flags) {
 		//console.log("FRONTEND " + message);
-		var length = Buffer.byteLength(message, "utf8");
+		var length = Buffer.byteLength(message, "utf16le");
 		var payload = new Buffer(length + 4);
 		payload.writeInt32BE(length, 0);
-		payload.write(message, 4, length, "utf8");
+		payload.write(message, 4, length, "utf16le");
 		deviceSocket.write(payload);
 	});
 	


### PR DESCRIPTION
Graphite uses UTF-16 and thus its easier to change it here rather than break Graphite as well.