### PR TITLE
Generate dSYM for NativeScript.framework

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -4,7 +4,7 @@ set -e
 
 WORKSPACE=`pwd`
 
-CMAKE_FLAGS="-G Xcode -DCMAKE_INSTALL_PREFIX=$WORKSPACE/dist"
+CMAKE_FLAGS="-G Xcode"
 
 mkdir -p "$WORKSPACE/cmake-build"
 cd "$WORKSPACE/cmake-build"
@@ -14,17 +14,25 @@ rm -f CMakeCache.txt
 echo -e "\tConfiguring..."
 cmake .. $CMAKE_FLAGS -DBUILD_SHARED_LIBS=ON > "$WORKSPACE/build.log" 2>&1
 echo -e "\tiPhoneOS..."
-xcodebuild -configuration Release -sdk iphoneos -target NativeScript >> "$WORKSPACE/build.log" 2>&1
+xcodebuild -configuration RelWithDebInfo -sdk iphoneos -target NativeScript >> "$WORKSPACE/build.log" 2>&1
 echo -e "\tiPhoneSimulator..."
-xcodebuild -configuration Release -sdk iphonesimulator -target NativeScript >> "$WORKSPACE/build.log" 2>&1
+xcodebuild -configuration RelWithDebInfo -sdk iphonesimulator -target NativeScript >> "$WORKSPACE/build.log" 2>&1
 
 echo "Packaging NativeScript.framework..."
 mkdir -p "$WORKSPACE/dist"
-cp -r "$WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework" "$WORKSPACE/dist"
+cp -r "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphoneos/NativeScript.framework" "$WORKSPACE/dist"
 rm "$WORKSPACE/dist/NativeScript.framework/NativeScript"
 lipo -create -output "$WORKSPACE/dist/NativeScript.framework/NativeScript" \
-    "$WORKSPACE/cmake-build/src/NativeScript/Release-iphonesimulator/NativeScript.framework/NativeScript" \
-    "$WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework/NativeScript" \
+    "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphonesimulator/NativeScript.framework/NativeScript" \
+    "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphoneos/NativeScript.framework/NativeScript" \
+         >> "$WORKSPACE/build.log" 2>&1
+strip -S "$WORKSPACE/dist/NativeScript.framework/NativeScript"
+
+cp -r "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphoneos/NativeScript.framework.dSYM" "$WORKSPACE/dist"
+rm "$WORKSPACE/dist/NativeScript.framework.dSYM/Contents/Resources/DWARF/NativeScript"
+lipo -create -output "$WORKSPACE/dist/NativeScript.framework.dSYM/Contents/Resources/DWARF/NativeScript" \
+    "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphonesimulator/NativeScript.framework.dSYM/Contents/Resources/DWARF/NativeScript" \
+    "$WORKSPACE/cmake-build/src/NativeScript/RelWithDebInfo-iphoneos/NativeScript.framework.dSYM/Contents/Resources/DWARF/NativeScript" \
          >> "$WORKSPACE/build.log" 2>&1
 
 echo "Building libNativeScript..."

--- a/cmake/CreateNativeScriptApp.cmake
+++ b/cmake/CreateNativeScriptApp.cmake
@@ -6,7 +6,7 @@ function(CreateNativeScriptApp _target _main _plist _resources)
 
     target_link_libraries(${_target}
         "-framework CoreGraphics"
-        "-framework UIKit"        
+        "-framework UIKit"
         "-framework MobileCoreServices"
         NativeScript
     )
@@ -31,7 +31,7 @@ function(CreateNativeScriptApp _target _main _plist _resources)
         XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "7.0"
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
         XCODE_ATTRIBUTE_GCC_C_LANGUAGE_STANDARD "gnu99"
-        XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=Debug] "DWARF"
+        XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT[variant=Debug] "dwarf"
     )
 
     include(SetActiveArchitectures)

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -75,6 +75,11 @@ module.exports = function(grunt) {
                     dest: "<%= outPackageFrameworkDir %>/internal/NativeScript/Frameworks",
                     expand: true
                 }, {
+                    cwd: "<%= outDistDir %>",
+                    src: ["NativeScript.framework.dsym", "NativeScript.framework.dsym/**"],
+                    dest: "<%= outPackageFrameworkDir %>/internal/NativeScript/Frameworks",
+                    expand: true
+                }, {
                     cwd: "<%= srcDir %>/src/debugging",
                     src: "TNSDebugging.h",
                     dest: "<%= outPackageFrameworkDir %>/internal",

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -194,6 +194,7 @@ if(${BUILD_SHARED_LIBS})
         INSTALL_NAME_DIR "@executable_path/Frameworks"
         XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
         MACOSX_FRAMEWORK_IDENTIFIER "org.nativescript.NativeScript"
+        XCODE_ATTRIBUTE_CLANG_DEBUG_INFORMATION_LEVEL[variant=RelWithDebInfo] "line-tables-only"
     )
     target_link_libraries(NativeScript
         ${WEBKIT_LIBRARIES}


### PR DESCRIPTION
https://github.com/NativeScript/ios-runtime/issues/242

Requires Xcode 7 on build machines.