### PR TITLE
Insert richer modules information in metadata and expose it in metadata API.

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -176,7 +176,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     case Interface: {
         Class klass = objc_getClass(symbolMeta->name());
         if (!klass) {
-            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModuleName());
+            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModule()->getName());
             klass = objc_getClass(symbolMeta->name());
         }
 
@@ -189,7 +189,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     case ProtocolType: {
         Protocol* aProtocol = objc_getProtocol(symbolMeta->name());
         if (!aProtocol) {
-            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModuleName());
+            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModule()->getName());
             aProtocol = objc_getProtocol(symbolMeta->name());
         }
 
@@ -209,7 +209,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
         break;
     }
     case MetaType::Function: {
-        void* functionSymbol = SymbolLoader::instance().loadFunctionSymbol(symbolMeta->topLevelModuleName(), symbolMeta->name());
+        void* functionSymbol = SymbolLoader::instance().loadFunctionSymbol(symbolMeta->topLevelModule()->getName(), symbolMeta->name());
         if (functionSymbol) {
             const FunctionMeta* functionMeta = static_cast<const FunctionMeta*>(symbolMeta);
             const Metadata::TypeEncoding* encodingPtr = functionMeta->encodings()->first();
@@ -221,7 +221,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     }
     case Var: {
         const VarMeta* varMeta = static_cast<const VarMeta*>(symbolMeta);
-        void* varSymbol = SymbolLoader::instance().loadDataSymbol(varMeta->topLevelModuleName(), varMeta->name());
+        void* varSymbol = SymbolLoader::instance().loadDataSymbol(varMeta->topLevelModule()->getName(), varMeta->name());
         if (varSymbol) {
             const Metadata::TypeEncoding* encoding = varMeta->encoding();
             JSCell* symbolType = globalObject->typeFactory()->parseType(globalObject, encoding);

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
@@ -37,7 +37,7 @@ bool ObjCConstructorNative::getOwnPropertySlot(JSObject* object, ExecState* exec
     ObjCConstructorNative* constructor = jsCast<ObjCConstructorNative*>(object);
 
     if (const MethodMeta* method = constructor->_metadata->staticMethod(propertyName.publicName())) {
-        SymbolLoader::instance().ensureFramework(method->topLevelModuleName());
+        SymbolLoader::instance().ensureFramework(method->topLevelModule()->getName());
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
         ObjCMethodCall* call = ObjCMethodCall::create(execState->vm(), globalObject, globalObject->objCMethodCallStructure(), method);

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -43,7 +43,7 @@ bool ObjCPrototype::getOwnPropertySlot(JSObject* object, ExecState* execState, P
     ObjCPrototype* prototype = jsCast<ObjCPrototype*>(object);
 
     if (const MethodMeta* memberMeta = prototype->_metadata->instanceMethod(propertyName.publicName())) {
-        SymbolLoader::instance().ensureFramework(memberMeta->topLevelModuleName());
+        SymbolLoader::instance().ensureFramework(memberMeta->topLevelModule()->getName());
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(prototype->globalObject());
         ObjCMethodCall* method = ObjCMethodCall::create(globalObject->vm(), globalObject, globalObject->objCMethodCallStructure(), memberMeta);
@@ -153,7 +153,7 @@ void ObjCPrototype::materializeProperties(VM& vm, GlobalObject* globalObject) {
 
     for (const PropertyMeta* propertyMeta : properties) {
         if (propertyMeta->isAvailable()) {
-            SymbolLoader::instance().ensureFramework(propertyMeta->topLevelModuleName());
+            SymbolLoader::instance().ensureFramework(propertyMeta->topLevelModule()->getName());
 
             const MethodMeta* getter = (propertyMeta->getter() != nullptr && propertyMeta->getter()->isAvailable()) ? propertyMeta->getter() : nullptr;
             const MethodMeta* setter = (propertyMeta->setter() != nullptr && propertyMeta->setter()->isAvailable()) ? propertyMeta->setter() : nullptr;

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -275,7 +275,7 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
 
     Class klass = objc_getClass(klassNameCharPtr);
     if (!klass) {
-        SymbolLoader::instance().ensureFramework(metadata->topLevelModuleName());
+        SymbolLoader::instance().ensureFramework(metadata->topLevelModule()->getName());
         klass = objc_getClass(klassNameCharPtr);
     }
 


### PR DESCRIPTION
Each meta has a pointer to ModuleMeta structure which describes a top level module (only top level modules can be required). All ModuleMeta structures are also kept in global ModuleTable (an array of pointers to ModuleMetas, sorted by module name). This table is used to perform lookups by module name.