### PR TITLE
Make build steps to fail if an internal command fails

### DIFF
--- a/build/project-template/internal/nativescript-post-build
+++ b/build/project-template/internal/nativescript-post-build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 pushd "$SRCROOT/internal"
 ./strip-dynamic-framework-architectures.sh

--- a/build/project-template/internal/nativescript-pre-build
+++ b/build/project-template/internal/nativescript-pre-build
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 pushd "$SRCROOT/internal/metadata-generator/bin"
 ./metadata-generation-build-step

--- a/build/project-template/internal/nativescript-pre-link
+++ b/build/project-template/internal/nativescript-pre-link
@@ -1,1 +1,2 @@
 #!/usr/bin/env bash
+set -e

--- a/build/scripts/metadata-generation-build-step
+++ b/build/scripts/metadata-generation-build-step
@@ -79,6 +79,7 @@ def generate_metadata(arch):
     error_file.close()
 
     if child_process.returncode != 0:
+        print("Error: Unable to generate metadata for {}.".format(arch))
         print(error_stream_content)
         sys.exit(1)
 


### PR DESCRIPTION
Make build steps to fail if an internal command fails. Print meaningful message when metadata generation step fails.