### PR TITLE
Simplify require errors.

### DIFF
--- a/src/NativeScript/require.js
+++ b/src/NativeScript/require.js
@@ -90,9 +90,10 @@
             absolutePath = absoluteFilePath;
         }
         absolutePath = nsstr(absolutePath).stringByStandardizingPath;
+        var bundlePath = absolutePath.substr(applicationPath.length);
 
         if (!fileManager.fileExistsAtPathIsDirectory(absolutePath, isDirectory)) {
-            throw new ModuleError(`Failed to find module '${moduleIdentifier}' relative to '${previousPath}'. Computed path: ${absolutePath}`);
+            throw new ModuleError(`Failed to find module '${moduleIdentifier}' relative to 'file://${previousPath}'. Computed path: '${bundlePath.replace(/^\//, '')}'.`);
         }
 
         if (isDirectory.value) {
@@ -104,7 +105,7 @@
         var moduleMetadata = {
             name: nsstr(moduleIdentifier).lastPathComponent,
             path: absolutePath,
-            bundlePath: absolutePath.substr(applicationPath.length)
+            bundlePath
         };
 
         pathCache.set(requestedPath, moduleMetadata);
@@ -116,6 +117,7 @@
         module.require = function require(moduleIdentifier) {
             return __loadModule(moduleIdentifier, modulePath).exports;
         };
+        module.require.displayName = "__require";
         var moduleSource = NSString.stringWithContentsOfFileEncodingError(moduleMetadata.path, NSUTF8StringEncoding, null);
         var moduleFunction = createModuleFunction(moduleSource, "file://" + moduleMetadata.bundlePath);
         var fileName = moduleMetadata.path;


### PR DESCRIPTION
Here is how it looks now:

```
JavaScript stack trace:
1   __findModule@require.js:96:170
2   __loadModule@require.js:143:42
3   __require@require.js:118:32
4   anonymous@file:///app/test/test.js:3:8
5   __executeModule@require.js:129:27
6   __loadModule@require.js:157:24
7   __require@require.js:118:32
8   anonymous@file:///app/index.js:1:78
9   __executeModule@require.js:129:27
10  __loadModule@require.js:157:24
JavaScript error:
require.js:96:170: JS ERROR Error: Failed to find module '../no' relative to 'file:///app/test/test.js'. Computed path: 'app/no.js'.
```
By prepending all of our internal functions with `__`, it's easy for the user to find his functions in a glance.

As @PanayotCankov suggested, file paths are clickable in the Inspector now:
![image](https://cloud.githubusercontent.com/assets/305639/11437273/2977373e-94f5-11e5-87b0-a31d369e9e5d.png)


Close #407.