### PR TITLE
Overhaul SymbolLoader

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -220,7 +220,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     case Interface: {
         Class klass = objc_getClass(symbolMeta->name());
         if (!klass) {
-            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModule()->getName());
+            SymbolLoader::instance().ensureModule(symbolMeta->topLevelModule());
             klass = objc_getClass(symbolMeta->name());
         }
 
@@ -233,7 +233,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     case ProtocolType: {
         Protocol* aProtocol = objc_getProtocol(symbolMeta->name());
         if (!aProtocol) {
-            SymbolLoader::instance().ensureFramework(symbolMeta->topLevelModule()->getName());
+            SymbolLoader::instance().ensureModule(symbolMeta->topLevelModule());
             aProtocol = objc_getProtocol(symbolMeta->name());
         }
 
@@ -253,7 +253,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
         break;
     }
     case MetaType::Function: {
-        void* functionSymbol = SymbolLoader::instance().loadFunctionSymbol(symbolMeta->topLevelModule()->getName(), symbolMeta->name());
+        void* functionSymbol = SymbolLoader::instance().loadFunctionSymbol(symbolMeta->topLevelModule(), symbolMeta->name());
         if (functionSymbol) {
             const FunctionMeta* functionMeta = static_cast<const FunctionMeta*>(symbolMeta);
             const Metadata::TypeEncoding* encodingPtr = functionMeta->encodings()->first();
@@ -265,7 +265,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     }
     case Var: {
         const VarMeta* varMeta = static_cast<const VarMeta*>(symbolMeta);
-        void* varSymbol = SymbolLoader::instance().loadDataSymbol(varMeta->topLevelModule()->getName(), varMeta->name());
+        void* varSymbol = SymbolLoader::instance().loadDataSymbol(varMeta->topLevelModule(), varMeta->name());
         if (varSymbol) {
             const Metadata::TypeEncoding* encoding = varMeta->encoding();
             JSCell* symbolType = globalObject->typeFactory()->parseType(globalObject, encoding);

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
@@ -39,7 +39,7 @@ bool ObjCConstructorNative::getOwnPropertySlot(JSObject* object, ExecState* exec
     ObjCConstructorNative* constructor = jsCast<ObjCConstructorNative*>(object);
 
     if (const MethodMeta* method = constructor->_metadata->staticMethod(propertyName.publicName())) {
-        SymbolLoader::instance().ensureFramework(method->topLevelModule()->getName());
+        SymbolLoader::instance().ensureModule(method->topLevelModule());
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
         ObjCMethodCall* call = ObjCMethodCall::create(execState->vm(), globalObject, globalObject->objCMethodCallStructure(), method);

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -57,7 +57,7 @@ bool ObjCPrototype::getOwnPropertySlot(JSObject* object, ExecState* execState, P
     ObjCPrototype* prototype = jsCast<ObjCPrototype*>(object);
 
     if (const MethodMeta* memberMeta = prototype->_metadata->instanceMethod(propertyName.publicName())) {
-        SymbolLoader::instance().ensureFramework(memberMeta->topLevelModule()->getName());
+        SymbolLoader::instance().ensureModule(memberMeta->topLevelModule());
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(prototype->globalObject());
         ObjCMethodCall* method = ObjCMethodCall::create(globalObject->vm(), globalObject, globalObject->objCMethodCallStructure(), memberMeta);
@@ -167,7 +167,7 @@ void ObjCPrototype::materializeProperties(VM& vm, GlobalObject* globalObject) {
 
     for (const PropertyMeta* propertyMeta : properties) {
         if (propertyMeta->isAvailable()) {
-            SymbolLoader::instance().ensureFramework(propertyMeta->topLevelModule()->getName());
+            SymbolLoader::instance().ensureModule(propertyMeta->topLevelModule());
 
             const MethodMeta* getter = (propertyMeta->getter() != nullptr && propertyMeta->getter()->isAvailable()) ? propertyMeta->getter() : nullptr;
             const MethodMeta* setter = (propertyMeta->setter() != nullptr && propertyMeta->setter()->isAvailable()) ? propertyMeta->setter() : nullptr;

--- a/src/NativeScript/SymbolLoader.h
+++ b/src/NativeScript/SymbolLoader.h
@@ -11,19 +11,25 @@
 
 #include <map>
 
+namespace Metadata {
+struct ModuleMeta;
+}
+
 namespace NativeScript {
+class SymbolResolver;
+
 class SymbolLoader {
 public:
     static SymbolLoader& instance();
 
-    void* loadFunctionSymbol(std::string libraryName, const char* symbolName);
-    void* loadDataSymbol(std::string libraryName, const char* symbolName);
-    bool ensureFramework(std::string frameworkName);
+    void* loadFunctionSymbol(const Metadata::ModuleMeta*, const char* symbolName);
+    void* loadDataSymbol(const Metadata::ModuleMeta*, const char* symbolName);
+    bool ensureModule(const Metadata::ModuleMeta*);
 
 private:
-    SymbolLoader();
+    SymbolResolver* resolveModule(const Metadata::ModuleMeta*);
 
-    std::map<const char*, WTF::RetainPtr<CFBundleRef>> _cache;
+    std::map<const Metadata::ModuleMeta*, std::unique_ptr<SymbolResolver>> _cache;
 };
 }
 

--- a/src/NativeScript/SymbolLoader.mm
+++ b/src/NativeScript/SymbolLoader.mm
@@ -1,80 +1,154 @@
 //
-//  SymbolLoader.cpp
+//  SymbolLoader.mm
 //  NativeScript
 //
 //  Created by Yavor Georgiev on 28.07.14.
 //  Copyright (c) 2014 г. Telerik. All rights reserved.
 //
 
-#include <dlfcn.h>
-#include <string>
 #include "SymbolLoader.h"
+#include <dlfcn.h>
+#include <wtf/NeverDestroyed.h>
+#include "Metadata/Metadata.h"
 
 namespace NativeScript {
-SymbolLoader::SymbolLoader() {
-}
+class SymbolResolver {
+public:
+    virtual void* loadFunctionSymbol(const char* symbolName) = 0;
+    virtual void* loadDataSymbol(const char* symbolName) = 0;
+    virtual bool load() = 0;
+};
+
+class CFBundleSymbolResolver : public SymbolResolver {
+public:
+    CFBundleSymbolResolver(WTF::RetainPtr<CFBundleRef> bundle)
+        : _bundle(bundle) {
+    }
+
+    virtual void* loadFunctionSymbol(const char* symbolName) override {
+        WTF::RetainPtr<CFStringRef> cfName = WTF::adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, symbolName, kCFStringEncodingUTF8, kCFAllocatorNull));
+        return CFBundleGetFunctionPointerForName(this->_bundle.get(), cfName.get());
+    }
+
+    virtual void* loadDataSymbol(const char* symbolName) override {
+        WTF::RetainPtr<CFStringRef> cfName = WTF::adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, symbolName, kCFStringEncodingUTF8, kCFAllocatorNull));
+        return CFBundleGetDataPointerForName(this->_bundle.get(), cfName.get());
+    }
+
+    virtual bool load() override {
+        CFErrorRef error = nullptr;
+        bool loaded = CFBundleLoadExecutableAndReturnError(this->_bundle.get(), &error);
+        if (error) {
+            dataLogF("%s\n", [[(NSError*)error localizedDescription] UTF8String]);
+        }
+
+        return loaded;
+    }
+
+private:
+    WTF::RetainPtr<CFBundleRef> _bundle;
+};
+
+class DlSymbolResolver : public SymbolResolver {
+public:
+    DlSymbolResolver(void* libraryHandle)
+        : _libraryHandle(libraryHandle) {
+    }
+
+    virtual void* loadFunctionSymbol(const char* symbolName) override {
+        return dlsym(this->_libraryHandle, symbolName);
+    }
+
+    virtual void* loadDataSymbol(const char* symbolName) override {
+        return dlsym(this->_libraryHandle, symbolName);
+    }
+
+    virtual bool load() override {
+        return !!this->_libraryHandle;
+    }
+
+private:
+    void* _libraryHandle;
+};
 
 SymbolLoader& SymbolLoader::instance() {
-    static std::once_flag once;
-    static SymbolLoader* loader;
-    std::call_once(once, []() { loader = new SymbolLoader(); });
-    return *loader;
+    static WTF::NeverDestroyed<SymbolLoader> loader;
+    return loader;
 }
 
-CFBundleRef getBundleFromName(std::map<const char*, WTF::RetainPtr<CFBundleRef>>& cache, const char* frameworkName) {
-    auto it = cache.find(frameworkName);
-    if (it != cache.end()) {
+SymbolResolver* SymbolLoader::resolveModule(const Metadata::ModuleMeta* module) {
+    if (!module) {
+        return nullptr;
+    }
+
+    auto it = this->_cache.find(module);
+    if (it != this->_cache.end()) {
         return it->second.get();
     }
 
-    NSString* frameworkPathStr = [NSString stringWithFormat:@"System/Library/Frameworks/%s.framework", frameworkName];
-    NSURL* baseUrl = nil;
-
+    std::unique_ptr<SymbolResolver> resolver;
+    if (module->isFramework()) {
+        NSString* frameworkPathStr = [NSString stringWithFormat:@"%s.framework", module->getName()];
+        NSURL* baseUrl = nil;
+        if (module->isSystem()) {
 #if TARGET_IPHONE_SIMULATOR
-    NSBundle* foundation = [NSBundle bundleForClass:[NSString class]];
-    NSString* foundationPath = [foundation bundlePath];
-    NSString* basePathStr = [foundationPath substringToIndex:[foundationPath rangeOfString:@"/System/Library/Frameworks/Foundation.framework"].location];
-    baseUrl = [NSURL fileURLWithPath:basePathStr
-                         isDirectory:YES];
+            NSBundle* foundation = [NSBundle bundleForClass:[NSString class]];
+            NSString* foundationPath = [foundation bundlePath];
+            NSString* basePathStr = [foundationPath substringToIndex:[foundationPath rangeOfString:@"Foundation.framework"].location];
+            baseUrl = [NSURL fileURLWithPath:basePathStr isDirectory:YES];
+#else
+            baseUrl = [NSURL fileURLWithPath:@"/System/Library/Frameworks" isDirectory:YES];
 #endif
+        } else {
+            baseUrl = [[NSBundle mainBundle] privateFrameworksURL];
+        }
 
-    NSURL* bundleUrl = [NSURL URLWithString:frameworkPathStr
-                              relativeToURL:baseUrl];
-    WTF::RetainPtr<CFBundleRef> bundle = adoptCF(CFBundleCreate(kCFAllocatorDefault, (CFURLRef)bundleUrl));
-    cache.insert(std::make_pair(frameworkName, bundle));
-    return bundle.get();
+        NSURL* bundleUrl = [NSURL URLWithString:frameworkPathStr relativeToURL:baseUrl];
+        if (WTF::RetainPtr<CFBundleRef> bundle = adoptCF(CFBundleCreate(kCFAllocatorDefault, (CFURLRef)bundleUrl))) {
+            WTF::dataLogF("NativeScript loaded bundle %s\n", bundleUrl.absoluteString.UTF8String);
+            resolver = std::make_unique<CFBundleSymbolResolver>(bundle);
+        } else {
+            WTF::dataLogF("NativeScript could not load bundle %s\n", bundleUrl.absoluteString.UTF8String);
+        }
+    } else if (module->libraries->count == 1) {
+        if (module->isSystem()) {
+            // NSObject is in /usr/lib/libobjc.dylib, so we get that
+            NSString* libsPath = [[NSBundle bundleForClass:[NSObject class]] bundlePath];
+            NSString* libraryPath = [NSString stringWithFormat:@"%@/%s.dylib", libsPath, module->libraries->first()->value().getName()];
+
+            if (void* library = dlopen(libraryPath.UTF8String, RTLD_LAZY | RTLD_LOCAL)) {
+                WTF::dataLogF("NativeScript loaded library %s\n", libraryPath.UTF8String);
+                resolver = std::make_unique<DlSymbolResolver>(library);
+            } else if (const char* libraryError = dlerror()) {
+                WTF::dataLogF("NativeScript could not load library%s, error: %s\n", libraryPath.UTF8String, libraryError);
+            }
+        }
+    }
+
+    return this->_cache.emplace(module, std::move(resolver)).first->second.get();
 }
 
-void* SymbolLoader::loadFunctionSymbol(std::string libraryName, const char* symbolName) {
-    CFBundleRef bundle = getBundleFromName(this->_cache, libraryName.c_str());
-    if (bundle) {
-        void* handle = CFBundleGetFunctionPointerForName(bundle, (CFStringRef) @(symbolName));
-        if (handle) {
-            return handle;
-        }
+void* SymbolLoader::loadFunctionSymbol(const Metadata::ModuleMeta* module, const char* symbolName) {
+    if (auto resolver = this->resolveModule(module)) {
+        return resolver->loadFunctionSymbol(symbolName);
     }
 
     return dlsym(RTLD_DEFAULT, symbolName);
 }
 
-void* SymbolLoader::loadDataSymbol(std::string libraryName, const char* symbolName) {
-    CFBundleRef bundle = getBundleFromName(this->_cache, libraryName.c_str());
-    if (bundle) {
-        void* handle = CFBundleGetDataPointerForName(bundle, (CFStringRef) @(symbolName));
-        if (handle) {
-            return handle;
-        }
+void* SymbolLoader::loadDataSymbol(const Metadata::ModuleMeta* module, const char* symbolName) {
+    if (auto resolver = this->resolveModule(module)) {
+        return resolver->loadDataSymbol(symbolName);
     }
 
     return dlsym(RTLD_DEFAULT, symbolName);
 }
 
-bool SymbolLoader::ensureFramework(std::string frameworkName) {
-    CFBundleRef bundle = getBundleFromName(this->_cache, frameworkName.c_str());
-    if (!bundle) {
-        return false;
+bool SymbolLoader::ensureModule(const Metadata::ModuleMeta* module) {
+    if (auto resolver = this->resolveModule(module)) {
+        return resolver->load();
     }
 
-    return CFBundleLoadExecutableAndReturnError(bundle, nullptr);
+    return false;
 }
 }

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -273,7 +273,7 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
 
     Class klass = objc_getClass(metadata->name());
     if (!klass) {
-        SymbolLoader::instance().ensureFramework(metadata->topLevelModule()->getName());
+        SymbolLoader::instance().ensureModule(metadata->topLevelModule());
         klass = objc_getClass(metadata->name());
     }
 


### PR DESCRIPTION
Make SymbolLoader cache by the ModuleMeta pointer, which is unique.
SymbolLoader now supports embedded frameworks.
Stubbed support for dylibs.

Fixes #273 