### PR TITLE
-[TNSValueWrapper value] can return null

### DIFF
--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -71,8 +71,10 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
     IMP newRetain = imp_implementationWithBlock (^(id self) {
         if ([self retainCount] == 1) {
             if (TNSValueWrapper* wrapper = objc_getAssociatedObject(self, globalObject->JSScope::vm())) {
-                JSLockHolder lockHolder(globalObject->vm());
-                gcProtect(wrapper.value);
+                if (JSObject* object = wrapper.value) {
+                    JSLockHolder lockHolder(globalObject->vm());
+                    gcProtect(object);
+                }
             }
         }
 
@@ -84,8 +86,10 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
     IMP newRelease = imp_implementationWithBlock (^(id self) {
         if ([self retainCount] == 2) {
             if (TNSValueWrapper* wrapper = objc_getAssociatedObject(self, globalObject->JSScope::vm())) {
-                JSLockHolder lockHolder(globalObject->vm());
-                gcUnprotect(wrapper.value);
+                if (JSObject* object = wrapper.value) {
+                    JSLockHolder lockHolder(globalObject->vm());
+                    gcUnprotect(object);
+                }
             }
         }
 


### PR DESCRIPTION
When memory-managing an instance of a class derived from an Objective-C one there is that sliver of time after the JavaScript representation of the object has been garbage-collected, but the Objective-C representation is still alive. Calls to `retain` or `release` will try to access a JavaScript object that's not there anymore, so guard against that.