### PR TITLE
ReferenceConstructor should accept a single type argument

### DIFF
--- a/src/NativeScript/Marshalling/Record/RecordInstance.h
+++ b/src/NativeScript/Marshalling/Record/RecordInstance.h
@@ -37,6 +37,10 @@ public:
         return this->_size;
     }
 
+    PointerInstance* pointer() const {
+        return this->_pointer.get();
+    }
+
 private:
     RecordInstance(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {

--- a/src/NativeScript/Marshalling/Reference/ReferenceInstance.h
+++ b/src/NativeScript/Marshalling/Reference/ReferenceInstance.h
@@ -43,6 +43,10 @@ public:
         return this->_pointer ? this->_pointer->data() : nullptr;
     }
 
+    PointerInstance* pointer() const {
+        return this->_pointer.get();
+    }
+
     JSC::JSCell* innerType() const {
         return this->_innerTypeCell.get();
     }

--- a/tests/TestRunner/app/Marshalling/ReferenceTests.js
+++ b/tests/TestRunner/app/Marshalling/ReferenceTests.js
@@ -229,4 +229,78 @@ describe(module.id, function () {
 
         expect(array.firstObject).toBe(object);
     });
+    
+    describe("ReferenceConstructor", function () {
+        it("should accept empty arguments", function () {
+            var reference = new interop.Reference();
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+        });
+        
+        it("should accept a single value argument", function () {
+            var value = "value";
+            
+            var reference = new interop.Reference(value);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(reference.value).toBe(value);
+        });
+        
+        it("should accept a single type argument", function () {
+            var reference = new interop.Reference(interop.types.bool);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(interop.handleof(reference)).toEqual(jasmine.any(interop.Pointer));
+        });
+        
+        it("should accept type and value arguments", function () {
+            var value = NSObject.alloc().init();
+            var reference = new interop.Reference(NSObject, value);
+            var buffer = interop.handleof(reference);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(reference.value).toBe(value);
+            expect(buffer).toEqual(jasmine.any(interop.Pointer));
+        });
+        
+        it("should accept type and pointer arguments", function () {
+            var pointer = interop.alloc(1);
+            var reference = new interop.Reference(interop.types.bool, pointer);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(interop.handleof(reference)).toBe(pointer);
+        });
+        
+        it("should accept type and record arguments", function () {
+            var record = new CGPoint();
+            var reference = new interop.Reference(CGPoint, record);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(interop.handleof(reference)).toBe(interop.handleof(record));
+        });
+        
+        it("should accept type and pointer-backed reference arguments", function () {
+            var ref = new interop.Reference(interop.types.bool);
+            var reference = new interop.Reference(interop.types.bool, ref);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(interop.handleof(reference)).toBe(interop.handleof(ref));
+        });
+        
+        it("should accept type and uninitialized reference arguments", function () {
+            var ref = new interop.Reference(123);
+            var reference = new interop.Reference(interop.types.int8, ref);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(ref.value).toEqual(reference.value);
+        });
+        
+        it("should accept reference type and reference arguments", function () {
+            var ref = new interop.Reference(interop.types.bool);
+            var reference = new interop.Reference(new interop.types.ReferenceType(interop.types.bool), ref);
+            
+            expect(reference).toEqual(jasmine.any(interop.Reference)); 
+            expect(interop.handleof(reference.value)).toBe(interop.handleof(ref));
+        });
+    });
 });


### PR DESCRIPTION
and allocate an internal buffer of the correct size.