### PR TITLE
Buhov/metadata merged in binary

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -137,11 +137,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 858B843018CA22B800AB12DE /* Build configuration list for PBXNativeTarget "__PROJECT_NAME__" */;
 			buildPhases = (
+				C97FD7AC1ADE5369004DB2A4 /* Generate Metadata */,
 				858B83F218CA22B800AB12DE /* Sources */,
 				858B83F418CA22B800AB12DE /* Frameworks */,
 				858B842C18CA22B800AB12DE /* Resources */,
 				85F5BDFC1A9363BE006B9701 /* Embed Frameworks */,
-				C97FD7AC1ADE5369004DB2A4 /* Generate Metadata */,
 				CD3EAD351B05FF060042DBFC /* Strip Dynamic Framework Architectures */,
 			);
 			buildRules = (
@@ -358,6 +358,13 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/NativeScript/lib",
 				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-sectcreate",
+					__DATA,
+					__TNSMetadata,
+					"$(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin",
+				);
 				PRODUCT_NAME = __PROJECT_NAME__;
 				VALID_ARCHS = "armv7 arm64";
 				WRAPPER_EXTENSION = app;
@@ -387,6 +394,13 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/NativeScript/lib",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-sectcreate",
+					__DATA,
+					__TNSMetadata,
+					"$(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin",
 				);
 				PRODUCT_NAME = __PROJECT_NAME__;
 				VALID_ARCHS = "armv7 arm64";

--- a/build/scripts/metadata-generation-build-step.sh
+++ b/build/scripts/metadata-generation-build-step.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function generateMetadata {
-    local errorLog="$BUILT_PRODUCTS_DIR/metadata-generation-stderr-$1.txt"
+    local errorLog="$CONFIGURATION_BUILD_DIR/metadata-generation-stderr-$1.txt"
 
     ./objc-metadata-generator \
         -isysroot "$SDKROOT" \
@@ -12,8 +12,8 @@ function generateMetadata {
         -header-search-paths "$HEADER_SEARCH_PATHS" \
         -framework-search-paths "$FRAMEWORK_SEARCH_PATHS" \
         -enable-header-preprocessing-if-needed=true \
-        -output-bin "$BUILT_PRODUCTS_DIR/$CONTENTS_FOLDER_PATH/metadata-$1.bin" \
-        -output-umbrella "$BUILT_PRODUCTS_DIR/umbrella-$1.h" \
+        -output-bin "$CONFIGURATION_BUILD_DIR/metadata-$1.bin" \
+        -output-umbrella "$CONFIGURATION_BUILD_DIR/umbrella-$1.h" \
         2> "$errorLog"
 
     if [ $? -ne 0 ]; then

--- a/cmake/GenerateMetadata.cmake
+++ b/cmake/GenerateMetadata.cmake
@@ -1,8 +1,11 @@
 macro(GenerateMetadata _target)
     add_dependencies(${_target} MetadataGenerator)
     add_custom_command(TARGET ${_target}
-        POST_BUILD
+        PRE_BUILD
         COMMAND "${CMAKE_SOURCE_DIR}/build/scripts/metadata-generation-build-step.sh"
         WORKING_DIRECTORY "${MetadataGenerator_BINARY_DIR}/bin"
+    )
+    target_link_libraries(${_target}
+    	"-sectcreate __DATA __TNSMetadata $(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin"
     )
 endmacro()

--- a/cmake/main.m
+++ b/cmake/main.m
@@ -5,9 +5,11 @@
 #endif
 
 TNSRuntime *runtime = nil;
+extern char startOfMetadataSection __asm("section$start$__DATA$__TNSMetadata");
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {
+    [TNSRuntime initializeMetadata:&startOfMetadataSection];
     runtime = [[TNSRuntime alloc]
         initWithApplicationPath:[NSBundle mainBundle].bundlePath];
     TNSRuntimeInspector.logsToSystemConsole = YES;

--- a/examples/BlankApp/main.m
+++ b/examples/BlankApp/main.m
@@ -11,20 +11,22 @@ static NSString *toString(JSContextRef context, JSValueRef value) {
   return [NSString stringWithUTF8String:errorMessage];
 }
 
+extern char startOfMetadataSection __asm("section$start$__DATA$__TNSMetadata");
+
 int main(int argc, char *argv[]) {
   @autoreleasepool {
+    [TNSRuntime initializeMetadata:&startOfMetadataSection];
     TNSRuntime *runtime = [[TNSRuntime alloc]
         initWithApplicationPath:[NSBundle mainBundle].bundlePath];
     TNSRuntimeInspector.logsToSystemConsole = YES;
 
     NSError *error = nil;
-    NSString *script =
-        [NSString stringWithContentsOfFile:[[NSBundle mainBundle]
-                                               pathForResource:@"bootstrap"
-                                                        ofType:@"js"
-                                                   inDirectory:@"app"]
-                                  encoding:NSUTF8StringEncoding
-                                     error:&error];
+    NSString *script = [NSString stringWithContentsOfFile:
+                            [[NSBundle mainBundle] pathForResource:@"bootstrap"
+                                                            ofType:@"js"
+                                                       inDirectory:@"app"]
+                                                 encoding:NSUTF8StringEncoding
+                                                    error:&error];
 
     if (error) {
       NSLog(@"%@", error.localizedDescription);

--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -258,6 +258,8 @@ private:
 public:
     static MetaFile* instance();
 
+    static MetaFile* setInstance(void* metadataPtr);
+
     const GlobalTable* globalTable() const {
         return &this->_globalTable;
     }

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -207,8 +207,14 @@ void GlobalTable::iterator::findNext() {
     } while (this->_topLevelIndex < this->_globalTable->buckets.count);
 }
 
+static MetaFile* metaFileInstance(nullptr);
+
 MetaFile* MetaFile::instance() {
-    static MetaFile* instance(reinterpret_cast<MetaFile*>(loadFileInMemory((std::string("metadata-") + std::string(CURRENT_ARCH) + std::string(".bin")).c_str())));
-    return instance;
+    return metaFileInstance;
+}
+
+MetaFile* MetaFile::setInstance(void* metadataPtr) {
+    metaFileInstance = reinterpret_cast<MetaFile*>(metadataPtr);
+    return metaFileInstance;
 }
 }

--- a/src/NativeScript/TNSRuntime.h
+++ b/src/NativeScript/TNSRuntime.h
@@ -17,6 +17,8 @@ FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handle
 
 @property(nonatomic, retain) NSString* applicationPath;
 
++ (void)initializeMetadata:(void*)metadataPtr;
+
 - (instancetype)initWithApplicationPath:(NSString*)applicationPath;
 
 - (JSGlobalContextRef)globalContext;

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -22,6 +22,7 @@
 #import "TNSRuntime.h"
 #import "TNSRuntime+Private.h"
 #include "JSErrors.h"
+#include "Metadata/Metadata.h"
 #include "inspector/SourceProviderManager.h"
 
 using namespace JSC;
@@ -33,6 +34,10 @@ using namespace NativeScript;
     if (self == [TNSRuntime self]) {
         initializeThreading();
     }
+}
+
++ (void)initializeMetadata:(void*)metadataPtr {
+    Metadata::MetaFile::setInstance(metadataPtr);
 }
 
 - (instancetype)initWithApplicationPath:(NSString*)applicationPath {
@@ -144,7 +149,9 @@ static JSC_HOST_CALL EncodedJSValue createModuleFunction(ExecState* execState) {
 - (void)dealloc {
     [self->_applicationPath release];
 #if PLATFORM(IOS)
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIApplicationDidReceiveMemoryWarningNotification
+                                                  object:nil];
 #endif
 
     {


### PR DESCRIPTION
There is no more `metadata.bin` file. Metadata is now included in the executable upon build. The app thinning will strip the fat binaries to a single slice on the AppStore when the app is distributed to the client devices. This will leave a single copy of the metadata in the actual download from the AppStore.
Close https://github.com/NativeScript/ios-runtime/issues/179