### PR TITLE
Remove the release build of the shared framework.

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -15,14 +15,11 @@ cmake --build . --config Release --target NativeScript
 cmake .. -DCMAKE_OSX_SYSROOT=iphoneos $CMAKE_FLAGS -DBUILD_SHARED_LIBS=YES
 cmake --build . --config Release --target NativeScript
 
-echo "Packaging NativeScript-Shared..."
-mkdir -p $WORKSPACE/dist/NativeScriptEmbedded/Release
-cp -r $WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework $WORKSPACE/dist/NativeScriptEmbedded/Release
-
-mkdir -p $WORKSPACE/dist/NativeScriptEmbedded/Debug
-cp -r $WORKSPACE/dist/NativeScriptEmbedded/Release/NativeScript.framework $WORKSPACE/dist/NativeScriptEmbedded/Debug
-rm $WORKSPACE/dist/NativeScriptEmbedded/Debug/NativeScript.framework/NativeScript
-lipo -create -output $WORKSPACE/dist/NativeScriptEmbedded/Debug/NativeScript.framework/NativeScript \
+echo "Packaging NativeScript.framework..."
+mkdir -p $WORKSPACE/dist
+cp -r $WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework $WORKSPACE/dist
+rm $WORKSPACE/dist/NativeScript.framework/NativeScript
+lipo -create -output $WORKSPACE/dist/NativeScript.framework/NativeScript \
     $WORKSPACE/cmake-build/src/NativeScript/Release-iphonesimulator/NativeScript.framework/NativeScript \
     $WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework/NativeScript
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -134,7 +134,7 @@ module.exports = function (grunt) {
             packageComponents: {
                 files: [
                     { expand: true, cwd: "<%= outDistDir %>", src: ["NativeScript", "NativeScript/**"], dest: "<%= outPackageFrameworkDir %>" },
-                    { expand: true, cwd: "<%= outDistDir %>/NativeScriptEmbedded/Debug/", src: ["NativeScript.framework", "NativeScript.framework/**"], dest: "<%= outPackageFrameworkDir %>" },
+                    { expand: true, cwd: "<%= outDistDir %>", src: ["NativeScript.framework", "NativeScript.framework/**"], dest: "<%= outPackageFrameworkDir %>" },
                     { expand: true, cwd: "<%= srcDir %>/src/debugging", src: "TNSDebugging.h", dest: "<%= outPackageFrameworkDir %>/__PROJECT_NAME__" },
                     { expand: true, cwd: "<%= srcDir %>/src/debugging/WebInspectorUI", src: "**", dest: "<%= outPackageDir %>/WebInspectorUI/Safari" },
                     { expand: true, cwd: "<%= outDistDir %>/metadataGenerator", src: "**", dest: "<%= outPackageFrameworkDir %>/metadataGenerator" },


### PR DESCRIPTION
The project template will now strip the unwanted architectures.