### PR TITLE
Delay debugger pausing

### DIFF
--- a/src/NativeScript/inspector/CachedResource.mm
+++ b/src/NativeScript/inspector/CachedResource.mm
@@ -23,7 +23,7 @@ WTF::HashMap<WTF::String, Inspector::Protocol::Page::ResourceType> CachedResourc
 CachedResource::CachedResource() {}
 
 CachedResource::CachedResource(WTF::String bundlePath, WTF::String filePath)
-    : m_filePath(filePath)
+    : m_filePath([filePath stringByResolvingSymlinksInPath])
     , m_bundlePath(bundlePath)
     , m_content(WTF::emptyString()) {
     m_mimeType = WTF::String(NativeScript::mimeTypeByExtension([filePath pathExtension]));

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -189,8 +189,18 @@ static void TNSEnableRemoteInspector(int argc, char **argv) {
 
       if (isWaitingForDebugger) {
         isWaitingForDebugger = NO;
-        CFRunLoopStop(CFRunLoopGetMain());
-        [inspector pause];
+          
+        CFRunLoopRef runloop = CFRunLoopGetMain();
+        CFRunLoopPerformBlock(runloop,
+                              (__bridge CFTypeRef)(NSRunLoopCommonModes),
+                              ^{
+                                    // If we pause right away the debugger messages that are send are not handled because the frontend is not yet initialized
+                                    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+                                    
+                                    [inspector pause];
+                               });
+        CFRunLoopWakeUp(runloop);
+        CFRunLoopStop(runloop);
       }
 
       NSArray *inspectorRunloopModes =


### PR DESCRIPTION
If we pause right away the debugger messages that are send are not handled because the frontend is not yet initialized