### PR TITLE
Swift-style initializers

### DIFF
--- a/examples/Gameraww/app/MasterViewController.js
+++ b/examples/Gameraww/app/MasterViewController.js
@@ -21,10 +21,13 @@ var JSMasterViewController = UITableViewController.extend(
         this.loadData();
       },
       "aboutPressed:" : function(sender) {
-        var alertWindow = new UIAlertView();
-        alertWindow.title = "About";
-        alertWindow.message = "NativeScript Team";
-        alertWindow.addButtonWithTitle("OK");
+        var alertWindow = new UIAlertView({
+          title : "About",
+          message : "NativeScript Team",
+          delegate : null,
+          cancelButtonTitle : "OK",
+          otherButtonTitles : null
+        });
         alertWindow.show();
       },
       numberOfSectionsInTableView : function(tableView) { return 1; },
@@ -67,10 +70,8 @@ var JSMasterViewController = UITableViewController.extend(
         fetch("http://www.reddit.com/r/aww.json?limit=500")
             .then(data => {
               var jsonString =
-                  NSString.alloc()
-                      .initWithDataEncoding(data, NSUTF8StringEncoding)
-                      .toString();
-              var json = JSON.parse(jsonString);
+                  new NSString({data : data, encoding : NSUTF8StringEncoding});
+              var json = JSON.parse(jsonString.toString());
               this.items = json.data.children.map(child => child.data);
 
               this.tableView.reloadData();

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -77,4 +77,48 @@ describe("Constructing Objective-C classes with new operator", function () {
         expect(arr.objectAtIndex(1)).toBe(2);
         expect(arr.objectAtIndex(2)).toBe(3);
     });
+
+    describe("Swift-style initializers", () => {
+      it("should work", () => {
+        let obj = new NSObject();
+        expect(obj).toEqual(jasmine.any(NSObject));
+        expect(obj.retainCount()).toBe(1);
+      });
+
+      it("should support parameters", () => {
+        let arr = new NSArray({array : [ 1, 2, 3 ]});
+        expect(arr).toEqual(jasmine.any(NSArray));
+        expect(arr.count).toEqual(3);
+      });
+
+      it("should support even more complex parameters", () => {
+        let alertView = new UIAlertView({
+          title : "About",
+          message : "NativeScript Team",
+          delegate : null,
+          cancelButtonTitle : "OK",
+          otherButtonTitles : null
+        });
+        expect(alertView.title).toEqual("About");
+        expect(alertView.message).toEqual("NativeScript Team");
+        expect(alertView.buttonTitleAtIndex(0)).toEqual("OK");
+      });
+
+      it("should support void initializers", () => {
+        let transform = new MDLTransform({identity : void 0});
+        expect(transform).toEqual(jasmine.any(MDLTransform));
+      });
+
+      it("should resolve NSError** initializers", () => {
+        expect(() => new NSString({
+                 contentsOfFile : "/does/not/exist",
+                 encoding : NSUTF8StringEncoding
+        })).toThrowError(/The file “exist” couldn’t be opened because there is no such file./);
+      });
+
+      it("should resolve initializers that only begin with 'init'", () => {
+        let url = new NSURL({fileURLWithPath : "/foo"});
+        expect(url).toEqual(jasmine.any(NSURL));
+      });
+    })
 });


### PR DESCRIPTION
This patch augments the JavaScript constructability of Objective-C classes. Constructor functions for Objective-C classes now support initialization via the Swift-style named parameter syntax which mimics Swift's initializer syntax.

Examples:
`NSURL.alloc().initWithString(aString)` becomes `new NSURL({ string: aString })`
`NSURL.alloc().initFileURLWithPath(aString)` becomes `new NSURL({ fileURLWithPath: aString })`
`NSString.alloc().initWithContentsOfFileEncodingError(aString, anEncoding)` becomes `new NSString({ contentsOfFile: aString, encoding: anEncoding })`