### PR TITLE
Revert "Explicitly set the metadata generator's OS X deployment target"

### DIFF
--- a/src/MetadataGenerator.cmake
+++ b/src/MetadataGenerator.cmake
@@ -4,8 +4,6 @@ ExternalProject_Add(MetadataGenerator
     CONFIGURE_COMMAND env -i "${CMAKE_COMMAND}"
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/metadataGenerator
         -DCMAKE_BUILD_TYPE=$<CONFIG>
-        -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
-        -DCMAKE_OSX_SYSROOT=macosx
         "${CMAKE_SOURCE_DIR}/src/metadata-generator"
     BUILD_COMMAND env -i "${CMAKE_COMMAND}"
         --build .


### PR DESCRIPTION
Merge with: https://github.com/NativeScript/ios-metadata-generator/pull/28