### PR TITLE
Do not register the instance structure

### DIFF
--- a/src/NativeScript/AllocatedPlaceholder.cpp
+++ b/src/NativeScript/AllocatedPlaceholder.cpp
@@ -12,4 +12,12 @@ namespace NativeScript {
 using namespace JSC;
 
 const ClassInfo AllocatedPlaceholder::s_info = { "AllocatedPlaceholder", &Base::s_info, 0, CREATE_METHOD_TABLE(AllocatedPlaceholder) };
+
+void AllocatedPlaceholder::visitChildren(JSCell* cell, JSC::SlotVisitor& visitor) {
+    Base::visitChildren(cell, visitor);
+
+    AllocatedPlaceholder* object = jsCast<AllocatedPlaceholder*>(cell);
+
+    visitor.append(&object->_instanceStructure);
+}
 }

--- a/src/NativeScript/AllocatedPlaceholder.h
+++ b/src/NativeScript/AllocatedPlaceholder.h
@@ -30,8 +30,14 @@ public:
         return this->_wrappedObject;
     }
 
+    JSC::Structure* instanceStructure() const {
+        return this->_instanceStructure.get();
+    }
+
 private:
     id _wrappedObject;
+
+    JSC::WriteBarrier<JSC::Structure> _instanceStructure;
 
     AllocatedPlaceholder(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {
@@ -40,8 +46,10 @@ private:
     void finishCreation(JSC::VM& vm, GlobalObject* globalObject, id wrappedObject, JSC::Structure* instanceStructure) {
         Base::finishCreation(vm);
         this->_wrappedObject = wrappedObject;
-        this->putDirect(vm, globalObject->instanceStructureIdentifier(), instanceStructure, JSC::ReadOnly | JSC::DontEnum | JSC::DontDelete);
+        this->_instanceStructure.set(vm, this, instanceStructure);
     }
+
+    static void visitChildren(JSCell*, JSC::SlotVisitor&);
 };
 }
 

--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -52,10 +52,6 @@ public:
 
     static void visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor);
 
-    const JSC::Identifier& instanceStructureIdentifier() const {
-        return this->_instanceStructureIdentifier;
-    }
-
     JSC::Structure* objCMethodCallStructure() const {
         return this->_objCMethodCallStructure.get();
     }
@@ -148,8 +144,6 @@ private:
     static void destroy(JSC::JSCell* cell);
 
     static void queueTaskToEventLoop(const JSC::JSGlobalObject* globalObject, WTF::PassRefPtr<JSC::Microtask> task);
-
-    JSC::Identifier _instanceStructureIdentifier;
 
     std::unique_ptr<Inspector::JSGlobalObjectInspectorController> _inspectorController;
     std::unique_ptr<Inspector::InstrumentingAgents> _instrumentingAgents;

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -110,8 +110,6 @@ void GlobalObject::finishCreation(VM& vm) {
 
     ExecState* globalExec = this->globalExec();
 
-    this->_instanceStructureIdentifier = Identifier::fromUid(PrivateName(PrivateName::Description, ASCIILiteral("__instanceStructureIdentifier")));
-
     std::unique_ptr<Inspector::InspectorTimelineAgent> timelineAgent = std::make_unique<Inspector::InspectorTimelineAgent>(this);
     this->_instrumentingAgents = std::make_unique<Inspector::InstrumentingAgents>();
     this->_instrumentingAgents->setInspectorTimelineAgent(timelineAgent.get());

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -89,7 +89,6 @@ void ObjCConstructorBase::finishCreation(VM& vm, JSGlobalObject* globalObject, J
 
     this->_prototype.set(vm, this, prototype);
     this->_instancesStructure.set(vm, this, ObjCWrapperObject::createStructure(vm, globalObject, prototype));
-    this->putDirect(vm, jsCast<GlobalObject*>(globalObject)->instanceStructureIdentifier(), this->instancesStructure(), ReadOnly | DontEnum | DontDelete);
 
     this->_klass = klass;
 

--- a/src/NativeScript/ObjC/ObjCSuperObject.mm
+++ b/src/NativeScript/ObjC/ObjCSuperObject.mm
@@ -18,7 +18,6 @@ const ClassInfo ObjCSuperObject::s_info = { "ObjCSuperObject", &Base::s_info, 0,
 void ObjCSuperObject::finishCreation(VM& vm, ObjCWrapperObject* wrapper, GlobalObject* globalObject) {
     Base::finishCreation(vm);
     this->_wrapperObject.set(vm, this, wrapper);
-    this->putDirect(vm, globalObject->instanceStructureIdentifier(), this->wrapperObject()->structure(), ReadOnly | DontEnum | DontDelete);
 }
 
 JSValue ObjCSuperObject::toThis(JSCell* cell, ExecState* execState, ECMAMode mode) {

--- a/src/NativeScript/ObjC/ObjCWrapperObject.mm
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.mm
@@ -20,7 +20,6 @@ void ObjCWrapperObject::finishCreation(VM& vm, id wrappedObject, GlobalObject* g
     this->setWrappedObject(wrappedObject);
     this->_canSetObjectAtIndexedSubscript = [wrappedObject respondsToSelector:@selector(setObject:
                                                                                   atIndexedSubscript:)];
-    this->putDirect(vm, globalObject->instanceStructureIdentifier(), this->structure(), ReadOnly | DontEnum | DontDelete);
 }
 
 WTF::String ObjCWrapperObject::className(const JSObject* object) {


### PR DESCRIPTION
When the inspector is enabled and a breakpoint is hit a Runtime.getDisplayableProperties message is dispatched. The logic behind Runtime.getDisplayableProperties enumerates getOwnPropertyNames and getOwnPropertySymbols and calls their toString method.
This results in a JSValue::toString call that defaults to JSCell::defaultValue which is guarded by a RELEASE_ASSERT_NOT_REACHED().

As a workaround do not register the instance structure