### PR TITLE
Wrap bridged NSError objects in JavaScript Errors

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -60,6 +60,7 @@ set(HEADER_FILES
     ObjC/Inheritance/ObjCClassBuilder.h
     ObjC/Inheritance/ObjCExtend.h
     ObjC/Inheritance/ObjCTypeScriptExtend.h
+    ObjC/NSErrorWrapperConstructor.h
     ObjC/ObjCMethodCall.h
     ObjC/ObjCMethodCallback.h
     ObjC/ObjCPrimitiveTypes.h
@@ -143,6 +144,7 @@ set(SOURCE_FILES
     ObjC/Inheritance/ObjCClassBuilder.mm
     ObjC/Inheritance/ObjCExtend.mm
     ObjC/Inheritance/ObjCTypeScriptExtend.mm
+    ObjC/NSErrorWrapperConstructor.mm
     ObjC/ObjCMethodCall.mm
     ObjC/ObjCMethodCallback.mm
     ObjC/ObjCPrimitiveTypes.mm

--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -15,6 +15,7 @@
 namespace NativeScript {
 class PointerInstance;
 class ReferenceInstance;
+class NSErrorWrapperConstructor;
 
 void* tryHandleofValue(const JSC::JSValue&, bool*);
 
@@ -53,6 +54,10 @@ public:
     JSC::WeakGCMap<id, JSC::JSObject>& objectMap() {
         return this->_objectMap;
     }
+    
+#ifdef __OBJC__
+    JSC::ErrorInstance* wrapError(JSC::ExecState*, NSError *) const;
+#endif
 
 private:
     Interop(JSC::VM& vm, JSC::Structure* structure)
@@ -70,6 +75,8 @@ private:
     JSC::WriteBarrier<JSC::Structure> _referenceInstanceStructure;
 
     JSC::WriteBarrier<JSC::Structure> _functionReferenceInstanceStructure;
+    
+    JSC::WriteBarrier<NSErrorWrapperConstructor> _nsErrorWrapperConstructor;
 
     JSC::WeakGCMap<const void*, PointerInstance> _pointerToInstance;
 

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -38,6 +38,7 @@
 #include "FunctionReferenceTypeInstance.h"
 #include "FunctionReferenceTypeConstructor.h"
 #include "ObjCTypes.h"
+#include "NSErrorWrapperConstructor.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -246,7 +247,10 @@ void Interop::finishCreation(VM& vm, GlobalObject* globalObject) {
     FunctionReferenceConstructor* functionReferenceConstructor = FunctionReferenceConstructor::create(vm, FunctionReferenceConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), functionReferencePrototype);
     this->putDirect(vm, Identifier::fromString(&vm, functionReferenceConstructor->name(globalObject->globalExec())), functionReferenceConstructor, ReadOnly | DontDelete);
     functionReferencePrototype->putDirect(vm, vm.propertyNames->constructor, functionReferenceConstructor, DontEnum);
-
+    
+    this->_nsErrorWrapperConstructor.set(vm, this, NSErrorWrapperConstructor::create(vm, NSErrorWrapperConstructor::createStructure(vm, globalObject, globalObject->functionPrototype())));
+    this->putDirect(vm, Identifier::fromString(&vm, "NSErrorWrapper"), this->_nsErrorWrapperConstructor.get());
+    
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(&vm, WTF::ASCIILiteral("alloc")), 0, &interopFuncAlloc, NoIntrinsic, ReadOnly | DontDelete);
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(&vm, WTF::ASCIILiteral("free")), 0, &interopFuncFree, NoIntrinsic, ReadOnly | DontDelete);
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(&vm, WTF::ASCIILiteral("adopt")), 0, &interopFuncAdopt, NoIntrinsic, ReadOnly | DontDelete);
@@ -332,5 +336,10 @@ void Interop::visitChildren(JSCell* cell, SlotVisitor& visitor) {
     visitor.append(&interop->_pointerInstanceStructure);
     visitor.append(&interop->_referenceInstanceStructure);
     visitor.append(&interop->_functionReferenceInstanceStructure);
+    visitor.append(&interop->_nsErrorWrapperConstructor);
 }
+    
+    ErrorInstance* Interop::wrapError(ExecState* execState, NSError *error) const {
+        return this->_nsErrorWrapperConstructor->createError(execState, error);
+    }
 }

--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
@@ -1,0 +1,53 @@
+//
+//  NSErrorWrapperConstructor.h
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 30.12.15 г..
+//  Copyright (c) 2015 Telerik. All rights reserved.
+//
+
+#pragma once
+
+@class NSError;
+
+namespace NativeScript {
+    class NSErrorWrapperConstructor : public JSC::InternalFunction {
+    public:
+        typedef JSC::InternalFunction Base;
+        
+        static NSErrorWrapperConstructor* create(JSC::VM& vm, JSC::Structure* structure) {
+            NSErrorWrapperConstructor* cell = new (NotNull, JSC::allocateCell<NSErrorWrapperConstructor>(vm.heap)) NSErrorWrapperConstructor(vm, structure);
+            cell->finishCreation(vm, structure->globalObject());
+            return cell;
+        }
+        
+        DECLARE_INFO;
+        
+        static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype) {
+            return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+        }
+        
+        JSC::Structure* errorStructure() const {
+            return this->_errorStructure.get();
+        }
+        
+        JSC::ErrorInstance* createError(JSC::ExecState*, NSError *) const;
+        
+    private:
+        NSErrorWrapperConstructor(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure) {
+        }
+        
+        static void destroy(JSC::JSCell* cell);
+        
+        void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
+        
+        static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
+        
+        static JSC::ConstructType getConstructData(JSC::JSCell*, JSC::ConstructData&);
+        
+        static JSC::CallType getCallData(JSC::JSCell*, JSC::CallData&);
+        
+        JSC::WriteBarrier<JSC::Structure> _errorStructure;
+    };
+}

--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
@@ -1,0 +1,68 @@
+//
+//  NSErrorWrapperConstructor.mm
+//  NativeScript
+//
+//  Created by Yavor Georgiev on 30.12.15 г..
+//  Copyright (c) 2015 Telerik. All rights reserved.
+//
+
+#include "NSErrorWrapperConstructor.h"
+#include "ObjCTypes.h"
+#include <JavaScriptCore/ErrorPrototype.h>
+
+namespace NativeScript {
+    using namespace JSC;
+    
+    const ClassInfo NSErrorWrapperConstructor::s_info = { "NSErrorWrapper", &Base::s_info, 0, CREATE_METHOD_TABLE(NSErrorWrapperConstructor) };
+    
+    void NSErrorWrapperConstructor::destroy(JSCell* cell) {
+        jsCast<NSErrorWrapperConstructor*>(cell)->~NSErrorWrapperConstructor();
+    }
+    
+    void NSErrorWrapperConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject) {
+        Base::finishCreation(vm, WTF::ASCIILiteral("NSError"));
+        
+        ErrorPrototype* prototype = ErrorPrototype::create(vm, globalObject, ErrorPrototype::createStructure(vm, globalObject, globalObject->errorPrototype()));
+        prototype->putDirect(vm, vm.propertyNames->constructor, this);
+        this->putDirect(vm, vm.propertyNames->prototype, prototype);
+        prototype->putDirect(vm, vm.propertyNames->name, jsString(&vm, WTF::ASCIILiteral("NSErrorWrapper")));
+        
+        this->_errorStructure.set(vm, this, ErrorInstance::createStructure(vm, globalObject, prototype));
+    }
+    
+    void NSErrorWrapperConstructor::visitChildren(JSCell* cell, SlotVisitor& slotVisitor) {
+        Base::visitChildren(cell, slotVisitor);
+        
+        NSErrorWrapperConstructor* self = jsCast<NSErrorWrapperConstructor*>(cell);
+        slotVisitor.append(&self->_errorStructure);
+    }
+    
+    ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSError *error) const {
+        ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, error.localizedDescription));
+        wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "error"), NativeScript::toValue(execState, error));
+        
+        return wrappedError;
+    }
+    
+    static EncodedJSValue JSC_HOST_CALL constructErrorWrapper(ExecState* execState) {
+        NSErrorWrapperConstructor* self = jsCast<NSErrorWrapperConstructor*>(execState->callee());
+        NSError *error = NativeScript::toObject(execState, execState->argument(0));
+        
+        if (!error || ![error isKindOfClass:[NSError class]]) {
+            return throwVMTypeError(execState);
+        }
+        
+        return JSValue::encode(self->createError(execState, error));
+        
+    }
+    
+    ConstructType NSErrorWrapperConstructor::getConstructData(JSCell*, ConstructData& constructData) {
+        constructData.native.function = &constructErrorWrapper;
+        return ConstructTypeHost;
+    }
+    
+    CallType NSErrorWrapperConstructor::getCallData(JSCell*, CallData& callData) {
+        callData.native.function = &constructErrorWrapper;
+        return CallTypeHost;
+    }
+}

--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -17,6 +17,7 @@
 #include "Metadata.h"
 #include "AllocatedPlaceholder.h"
 #include "ReleasePool.h"
+#include "Interop.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -131,7 +132,7 @@ void ObjCMethodCall::postInvocation(FFICall* callee, ExecState* execState, FFICa
 
     if (call->_hasErrorOutParameter && call->_parameterTypesCells.size() - 1 == execState->argumentCount()) {
         if (NSError* error = *invocation.getArgument<NSError**>(call->_argsCount - 1)) {
-            execState->vm().throwException(execState, toValue(execState, error));
+            execState->vm().throwException(execState, interop(execState)->wrapError(execState, error));
         }
     }
 }

--- a/src/ts/Interop.d.ts
+++ b/src/ts/Interop.d.ts
@@ -206,4 +206,14 @@ declare module interop {
        */
       takeUnretainedValue(): T;
     }
+    
+    interface NSErrorWrapper extends Error {
+        error: NSError;
+    }
+    
+    declare var NSErrorWrapper: {
+        new (error: NSError): NSErrorWrapper;
+        (error: NSError): NSErrorWrapper;
+        prototype: NSErrorWrapper;
+    }
 }

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -239,7 +239,8 @@ describe(module.id, function () {
             TNSApi.new().methodError(1);
         } catch (e) {
             isThrown = true;
-            expect(e instanceof NSError).toBe(true);
+            expect(e instanceof interop.NSErrorWrapper).toBe(true);
+            expect(e.stack).toEqual(jasmine.any(String));
         } finally {
             expect(isThrown).toBe(true);
         }
@@ -434,7 +435,7 @@ describe(module.id, function () {
             var api = TNSApi.new();
             api.methodError.async(api, [1])
             .catch(error => {
-                expect(error).toEqual(jasmine.any(NSError));
+                expect(error).toEqual(jasmine.any(interop.NSErrorWrapper));
                 done();
             });
         });


### PR DESCRIPTION
Introduce the new `NSErrorWrapper` that will wrap an `NSError` thrown in JavaScript so that it can retain the `message` and `stack` properties expected in all JavaScript errors.