### PR TITLE
Implement and consume NSFastEnumeration

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -48,6 +48,12 @@ set(HEADER_FILES
     ObjC/Inheritance/ObjCClassBuilder.h
     ObjC/Inheritance/ObjCExtend.h
     ObjC/Inheritance/ObjCTypeScriptExtend.h
+    ObjC/Enumeration/ObjCFastEnumerationIterator.h
+    ObjC/Enumeration/ObjCFastEnumerationIterator.mm
+    ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.h
+    ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.mm
+    ObjC/Enumeration/TNSFastEnumerationAdapter.h
+    ObjC/Enumeration/TNSFastEnumerationAdapter.mm
     ObjC/ObjCMethodCall.h
     ObjC/ObjCMethodCallback.h
     ObjC/ObjCPrimitiveTypes.h

--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -124,6 +124,10 @@ public:
         return _typeFactory.get();
     }
 
+    JSC::Structure* fastEnumerationIteratorStructure() const {
+        return this->_fastEnumerationIteratorStructure.get();
+    }
+
 #if defined(__LP64__) && __LP64__
     JSC::WeakGCMap<const void*, ObjCWrapperObject>& taggedPointers() {
         return this->_taggedPointers;
@@ -155,6 +159,8 @@ private:
 
     JSC::WriteBarrier<JSC::Structure> _recordFieldGetterStructure;
     JSC::WriteBarrier<JSC::Structure> _recordFieldSetterStructure;
+
+    JSC::WriteBarrier<JSC::Structure> _fastEnumerationIteratorStructure;
 
     JSC::WriteBarrier<TypeFactory> _typeFactory;
 

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -41,6 +41,8 @@
 #include "JSWeakRefPrototype.h"
 #include "JSWeakRefInstance.h"
 #include "TypeFactory.h"
+#include "ObjCFastEnumerationIterator.h"
+#include "ObjCFastEnumerationIteratorPrototype.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -119,6 +121,9 @@ void GlobalObject::finishCreation(VM& vm) {
     this->_weakRefInstanceStructure.set(vm, this, JSWeakRefInstance::createStructure(vm, this, weakRefPrototype));
     this->putDirect(vm, Identifier::fromString(&vm, WTF::ASCIILiteral("WeakRef")), JSWeakRefConstructor::create(vm, this->weakRefConstructorStructure(), weakRefPrototype));
 
+    auto fastEnumerationIteratorPrototype = ObjCFastEnumerationIteratorPrototype::create(vm, this, ObjCFastEnumerationIteratorPrototype::createStructure(vm, this, this->objectPrototype()));
+    this->_fastEnumerationIteratorStructure.set(vm, this, ObjCFastEnumerationIterator::createStructure(vm, this, fastEnumerationIteratorPrototype));
+
     this->_interopIdentifier = Identifier::fromString(&vm, Interop::info()->className);
     this->_interop.set(vm, this, Interop::create(vm, this, Interop::createStructure(vm, this, this->objectPrototype())));
 
@@ -166,6 +171,7 @@ void GlobalObject::visitChildren(JSCell* cell, SlotVisitor& visitor) {
     visitor.append(&globalObject->_weakRefConstructorStructure);
     visitor.append(&globalObject->_weakRefPrototypeStructure);
     visitor.append(&globalObject->_weakRefInstanceStructure);
+    visitor.append(&globalObject->_fastEnumerationIteratorStructure);
 }
 
 void GlobalObject::destroy(JSCell* cell) {

--- a/src/NativeScript/JSErrors.h
+++ b/src/NativeScript/JSErrors.h
@@ -13,6 +13,13 @@
 
 namespace NativeScript {
 void reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*) NO_RETURN_DUE_TO_CRASH;
+
+inline void reportErrorIfAny(JSC::ExecState* execState) {
+    if (JSC::Exception* exception = execState->exception()) {
+        execState->clearException();
+        reportFatalErrorBeforeShutdown(execState, exception);
+    }
+}
 }
 
 #endif /* defined(__NativeScript__JSErrors__) */

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.h
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.h
@@ -1,0 +1,65 @@
+//
+//  ObjCFastEnumerationIterator.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 14.07.15.
+//
+//
+
+#ifndef __NativeScript__ObjCFastEnumerationIterator__
+#define __NativeScript__ObjCFastEnumerationIterator__
+
+#include <JavaScriptCore/JSObject.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+
+#import <Foundation/NSEnumerator.h>
+
+namespace NativeScript {
+class ObjCFastEnumerationIterator : public JSC::JSDestructibleObject {
+public:
+    typedef JSC::JSDestructibleObject Base;
+
+    static const unsigned StructureFlags = Base::StructureFlags;
+
+    static ObjCFastEnumerationIterator* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, id object) {
+        ObjCFastEnumerationIterator* prototype = new (NotNull, JSC::allocateCell<ObjCFastEnumerationIterator>(vm.heap)) ObjCFastEnumerationIterator(vm, structure);
+        prototype->finishCreation(vm, globalObject, object);
+        return prototype;
+    }
+
+    DECLARE_INFO;
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype) {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    bool next(JSC::ExecState*, JSC::JSValue& value);
+
+private:
+    ObjCFastEnumerationIterator(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+        , _state({})
+        , _index(0) {
+    }
+
+    ~ObjCFastEnumerationIterator();
+
+    static void destroy(JSC::JSCell* cell) {
+        static_cast<ObjCFastEnumerationIterator*>(cell)->~ObjCFastEnumerationIterator();
+    }
+
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, id);
+
+    NSFastEnumerationState _state;
+    std::array<id, 16> _buffer;
+    unsigned long _mutationSentinel;
+
+    NSUInteger _count;
+    NSUInteger _index;
+
+    WTF::RetainPtr<id> _object;
+};
+}
+
+#endif /* defined(__NativeScript__ObjCFastEnumerationIterator__) */

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.mm
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.mm
@@ -1,0 +1,56 @@
+//
+//  ObjCFastEnumerationIterator.mm
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 14.07.15.
+//
+//
+
+#include "ObjCFastEnumerationIterator.h"
+#include "ObjCTypes.h"
+
+namespace NativeScript {
+using namespace JSC;
+
+const ClassInfo ObjCFastEnumerationIterator::s_info = { "NSFastEnumeration Iterator", &Base::s_info, 0, CREATE_METHOD_TABLE(ObjCFastEnumerationIterator) };
+
+void ObjCFastEnumerationIterator::finishCreation(VM& vm, JSGlobalObject* globalObject, id object) {
+    Base::finishCreation(vm);
+
+    this->_object = object;
+#ifdef DEBUG_MEMORY
+    NSLog(@"ObjCFastEnumerationIterator retained %@(%p)", object_getClass(object), object);
+#endif
+
+    if ((this->_count = [this->_object.get() countByEnumeratingWithState:&this->_state objects:this->_buffer.data() count:this->_buffer.size()])) {
+        this->_mutationSentinel = *this->_state.mutationsPtr;
+    }
+}
+
+bool ObjCFastEnumerationIterator::next(ExecState* execState, JSValue& value) {
+    if (this->_index == this->_count && this->_count) {
+        this->_count = [this->_object.get() countByEnumeratingWithState:&this->_state objects:this->_buffer.data() count:this->_buffer.size()];
+
+        if (this->_mutationSentinel != *this->_state.mutationsPtr) {
+            execState->vm().throwException(execState, createError(execState, WTF::ASCIILiteral("The iterable was changed during enumeration.")));
+            return false;
+        }
+
+        this->_index = 0;
+    }
+
+    if (this->_index < this->_count) {
+        value = toValue(execState, this->_state.itemsPtr[this->_index++]);
+        return true;
+    }
+
+    return false;
+}
+
+ObjCFastEnumerationIterator::~ObjCFastEnumerationIterator() {
+#ifdef DEBUG_MEMORY
+    NSLog(@"ObjCFastEnumerationIterator soon releasing %@(%p)", object_getClass(this->_object.get()), this->_object.get());
+#endif
+    Heap::heap(this)->releaseSoon(std::move(this->_object));
+}
+}

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.h
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.h
@@ -1,0 +1,42 @@
+//
+//  ObjCFastEnumerationIteratorPrototype.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 14.07.15.
+//
+//
+
+#ifndef __NativeScript__ObjCFastEnumerationIteratorPrototype__
+#define __NativeScript__ObjCFastEnumerationIteratorPrototype__
+
+#include <JavaScriptCore/JSObject.h>
+
+namespace NativeScript {
+class ObjCFastEnumerationIteratorPrototype : public JSC::JSDestructibleObject {
+public:
+    typedef JSC::JSDestructibleObject Base;
+
+    static const unsigned StructureFlags = Base::StructureFlags;
+
+    static ObjCFastEnumerationIteratorPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        ObjCFastEnumerationIteratorPrototype* prototype = new (NotNull, JSC::allocateCell<ObjCFastEnumerationIteratorPrototype>(globalObject->vm().heap)) ObjCFastEnumerationIteratorPrototype(globalObject->vm(), structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    DECLARE_INFO;
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype) {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+private:
+    ObjCFastEnumerationIteratorPrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure) {
+    }
+
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
+};
+}
+
+#endif /* defined(__NativeScript__ObjCFastEnumerationIteratorPrototype__) */

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.mm
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.mm
@@ -1,0 +1,43 @@
+//
+//  ObjCFastEnumerationIteratorPrototype.mm
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 14.07.15.
+//
+//
+
+#include "ObjCFastEnumerationIteratorPrototype.h"
+#include "ObjCFastEnumerationIterator.h"
+#include <JavaScriptCore/IteratorOperations.h>
+
+namespace NativeScript {
+using namespace JSC;
+
+const ClassInfo ObjCFastEnumerationIteratorPrototype::s_info = { "NSFastEnumeration Iterator", &Base::s_info, 0, CREATE_METHOD_TABLE(ObjCFastEnumerationIteratorPrototype) };
+
+EncodedJSValue JSC_HOST_CALL FastEnumerationIteratorPrototypeFuncNext(ExecState*);
+
+void ObjCFastEnumerationIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject) {
+    Base::finishCreation(vm);
+    vm.prototypeMap.addPrototype(this);
+
+    JSC_NATIVE_FUNCTION(vm.propertyNames->next, FastEnumerationIteratorPrototypeFuncNext, DontEnum, 0);
+}
+
+EncodedJSValue JSC_HOST_CALL FastEnumerationIteratorPrototypeFuncNext(ExecState* execState) {
+    auto iterator = jsDynamicCast<ObjCFastEnumerationIterator*>(execState->thisValue());
+    if (!iterator)
+        return JSValue::encode(throwTypeError(execState, ASCIILiteral("Cannot call NSFastEnumerationIterator.next() on a non-NSFastEnumerationIterator object")));
+
+    JSValue result;
+    if (iterator->next(execState, result)) {
+        return JSValue::encode(createIteratorResultObject(execState, result, false));
+    }
+
+    if (execState->hadException()) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(createIteratorResultObject(execState, jsUndefined(), true));
+}
+}

--- a/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.h
+++ b/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.h
@@ -1,0 +1,18 @@
+//
+//  TNSFastEnumerationAdapter.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 15.07.15.
+//
+//
+
+#import <Foundation/NSEnumerator.h>
+
+#ifndef __NativeScript__TNSFastEnumerationAdapter__
+#define __NativeScript__TNSFastEnumerationAdapter__
+
+namespace NativeScript {
+NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id buffer[], NSUInteger length, JSC::JSGlobalObject* globalObject);
+}
+
+#endif /* defined(__NativeScript__TNSFastEnumerationAdapter__) */

--- a/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.mm
+++ b/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.mm
@@ -1,0 +1,90 @@
+//
+//  TNSFastEnumerationAdapter.mm
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 15.07.15.
+//
+//
+
+#include "TNSFastEnumerationAdapter.h"
+#include "JSErrors.h"
+#include "ObjCTypes.h"
+#include <JavaScriptCore/IteratorOperations.h>
+
+namespace NativeScript {
+using namespace JSC;
+
+NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id buffer[], NSUInteger length, JSGlobalObject* globalObject) {
+    enum State : decltype(state->state) {
+        Uninitialized = 0,
+        Iterating,
+        Done
+    };
+
+    if (state->state == State::Uninitialized) {
+        ExecState* execState = globalObject->globalExec();
+        TNSValueWrapper* wrapper = objc_getAssociatedObject(self, globalObject->JSC::JSScope::vm());
+
+        JSLockHolder lock(execState);
+
+        JSValue iteratorFunction = wrapper.value->get(execState, execState->propertyNames().iteratorSymbol);
+        reportErrorIfAny(execState);
+
+        CallData iteratorFunctionCallData;
+        CallType iteratorFunctionCallType = getCallData(iteratorFunction, iteratorFunctionCallData);
+        if (iteratorFunctionCallType == CallTypeNone) {
+            reportFatalErrorBeforeShutdown(execState, Exception::create(execState->vm(), createTypeError(execState)));
+        }
+
+        ArgList iteratorFunctionArguments;
+        JSValue iterator = call(execState, iteratorFunction, iteratorFunctionCallType, iteratorFunctionCallData, wrapper.value, iteratorFunctionArguments);
+        reportErrorIfAny(execState);
+
+        if (!iterator.isObject()) {
+            reportFatalErrorBeforeShutdown(execState, Exception::create(execState->vm(), createTypeError(execState)));
+        }
+
+        state->mutationsPtr = reinterpret_cast<unsigned long*>(self);
+        state->extra[0] = reinterpret_cast<unsigned long>(execState);
+        state->extra[1] = reinterpret_cast<unsigned long>(iterator.asCell());
+        gcProtect(iterator);
+
+        state->state = State::Iterating;
+    }
+
+    ExecState* execState = reinterpret_cast<ExecState*>(state->extra[0]);
+    JSValue iterator(reinterpret_cast<JSCell*>(state->extra[1]));
+    JSLockHolder lock(execState);
+
+    if (state->state == State::Done) {
+        return 0;
+    }
+
+    NSUInteger count = 0;
+    state->itemsPtr = buffer;
+
+    while (count < length) {
+        JSValue next = iteratorStep(execState, iterator);
+        reportErrorIfAny(execState);
+
+        if (next.isFalse()) {
+            iteratorClose(execState, iterator);
+            reportErrorIfAny(execState);
+            gcUnprotect(iterator);
+
+            state->state = State::Done;
+            break;
+        }
+
+        JSValue value = iteratorValue(execState, next);
+        reportErrorIfAny(execState);
+
+        *buffer++ = toObject(execState, value);
+        reportErrorIfAny(execState);
+
+        count++;
+    }
+
+    return count;
+}
+}

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -25,7 +25,7 @@ public:
 
     static ObjCPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::InterfaceMeta* metadata) {
         ObjCPrototype* prototype = new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure);
-        prototype->finishCreation(vm, metadata);
+        prototype->finishCreation(vm, globalObject, metadata);
         return prototype;
     }
 
@@ -44,7 +44,7 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, const Metadata::InterfaceMeta*);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, const Metadata::InterfaceMeta*);
 
     static bool getOwnPropertySlot(JSC::JSObject*, JSC::ExecState*, JSC::PropertyName, JSC::PropertySlot&);
 

--- a/tests/TestFixtures/Interfaces/TNSInheritance.h
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.h
@@ -50,3 +50,9 @@
 - (void)derivedNotImplementedCategoryMethod;
 - (void)derivedNotImplementedNativeCategoryMethodOverridenInJavaScript;
 @end
+
+@interface TNSIterableConsumer : NSObject
+
++ (void)consumeIterable:(id<NSFastEnumeration>)iterable;
+
+@end

--- a/tests/TestFixtures/Interfaces/TNSInheritance.m
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.m
@@ -50,3 +50,13 @@
     TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
 }
 @end
+
+@implementation TNSIterableConsumer
+
++ (void)consumeIterable:(id<NSFastEnumeration>)iterable {
+    for (id obj in iterable) {
+        TNSLog([obj description]);
+    }
+}
+
+@end

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -432,4 +432,39 @@ describe(module.id, function () {
             expect(NSDate.dateWithTimeIntervalSinceReferenceDate(0).class()).toBe(NSDate);
         });
     }
+    
+    function range(start, end, inclusive) {
+        var mapper = (_, k) => start + k;
+        if (end < start) {
+            mapper = (_, k) => start - k;
+        }
+        
+        return Array.from({ length: Math.abs(start - end) + (inclusive ? 1 : 0) }, mapper);
+    }
+    
+    it("should be able to iterate over NSArray", function () {
+        var expected = range(0, 256);
+        var actual = new Array();
+        
+        var array = NSArray.arrayWithArray(expected);
+        for (var x of array) {
+            actual.push(x);
+        }
+        
+        expect(actual).toEqual(expected);
+         
+    });
+    
+    it("should be able to iterate over NSEnumerator", function () {
+        var expected = range(0, 256);
+        var actual = new Array();
+        
+        var array = NSArray.arrayWithArray(expected);
+        for (var x of array.reverseObjectEnumerator()) {
+            actual.push(x);
+        }
+        expected.reverse();
+        
+        expect(actual).toEqual(expected);
+    })
 });

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -1841,4 +1841,40 @@ describe(module.id, function () {
         var encoding = method_getTypeEncoding(method);
         expect(NSString.stringWithCString(encoding).toString()).toBe("v@:");
     });
+    
+    it("should project Symbol.iterable as NSFastEnumeration", function () {
+        var start = 1;
+        var end = 10;
+        var lastStep = 0;
+        var IterableClass = NSObject.extend({
+            [Symbol.iterator]() {
+                return {
+                    step: start,
+                    
+                    next() {
+                        if (this.step <= end) {
+                            return { value: this.step++, done: false };
+                        } else {
+                            return { done: true };
+                        }
+                    },
+                    
+                    return() {
+                        lastStep = this.step;
+                        return {};
+                    }
+                }
+            }
+        });
+        
+        var expected = "12345678910";
+        TNSIterableConsumer.consumeIterable(IterableClass.alloc().init());
+        var actual = TNSGetOutput();
+        
+        expect(IterableClass.conformsToProtocol(NSFastEnumeration)).toBe(true);
+        expect(actual).toEqual(expected);
+        expect(lastStep).toEqual(end + 1);
+        
+        TNSClearOutput();
+    })
 });

--- a/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
+++ b/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
@@ -110,7 +110,7 @@ describe(module.id, function () {
         expect(TNSGetOutput()).toBe('2001-09-09 01:46:40 +0000');
     });
 
-    it("MethodWithNSArray", function () {
+    it("should be possible to marshal a JavaScript Array exotic to NSArray", function () {
         var array = [1, [2, 'a'], NSObject];
         var result = TNSObjCTypes.alloc().init().methodWithNSArray(array);
         expect(TNSGetOutput()).toBe(
@@ -132,6 +132,20 @@ describe(module.id, function () {
             '3' +
             '4' +
             'NSObject');
+        TNSClearOutput();
+    });
+
+    it("should be possible to marshal an array-like object to NSArray", function () {
+        var expected = "";
+        var arrayLike = { length: 256 };
+        for (var i = 0; i < arrayLike.length; i++) {
+            arrayLike[i] = i;
+            expected += String(i);
+        }
+        
+        TNSObjCTypes.alloc().init().methodWithNSArray(arrayLike);
+        
+        expect(TNSGetOutput()).toBe(expected);
         TNSClearOutput();
     });
 


### PR DESCRIPTION
This change exposes the Objective-C fast enumeration machinery by adding a `Symbol.iterator` property to the prototype of classes that implement fast enumeration.

This allows code expressed with a `for...in` statement in Objective-C to be implemented with JavaScript's `for...of` statement in NativeScript. Also, JavaScript APIs that expect iterable objects can now consume `NSFastEnumeration`-conforming Objective-C objects.

What's more, `TNSArrayAdapter` now implements bulk enumeration to speed up fast enumeration when the adapted object is the array exotic.