### PR TITLE
Fix mangling of utf8 characters in module code

### DIFF
--- a/src/NativeScript/inspector/SourceProviderManager.cpp
+++ b/src/NativeScript/inspector/SourceProviderManager.cpp
@@ -15,6 +15,11 @@ RefPtr<JSC::SourceProvider> ResourceManager::addSourceProvider(WTF::String url, 
 }
 
 WTF::String ResourceManager::constructFunctionContent(WTF::String moduleBody) {
-    return String::format("{function anonymous(require, module, exports, __dirname, __filename) { %s \n}}", moduleBody.utf8().data());
+    StringBuilder builder;
+    builder.append("{function anonymous(require, module, exports, __dirname, __filename) {");
+    builder.append(moduleBody);
+    builder.append("\n}}");
+
+    return builder.toString();
 }
 }


### PR DESCRIPTION
WTF::String::format() messes up with the utf8 characters. https://bugs.webkit.org/show_bug.cgi?id=37327