### PR TITLE
Allow vanilla TypeScript classes to extend null

### DIFF
--- a/src/NativeScript/__extends.js
+++ b/src/NativeScript/__extends.js
@@ -1,14 +1,8 @@
-(function __extends(Derived, Base) {
-    for (var key in Base) {
-        if (Base.hasOwnProperty(key)) {
-            Derived[key] = Base[key];
-        }
-    }
-
-    function __() {
-        this.constructor = Derived;
-    }
-
-    __.prototype = Base.prototype;
-    Derived.prototype = new __();
+// __extends is a TypeScript helper function generated when targeting older ES versions.
+// We inject our own function that branches logic whether base class is native or not.
+// This one gets called for classes that don't inherit from native ones.
+(function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 });


### PR DESCRIPTION
Get the latest `__extends` function from TypeScript compiler. Allows to classes to extend from `null`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends#Extending_null.