### PR TITLE
Two-way marshaling between NSData and ArrayBuffer

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -61,6 +61,7 @@ set(HEADER_FILES
     ObjC/ObjCWrapperObject.h
     ObjC/TNSArrayAdapter.h
     ObjC/TNSDictionaryAdapter.h
+    ObjC/TNSDataAdapter.h
     Runtime/JSWeakRefConstructor.h
     Runtime/JSWeakRefInstance.h
     Runtime/JSWeakRefPrototype.h
@@ -132,6 +133,7 @@ set(SOURCE_FILES
     ObjC/ObjCWrapperObject.mm
     ObjC/TNSArrayAdapter.mm
     ObjC/TNSDictionaryAdapter.mm
+    ObjC/TNSDataAdapter.mm
     Runtime/JSWeakRefConstructor.cpp
     Runtime/JSWeakRefInstance.cpp
     Runtime/JSWeakRefPrototype.cpp

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -17,6 +17,7 @@
 
 #import "TNSArrayAdapter.h"
 #import "TNSDictionaryAdapter.h"
+#import "TNSDataAdapter.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -102,6 +103,8 @@ void ObjCConstructorBase::finishCreation(VM& vm, JSGlobalObject* globalObject, J
         this->_ffiTypeMethodTable.write = &writeAdapter<TNSArrayAdapter>;
     } else if (klass == [NSDictionary class]) {
         this->_ffiTypeMethodTable.write = &writeAdapter<TNSDictionaryAdapter>;
+    } else if (klass == [NSData class] || klass == [NSMutableData class]) {
+        this->_ffiTypeMethodTable.write = &writeAdapter<TNSDataAdapter>;
     } else {
         this->_ffiTypeMethodTable.write = &write;
     }

--- a/src/NativeScript/ObjC/ObjCTypes.mm
+++ b/src/NativeScript/ObjC/ObjCTypes.mm
@@ -20,6 +20,7 @@
 
 #import "TNSArrayAdapter.h"
 #import "TNSDictionaryAdapter.h"
+#import "TNSDataAdapter.h"
 
 using namespace JSC;
 
@@ -83,19 +84,6 @@ static WeakHandleOwner* weakHandleOwner() {
 
 namespace NativeScript {
 
-static NSData* toObject(ExecState* execState, ArrayBuffer* arrayBuffer) {
-    return [NSData dataWithBytes:arrayBuffer->data()
-                          length:arrayBuffer->byteLength()];
-}
-
-static NSData* toObject(ExecState* execState, JSArrayBuffer* arrayBuffer) {
-    return toObject(execState, arrayBuffer->impl());
-}
-
-static NSData* toObject(ExecState* execState, JSArrayBufferView* arrayBufferView) {
-    return toObject(execState, arrayBufferView->buffer());
-}
-
 id toObject(ExecState* execState, const JSValue& value) {
     if (value.inherits(ObjCWrapperObject::info())) {
         return jsCast<ObjCWrapperObject*>(value.asCell())->wrappedObject();
@@ -146,12 +134,9 @@ id toObject(ExecState* execState, const JSValue& value) {
         return [NSDate dateWithTimeIntervalSince1970:(value.toNumber(execState) / 1000)];
     }
 
-    if (value.inherits(JSArrayBuffer::info())) {
-        return toObject(execState, jsCast<JSArrayBuffer*>(value.asCell()));
-    }
-
-    if (value.inherits(JSArrayBufferView::info())) {
-        return toObject(execState, jsCast<JSArrayBufferView*>(value.asCell()));
+    if (value.inherits(JSArrayBuffer::info()) || value.inherits(JSArrayBufferView::info())) {
+        return [[[TNSDataAdapter alloc] initWithJSObject:asObject(value)
+                                               execState:execState->lexicalGlobalObject()->globalExec()] autorelease];
     }
 
     bool hasHandle;

--- a/src/NativeScript/ObjC/TNSDataAdapter.h
+++ b/src/NativeScript/ObjC/TNSDataAdapter.h
@@ -1,0 +1,13 @@
+//
+//  TNSDataAdapter.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 20.07.15.
+//
+//
+
+@interface TNSDataAdapter : NSMutableData
+
+- (instancetype)initWithJSObject:(JSC::JSObject*)jsObject execState:(JSC::ExecState*)execState;
+
+@end

--- a/src/NativeScript/ObjC/TNSDataAdapter.mm
+++ b/src/NativeScript/ObjC/TNSDataAdapter.mm
@@ -1,0 +1,59 @@
+//
+//  TNSDataAdapter.mm
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 20.07.15.
+//
+//
+
+#import "TNSDataAdapter.h"
+#include "ObjCTypes.h"
+#include "JSErrors.h"
+#include <JavaScriptCore/JSArrayBuffer.h>
+#include <JavaScriptCore/StrongInlines.h>
+
+using namespace NativeScript;
+using namespace JSC;
+
+@implementation TNSDataAdapter {
+    Strong<JSObject> _object;
+    ExecState* _execState;
+}
+
+- (instancetype)initWithJSObject:(JSObject*)jsObject execState:(ExecState*)execState {
+    if (self) {
+        self->_object.set(execState->vm(), jsObject);
+        self->_execState = execState;
+        [TNSValueWrapper attachValue:jsObject toHost:self];
+    }
+
+    return self;
+}
+
+- (const void*)bytes {
+    return [self mutableBytes];
+}
+
+- (void*)mutableBytes {
+    JSLockHolder lock(self->_execState);
+
+    if (JSArrayBuffer* arrayBuffer = jsDynamicCast<JSArrayBuffer*>(self->_object.get())) {
+        return arrayBuffer->impl()->data();
+    }
+
+    JSArrayBufferView* arrayBufferView = jsCast<JSArrayBufferView*>(self->_object.get());
+    if (arrayBufferView->hasArrayBuffer()) {
+        return arrayBufferView->buffer()->data();
+    }
+
+    return arrayBufferView->vector();
+}
+
+- (NSUInteger)length {
+    JSLockHolder lock(self->_execState);
+    NSUInteger length = self->_object->get(self->_execState, self->_execState->propertyNames().byteLength).toUInt32(self->_execState);
+    reportErrorIfAny(self->_execState);
+    return length;
+}
+
+@end

--- a/src/ts/Interop.d.ts
+++ b/src/ts/Interop.d.ts
@@ -72,6 +72,11 @@ declare module interop {
     function handleof(instance: any): Pointer;
 
     /**
+     * Wraps an NSData instance in an ArrayBuffer.
+     */
+    function bufferFromData(data: NSData): ArrayBuffer;
+
+    /**
      * A type that wraps a pointer and allows read/write operations on its value.
      */
     interface Reference<T> {

--- a/tests/TestRunner/app/Infrastructure/Jasmine/jasmine-2.0.1/boot.js
+++ b/tests/TestRunner/app/Infrastructure/Jasmine/jasmine-2.0.1/boot.js
@@ -81,8 +81,10 @@ var TerminalReporter = require('../jasmine-reporters/terminal_reporter').Termina
    */
   if (typeof window == "undefined" && typeof global == "object") {
     extend(global, jasmineInterface);
+    global.jasmine = jasmine;
   } else {
     extend(window, jasmineInterface);
+    window.jasmine = jasmine;
   }
 
   /**

--- a/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
+++ b/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
@@ -168,18 +168,30 @@ describe(module.id, function () {
         expect(result).toBe(map);
     });
 
-    it("MethodWithNSData", function () {
+    it("should be possible to wrap an ArrayBuffer in NSData", function () {
         var data = new Uint8Array([49, 50, 51, 52]);
+        var buffer = data.buffer;
         var expected = '1234';
 
-        TNSObjCTypes.alloc().init().methodWithNSData(data);
+        var wrappedArrayBufferViewData = TNSObjCTypes.alloc().init().methodWithNSData(data);
         expect(TNSGetOutput()).toBe(expected);
+        expect(wrappedArrayBufferViewData).toBe(data);
         TNSClearOutput();
 
-        TNSObjCTypes.alloc().init().methodWithNSData(data.buffer);
+        var wrappedArrayBufferData = TNSObjCTypes.alloc().init().methodWithNSData(buffer);
         expect(TNSGetOutput()).toBe(expected);
+        expect(wrappedArrayBufferData).toBe(buffer);
         TNSClearOutput();
     });
+
+    it("should be possible to wrap NSData in an ArrayBuffer", function () {
+        var data = NSString.stringWithString("test").dataUsingEncoding(NSUTF8StringEncoding);
+        
+        var buffer = interop.bufferFromData(data);
+        
+        expect(buffer).toEqual(jasmine.any(ArrayBuffer));
+        expect(interop.handleof(buffer)).toBe(data.bytes);
+    })
 
     it("MethodWithNSCFBool", function () {
         expect(TNSObjCTypes.alloc().init().methodWithNSCFBool()).toBe(true);


### PR DESCRIPTION
Introduce TNSDataAdapter to facilitate wrapping ArrayBuffers and ArrayBufferViews in an NSData interface without copying.
Introduce the interop.bufferFromData function which created an ArrayBuffer backed by an NSData instance.

Related to: https://github.com/NativeScript/ios-runtime/issues/231
