### PR TITLE
Fix cocoapods

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		858B842D18CA22B800AB12DE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 858B833A18CA111C00AB12DE /* InfoPlist.strings */; };
 		CD45EE7C18DC2D5800FB50C0 /* app in Resources */ = {isa = PBXBuildFile; fileRef = CD45EE7A18DC2D5800FB50C0 /* app */; };
-		CD62955D1BB2678900AE3A93 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CD62955C1BB2678900AE3A93 /* main.m */; settings = {ASSET_TAGS = (); }; };
+		CD62955D1BB2678900AE3A93 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CD62955C1BB2678900AE3A93 /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -33,6 +33,8 @@
 		858B843318CA22B800AB12DE /* __PROJECT_NAME__.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = __PROJECT_NAME__.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD45EE7A18DC2D5800FB50C0 /* app */ = {isa = PBXFileReference; lastKnownFileType = folder; path = app; sourceTree = "<group>"; };
 		CD62955C1BB2678900AE3A93 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = internal/main.m; sourceTree = SOURCE_ROOT; };
+		CDD59A261BB43B5D00EC2671 /* build-debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "build-debug.xcconfig"; sourceTree = "<group>"; };
+		CDD59A271BB43B5D00EC2671 /* build-release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "build-release.xcconfig"; sourceTree = "<group>"; };
 		CDF4743E1BA4855C0087EA85 /* build.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = build.xcconfig; sourceTree = "<group>"; };
 		F9B8C6A31ACEDEEB00547416 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -88,6 +90,8 @@
 			isa = PBXGroup;
 			children = (
 				CDF4743E1BA4855C0087EA85 /* build.xcconfig */,
+				CDD59A261BB43B5D00EC2671 /* build-debug.xcconfig */,
+				CDD59A271BB43B5D00EC2671 /* build-release.xcconfig */,
 				858B833918CA111C00AB12DE /* __PROJECT_NAME__-Info.plist */,
 				858B833A18CA111C00AB12DE /* InfoPlist.strings */,
 				CD62955C1BB2678900AE3A93 /* main.m */,
@@ -247,7 +251,6 @@
 /* Begin XCBuildConfiguration section */
 		858B835818CA111C00AB12DE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CDF4743E1BA4855C0087EA85 /* build.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
@@ -285,7 +288,6 @@
 		};
 		858B835918CA111C00AB12DE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CDF4743E1BA4855C0087EA85 /* build.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
@@ -321,6 +323,7 @@
 		};
 		858B843118CA22B800AB12DE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CDD59A261BB43B5D00EC2671 /* build-debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_MODULES = NO;
@@ -342,6 +345,7 @@
 		};
 		858B843218CA22B800AB12DE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CDD59A271BB43B5D00EC2671 /* build-release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_ENABLE_MODULES = NO;

--- a/build/project-template/__PROJECT_NAME__/build-debug.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build-debug.xcconfig
@@ -1,0 +1,2 @@
+#include "build.xcconfig"
+#include "Pods/Target Support Files/Pods/Pods.debug.xcconfig"

--- a/build/project-template/__PROJECT_NAME__/build-release.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build-release.xcconfig
@@ -1,0 +1,2 @@
+#include "build.xcconfig"
+#include "Pods/Target Support Files/Pods/Pods.release.xcconfig"

--- a/build/project-template/__PROJECT_NAME__/build.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build.xcconfig
@@ -5,3 +5,5 @@
 // * Generic 'iPhone Developer' (no quotes) will match the right Identity
 // * with the right Provisioning Profile plus Certificate, based on the app bundle id
 CODE_SIGN_IDENTITY = iPhone Developer
+
+// * Xcconfig files from third-party NativeScript plugins will be included here


### PR DESCRIPTION
* Moved the build.xcconfig to target level
* When installing cocoapods, it will not remove it, so we include cocoapods xcconfigs
* A not found xcconfig is not a build error

This is done because there is a Pod target that doesn't need NativeScript xcconfig.