### PR TITLE
FFICall now allocates packed structure for the call arguments, so we …

### DIFF
--- a/src/NativeScript/Marshalling/Fundamentals/FFINumericTypes.mm
+++ b/src/NativeScript/Marshalling/Fundamentals/FFINumericTypes.mm
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Telerik. All rights reserved.
 //
 
+#include <string.h>
 #include "FFINumericTypes.h"
 
 namespace NativeScript {
@@ -16,7 +17,9 @@ using namespace JSC;
         return jsNumber(*static_cast<const T*>(buffer));                                                 \
     }                                                                                                    \
     static void name##Write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {    \
-        *static_cast<T*>(buffer) = value.toNumber(execState);                                            \
+        /* TRICKY: The buffer pointer is no longer well aligned T. */                                    \
+        T theValue = value.toNumber(execState);                                                          \
+        memcpy(buffer, &theValue, sizeof(T));                                                            \
     }                                                                                                    \
     static void name##PostCall(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) { \
     }                                                                                                    \


### PR DESCRIPTION
…have to keep that in mind when we deal with the argument pointers.