### PR TITLE
Expose build configuration as an enviromental variable

### DIFF
--- a/build/project-template/internal/main.m
+++ b/build/project-template/internal/main.m
@@ -20,9 +20,11 @@ int main(int argc, char *argv[]) {
 #ifndef NDEBUG
     NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(
         NSLibraryDirectory, NSUserDomainMask, YES) firstObject];
-    NSString *liveSyncPath =
-        [NSString pathWithComponents:
-                      @[ libraryPath, @"Application Support", @"LiveSync" ]];
+    NSString *liveSyncPath = [NSString pathWithComponents:@[
+      libraryPath,
+      @"Application Support",
+      @"LiveSync"
+    ]];
     NSString *appFolderPath =
         [NSString pathWithComponents:@[ liveSyncPath, @"app" ]];
 
@@ -43,6 +45,10 @@ int main(int argc, char *argv[]) {
     [TNSRuntimeInspector setLogsToSystemConsole:YES];
     TNSEnableRemoteInspector(argc, argv);
 #endif
+
+    if (putenv("BUILD_CONFIGURATION=" BUILD_CONFIGURATION) == -1) {
+      perror("Could not set build configuration");
+    }
 
     [runtime executeModule:@"./"];
 

--- a/build/project-template/internal/nativescript-build.xcconfig
+++ b/build/project-template/internal/nativescript-build.xcconfig
@@ -2,6 +2,7 @@
 // * Add [sdk=*] after each one to avoid conflict with CocoaPods flags
 HEADER_SEARCH_PATHS[sdk=*] = $(inherited) "$(SRCROOT)/internal" "$(SRCROOT)/internal/NativeScript/include"
 OTHER_LDFLAGS[sdk=*] = $(inherited) -ObjC -sectcreate __DATA __TNSMetadata "$(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin" -lNativeScript -L"$(SRCROOT)/internal/NativeScript/lib" -licucore -lz -lc++ -framework Foundation -framework UIKit -framework CoreGraphics -framework MobileCoreServices -framework Security
+GCC_PREPROCESSOR_DEFINITIONS[sdk=*] = $(inherited) "BUILD_CONFIGURATION=\"$(CONFIGURATION)\""
 
 // We need to add CONFIGURATION_BUILD_DIR here so that we can explicitly quote-escape any paths in it, because the implicitly added path by Xcode is not always escaped
 FRAMEWORK_SEARCH_PATHS[sdk=*] = $(inherited) "$(SRCROOT)/../../lib/iOS" "$(CONFIGURATION_BUILD_DIR)"


### PR DESCRIPTION
One way to read it from JavaScript:

```javascript
NSProcessInfo.processInfo().environment.objectForKey('BUILD_CONFIGURATION'); // Debug, Release, ...
```

ping @PanayotCankov 