### PR TITLE
Release the proper value when new-ing classes

### DIFF
--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
@@ -42,7 +42,11 @@ EncodedJSValue JSC_HOST_CALL ObjCConstructorCall::executeCall(ExecState* execSta
     self->executeFFICall(execState, FFI_FN(&objc_msgSend));
 
     JSValue result = self->postCall(execState);
-    [instance release];
+
+    // wrapping the object retains it, we need to balance the +1 from alloc-ing it
+    id resultObject = *static_cast<id*>(self->getReturn());
+    [resultObject release];
+
     return JSValue::encode(result);
 }
 

--- a/tests/TestFixtures/CMakeLists.txt
+++ b/tests/TestFixtures/CMakeLists.txt
@@ -7,6 +7,7 @@ set(HEADER_FILES
     Interfaces/TNSConstructorResolution.h
     Interfaces/TNSInheritance.h
     Interfaces/TNSMethodCalls.h
+    Interfaces/TNSClassWithPlaceholder.h
     Marshalling/TNSFunctionPointers.h
     Marshalling/TNSObjCTypes.h
     Marshalling/TNSPrimitivePointers.h
@@ -22,6 +23,7 @@ set(SOURCE_FILES
     Interfaces/TNSConstructorResolution.m
     Interfaces/TNSInheritance.m
     Interfaces/TNSMethodCalls.m
+    Interfaces/TNSClassWithPlaceholder.m
     Marshalling/TNSFunctionPointers.m
     Marshalling/TNSObjCTypes.m
     Marshalling/TNSPrimitivePointers.m
@@ -30,6 +32,8 @@ set(SOURCE_FILES
     TNSTestNativeCallbacks.m
     TNSTestCommon.m
 )
+
+set_source_files_properties(Interfaces/TNSClassWithPlaceholder.m PROPERTIES COMPILE_FLAGS -fno-objc-arc)
 
 add_library(TestFixtures STATIC ${HEADER_FILES} ${SOURCE_FILES})
 

--- a/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.h
+++ b/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.h
@@ -1,0 +1,13 @@
+//
+//  TNSClassWithPlaceholder.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 26.05.15.
+//  Copyright (c) 2015 г. Telerik. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface TNSClassWithPlaceholder : NSObject
+
+@end

--- a/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
+++ b/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
@@ -1,0 +1,51 @@
+//
+//  TNSClassWithPlaceholder.m
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 26.05.15.
+//  Copyright (c) 2015 г. Telerik. All rights reserved.
+//
+
+#import "TNSClassWithPlaceholder.h"
+
+@interface TNSClassWithPlaceholderReal : TNSClassWithPlaceholder
+
+@end
+
+@implementation TNSClassWithPlaceholderReal
+
+- (NSString *)description {
+    return @"real";
+}
+
+@end
+
+@interface TNSClassWithPlaceholderPlaceholder : TNSClassWithPlaceholder
+
+@end
+
+@implementation TNSClassWithPlaceholderPlaceholder
+
+- (TNSClassWithPlaceholder *)init {
+    return (id)[[TNSClassWithPlaceholderReal alloc] init];
+}
+
+- (oneway void)release {
+    [super release];
+
+    TNSLog(@"release on placeholder called");
+}
+
+@end
+
+@implementation TNSClassWithPlaceholder
+
++ (instancetype)alloc {
+    if (self == [TNSClassWithPlaceholder class]) {
+        return [TNSClassWithPlaceholderPlaceholder alloc];
+    }
+
+    return [super alloc];
+}
+
+@end

--- a/tests/TestFixtures/TestFixtures.h
+++ b/tests/TestFixtures/TestFixtures.h
@@ -21,6 +21,7 @@
 #import "Interfaces/TNSMethodCalls.h"
 #import "Interfaces/TNSConstructorResolution.h"
 #import "Interfaces/TNSInheritance.h"
+#import "Interfaces/TNSClassWithPlaceholder.h"
 
 #import "TNSTestCommon.h"
 

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -1,0 +1,12 @@
+describe("Constructing Objective-C classes with new operator", function () {
+    afterEach(function () {
+        TNSClearOutput();
+    });
+    
+    it("should not release the result of alloc", function () {
+        var obj = new TNSClassWithPlaceholder();
+        
+        expect(obj.description).toBe("real");
+        expect(TNSGetOutput()).toBe("");
+    }) 
+});

--- a/tests/TestRunner/app/bootstrap.js
+++ b/tests/TestRunner/app/bootstrap.js
@@ -55,6 +55,7 @@ require('./MethodCallsTests');
 require('./FunctionsTests');
 require('./VersionDiffTests');
 require('./ApiTests');
+require('./ObjCConstructors');
 
 require('./MetadataTests');
 


### PR DESCRIPTION
`ObjCConstructorCall` used to release the object returned by `alloc`, but it has to release the object returned by the initializer call instead, to account for cases when `alloc` returns a dummy placeholder factory object or when an initializer replaces `self`.