### PR TITLE
Support for iOS 9 and new Objective-C syntax (generics, nullability specifiers, new keywords etc.)

### DIFF
--- a/build/scripts/metadata-generation-build-step.sh
+++ b/build/scripts/metadata-generation-build-step.sh
@@ -11,7 +11,7 @@ function generateMetadata {
         -std $GCC_C_LANGUAGE_STANDARD \
         -header-search-paths "$HEADER_SEARCH_PATHS" \
         -framework-search-paths "$FRAMEWORK_SEARCH_PATHS" \
-        -remove-new-objc-features=true \
+        -enable-header-preprocessing-if-needed=true \
         -output-bin "$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/metadata-$1.bin" \
         -output-umbrella "$BUILT_PRODUCTS_DIR/umbrella-$1.h" \
         2> "$errorLog"

--- a/build/scripts/metadata-generation-build-step.sh
+++ b/build/scripts/metadata-generation-build-step.sh
@@ -11,6 +11,7 @@ function generateMetadata {
         -std $GCC_C_LANGUAGE_STANDARD \
         -header-search-paths "$HEADER_SEARCH_PATHS" \
         -framework-search-paths "$FRAMEWORK_SEARCH_PATHS" \
+        -remove-new-objc-features=true \
         -output-bin "$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/metadata-$1.bin" \
         -output-umbrella "$BUILT_PRODUCTS_DIR/umbrella-$1.h" \
         2> "$errorLog"

--- a/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
+++ b/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
@@ -14,7 +14,7 @@
 
 @implementation TNSClassWithPlaceholderReal
 
-- (NSString *)description {
+- (NSString*)description {
     return @"real";
 }
 
@@ -26,9 +26,14 @@
 
 @implementation TNSClassWithPlaceholderPlaceholder
 
-- (TNSClassWithPlaceholder *)init {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
+
+- (TNSClassWithPlaceholder*)init {
     return (id)[[TNSClassWithPlaceholderReal alloc] init];
 }
+
+#pragma clang diagnostic pop
 
 - (oneway void)release {
     [super release];


### PR DESCRIPTION
To parse iOS 9 SDK headers, we strip on the fly all unfamiliar syntax.