### PR TITLE
Replace ObjC association with WeakGCMap

### DIFF
--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -144,12 +144,6 @@ public:
         return this->_releasePools;
     }
 
-#if defined(__LP64__) && __LP64__
-    JSC::WeakGCMap<const void*, ObjCWrapperObject>& taggedPointers() {
-        return this->_taggedPointers;
-    };
-#endif
-
 private:
     GlobalObject(JSC::VM& vm, JSC::Structure* structure);
 
@@ -201,11 +195,6 @@ private:
     std::map<const Protocol*, JSC::Strong<ObjCProtocolWrapper>> _objCProtocolWrappers;
 
     WTF::Deque<std::map<std::string, std::unique_ptr<ReleasePoolBase>>> _releasePools;
-
-#if defined(__LP64__) && __LP64__
-    // See comment in toValue
-    JSC::WeakGCMap<const void*, ObjCWrapperObject> _taggedPointers;
-#endif
 };
 }
 

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -80,9 +80,6 @@ const GlobalObjectMethodTable GlobalObject::globalObjectMethodTable = { &allowsA
 
 GlobalObject::GlobalObject(VM& vm, Structure* structure)
     : JSGlobalObject(vm, structure, &GlobalObject::globalObjectMethodTable)
-#if defined(__LP64__) && __LP64__
-    , _taggedPointers(vm)
-#endif
 {
 }
 

--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -50,10 +50,15 @@ public:
         return this->_functionReferenceInstanceStructure.get();
     }
 
+    JSC::WeakGCMap<id, JSC::JSObject>& objectMap() {
+        return this->_objectMap;
+    }
+
 private:
     Interop(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure)
-        , _pointerToInstance(vm) {
+        , _pointerToInstance(vm)
+        , _objectMap(vm) {
     }
 
     void finishCreation(JSC::VM&, GlobalObject*);
@@ -67,7 +72,13 @@ private:
     JSC::WriteBarrier<JSC::Structure> _functionReferenceInstanceStructure;
 
     JSC::WeakGCMap<const void*, PointerInstance> _pointerToInstance;
+
+    JSC::WeakGCMap<id, JSC::JSObject> _objectMap;
 };
+
+static inline Interop* interop(JSC::ExecState* execState) {
+    return JSC::jsCast<GlobalObject*>(execState->lexicalGlobalObject())->interop();
+}
 }
 
 #endif /* defined(__NativeScript__Interop__) */

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -9,6 +9,7 @@
 #include "ObjCConstructorBase.h"
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
+#include "ObjCWrapperObject.h"
 #include "ObjCMethodCall.h"
 #include "ObjCConstructorCall.h"
 #include "ObjCTypes.h"

--- a/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.h
+++ b/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.h
@@ -12,7 +12,7 @@
 #define __NativeScript__TNSFastEnumerationAdapter__
 
 namespace NativeScript {
-NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id buffer[], NSUInteger length, JSC::JSGlobalObject* globalObject);
+NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id buffer[], NSUInteger length, GlobalObject* globalObject);
 }
 
 #endif /* defined(__NativeScript__TNSFastEnumerationAdapter__) */

--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -12,6 +12,7 @@
 #include "ObjCPrototype.h"
 #include "ObjCConstructorDerived.h"
 #include "ObjCSuperObject.h"
+#include "ObjCWrapperObject.h"
 #include "TypeFactory.h"
 #include "Metadata.h"
 #include "AllocatedPlaceholder.h"

--- a/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
+++ b/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
@@ -13,6 +13,7 @@
 #include "ObjCSuperObject.h"
 #include "ObjCConstructorBase.h"
 #include "ObjCProtocolWrapper.h"
+#include "ObjCWrapperObject.h"
 #include "Interop.h"
 #include "AllocatedPlaceholder.h"
 

--- a/src/NativeScript/ObjC/ObjCTypes.h
+++ b/src/NativeScript/ObjC/ObjCTypes.h
@@ -9,20 +9,6 @@
 #ifndef __NativeScript__ObjCIdType__
 #define __NativeScript__ObjCIdType__
 
-#include <objc/runtime.h>
-#include "FFIType.h"
-#include "ObjCWrapperObject.h"
-
-@interface TNSValueWrapper : NSObject
-
-+ (void)attachValue:(JSC::JSObject*)value toHost:(id)host;
-
-- (JSC::JSObject*)value;
-
-- (void)detach;
-
-@end
-
 namespace NativeScript {
 id toObject(JSC::ExecState*, const JSC::JSValue&);
 JSC::JSValue toValue(JSC::ExecState*, id, Class klass = nil);

--- a/src/NativeScript/ObjC/ObjCWrapperObject.h
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.h
@@ -57,6 +57,7 @@ private:
     static void putByIndex(JSC::JSCell* cell, JSC::ExecState* execState, unsigned propertyName, JSC::JSValue value, bool shouldThrow);
 
     WTF::RetainPtr<id> _wrappedObject;
+    JSC::WeakGCMap<id, JSC::JSObject>* _objectMap;
 
     bool _canSetObjectAtIndexedSubscript;
 };

--- a/src/NativeScript/ObjC/ObjCWrapperObject.mm
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.mm
@@ -20,6 +20,8 @@ void ObjCWrapperObject::finishCreation(VM& vm, id wrappedObject, GlobalObject* g
     this->setWrappedObject(wrappedObject);
     this->_canSetObjectAtIndexedSubscript = [wrappedObject respondsToSelector:@selector(setObject:
                                                                                   atIndexedSubscript:)];
+    this->_objectMap = &globalObject->interop()->objectMap();
+    this->_objectMap->set(wrappedObject, this);
 }
 
 WTF::String ObjCWrapperObject::className(const JSObject* object) {
@@ -46,6 +48,7 @@ void ObjCWrapperObject::putByIndex(JSCell* cell, ExecState* execState, unsigned 
 }
 
 ObjCWrapperObject::~ObjCWrapperObject() {
+    this->_objectMap->remove(this->wrappedObject());
 #ifdef DEBUG_MEMORY
     NSLog(@"ObjCWrapperObject soon releasing %@(%p)", object_getClass(this->_wrappedObject.get()), this->_wrappedObject.get());
 #endif

--- a/src/NativeScript/ObjC/TNSArrayAdapter.mm
+++ b/src/NativeScript/ObjC/TNSArrayAdapter.mm
@@ -8,6 +8,7 @@
 
 #import "TNSArrayAdapter.h"
 #include "ObjCTypes.h"
+#include "Interop.h"
 #include <JavaScriptCore/StrongInlines.h>
 
 using namespace NativeScript;
@@ -22,7 +23,7 @@ using namespace JSC;
     if (self) {
         self->_object = Strong<JSObject>(execState->vm(), jsObject);
         self->_execState = execState;
-        [TNSValueWrapper attachValue:jsObject toHost:self];
+        interop(execState)->objectMap().set(self, jsObject);
     }
 
     return self;
@@ -71,6 +72,15 @@ using namespace JSC;
     state->extra[0] = currentIndex;
 
     return count;
+}
+
+- (void)dealloc {
+    {
+        JSLockHolder lock(self->_execState);
+        interop(self->_execState)->objectMap().remove(self);
+    }
+
+    [super dealloc];
 }
 
 @end

--- a/src/NativeScript/ObjC/TNSDataAdapter.mm
+++ b/src/NativeScript/ObjC/TNSDataAdapter.mm
@@ -7,7 +7,7 @@
 //
 
 #import "TNSDataAdapter.h"
-#include "ObjCTypes.h"
+#include "Interop.h"
 #include "JSErrors.h"
 #include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/StrongInlines.h>
@@ -24,7 +24,7 @@ using namespace JSC;
     if (self) {
         self->_object.set(execState->vm(), jsObject);
         self->_execState = execState;
-        [TNSValueWrapper attachValue:jsObject toHost:self];
+        interop(execState)->objectMap().set(self, jsObject);
     }
 
     return self;
@@ -54,6 +54,15 @@ using namespace JSC;
     NSUInteger length = self->_object->get(self->_execState, self->_execState->propertyNames().byteLength).toUInt32(self->_execState);
     reportErrorIfAny(self->_execState);
     return length;
+}
+
+- (void)dealloc {
+    {
+        JSLockHolder lock(self->_execState);
+        interop(self->_execState)->objectMap().remove(self);
+    }
+
+    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
This nets us a few small performance wins because we no longer use the thread-safe Objective-C association API to store JavaScript wrappers in native objects.