### PR TITLE
Make the API iterator test asynchronous.

### DIFF
--- a/tests/TestRunner/app/Infrastructure/Jasmine/jasmine-2.0.1/jasmine.js
+++ b/tests/TestRunner/app/Infrastructure/Jasmine/jasmine-2.0.1/jasmine.js
@@ -102,7 +102,7 @@ getJasmineRequireObj().base = (function (jasmineGlobal) {
 
     j$.MAX_PRETTY_PRINT_DEPTH = 40;
     j$.MAX_PRETTY_PRINT_ARRAY_LENGTH = 100;
-    j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
+    j$.DEFAULT_TIMEOUT_INTERVAL = 100000;
 
     j$.getGlobal = function() {
       return jasmineGlobal;


### PR DESCRIPTION
This was my WIP when testing https://github.com/NativeScript/ios-runtime/pull/196 but it could be merged alone.

I think, that It allows the GC to kick more sporadically and sometimes `RecordFields` are released before they are assigned to `RecordPrototype`.