### PR TITLE
Expose compile-time constants as JsCode

### DIFF
--- a/tests/TestRunner/app/Marshalling/ConstantsTests.js
+++ b/tests/TestRunner/app/Marshalling/ConstantsTests.js
@@ -11,6 +11,10 @@ describe(module.id, function () {
         expect(TNSConstant).toBe(TNSConstant);
         expect(TNSConstant).toBe("TNSConstant");
     });
+         
+    it("CompileTimeConstant", function () {
+        expect(kCGFontIndexMax).toBe(65534);
+    });
 
 // TODO
 //    it("ChangeConstantValue", function () {


### PR DESCRIPTION
Related issue: https://github.com/NativeScript/ios-runtime/issues/279
Merge after https://github.com/NativeScript/ios-metadata-generator/pull/23
Ready for merge.