### PR TITLE
Disable JIT

### DIFF
--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -33,6 +33,7 @@ using namespace NativeScript;
 + (void)initialize {
     if (self == [TNSRuntime self]) {
         initializeThreading();
+        JSC::Options::useJIT() = false;
     }
 }
 


### PR DESCRIPTION
We are disabling JIT because of a bug found in the latest webkit version, causing some tests to fail. We can't figure out the actual piece of code causing the bug, but disabling JIT makes it disappear.

P.S. Til now, JIT was enabled only on simulator, because of iOS restrictions, so the change will not affect device builds.