### PR TITLE
Add all properties of domain types to the TypeScript generated glue code

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
@@ -74,6 +74,14 @@ JSC::EncodedJSValue registerDispatcher(JSC::ExecState* execState) {
     return JSValue::encode(jsUndefined());
 }
 
+JSC::EncodedJSValue inspectorTimestamp(JSC::ExecState* execState) {
+    NativeScript::GlobalObject* globalObject = jsCast<NativeScript::GlobalObject*>(execState->lexicalGlobalObject());
+
+    JSC::JSValue elapsedTime = JSC::jsNumber(globalObject->inspectorController().executionStopwatch()->elapsedTime());
+
+    return JSValue::encode(elapsedTime);
+}
+
 GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& globalObject)
     : m_injectedScriptManager(std::make_unique<InjectedScriptManager>(*this, InjectedScriptHost::create()))
     , m_executionStopwatch(Stopwatch::create())
@@ -86,6 +94,7 @@ GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& g
 
 {
     globalObject.putDirectNativeFunction(globalObject.vm(), &globalObject, Identifier::fromString(&globalObject.vm(), WTF::ASCIILiteral("__registerDomainDispatcher")), 0, &registerDispatcher, NoIntrinsic, DontEnum);
+    globalObject.putDirectNativeFunction(globalObject.vm(), &globalObject, Identifier::fromString(&globalObject.vm(), WTF::ASCIILiteral("__inspectorTimestamp")), 0, &inspectorTimestamp, NoIntrinsic, DontEnum);
 
     auto inspectorAgent = std::make_unique<InspectorAgent>(m_jsAgentContext);
     auto runtimeAgent = std::make_unique<JSGlobalObjectRuntimeAgent>(m_jsAgentContext);

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
@@ -64,7 +64,7 @@ using namespace JSC;
 using namespace Inspector;
 
 namespace NativeScript {
-JSC::EncodedJSValue registerDispatcher(JSC::ExecState* execState) {
+JSC::EncodedJSValue JSC_HOST_CALL registerDispatcher(JSC::ExecState* execState) {
     NativeScript::GlobalObject* globalObject = jsCast<NativeScript::GlobalObject*>(execState->lexicalGlobalObject());
     WTF::String domainIdentifier = execState->argument(0).toWTFString(execState);
     JSCell* constructorFunction = execState->argument(1).asCell();
@@ -74,7 +74,7 @@ JSC::EncodedJSValue registerDispatcher(JSC::ExecState* execState) {
     return JSValue::encode(jsUndefined());
 }
 
-JSC::EncodedJSValue inspectorTimestamp(JSC::ExecState* execState) {
+JSC::EncodedJSValue JSC_HOST_CALL inspectorTimestamp(JSC::ExecState* execState) {
     NativeScript::GlobalObject* globalObject = jsCast<NativeScript::GlobalObject*>(execState->lexicalGlobalObject());
 
     JSC::JSValue elapsedTime = JSC::jsNumber(globalObject->inspectorController().executionStopwatch()->elapsedTime());

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.h
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.h
@@ -67,6 +67,7 @@ class JSValue;
 namespace NativeScript {
 
 JSC::EncodedJSValue JSC_HOST_CALL registerDispatcher(JSC::ExecState* execState);
+JSC::EncodedJSValue JSC_HOST_CALL inspectorTimestamp(JSC::ExecState* execState);
 
 class GlobalObjectInspectorController final
     : public Inspector::InspectorEnvironment


### PR DESCRIPTION
Also expose inspectorTimestamp method that would be used from modules guys to record a timeline event. Doing that in JavaScript was not possible because the elapsed time is based on some context that is held and modified by several different places