### PR TITLE
TNSDebugging should work with the dynamic NativeScript.framework.

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -137,8 +137,7 @@ static dispatch_source_t TNSCreateInspectorServer(
 }
 
 static void TNSObjectiveCUncaughtExceptionHandler(NSException *exception) {
-  JSStringRef exceptionMessage =
-      JSStringCreateWithCFString((__bridge CFStringRef)(exception.description));
+  JSStringRef exceptionMessage = JSStringCreateWithUTF8CString(exception.description.UTF8String);
 
   JSValueRef errorArguments[] = {
       JSValueMakeString(runtime.globalContext, exceptionMessage)};


### PR DESCRIPTION
The JSStringCreateWithCFString symbol, used in TNSDebugging.h, seems to be stripped from the dynamic NativeScript.framework. Replaced it with JSStringCreateWithUTF8CString so that the debugging can work with that framework.