### PR TITLE
Expose module specific global tables from metadata.

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -248,6 +248,8 @@ struct ModuleTable {
     int sizeInBytes() const {
         return modules.sizeInBytes();
     }
+
+    const ModuleMeta* getModule(const char* moduleName) const;
 };
 
 struct MetaFile {
@@ -407,6 +409,7 @@ public:
     UInt8 flags;
     String name;
     PtrTo<ArrayOfPtrTo<LibraryMeta>> libraries;
+    PtrTo<GlobalTable> globalTable;
 
     const char* getName() const {
         return name.valuePtr();
@@ -449,7 +452,7 @@ struct Meta {
 
 private:
     MetaNames _names;
-    PtrTo<ModuleMeta> _topLevelModule;
+    String _topLevelModule;
     UInt8 _flags;
     UInt8 _introduced;
 
@@ -459,7 +462,8 @@ public:
     }
 
     const ModuleMeta* topLevelModule() const {
-        return this->_topLevelModule.valuePtr();
+        const char* moduleName = this->_topLevelModule.valuePtr();
+        return MetaFile::instance()->topLevelModulesTable()->getModule(moduleName);
     }
 
     bool hasName() const {

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -68,6 +68,16 @@ const Meta* GlobalTable::findMeta(const char* identifierString, size_t length, u
     return nullptr;
 }
 
+const ModuleMeta* ModuleTable::getModule(const char* moduleName) const {
+    for (ArrayOfPtrTo<ModuleMeta>::iterator it = modules.begin(); it != modules.end(); it++) {
+        const ModuleMeta* module = (*it).valuePtr();
+        if (strcmp(module->name.valuePtr(), moduleName) == 0) {
+            return module;
+        }
+    }
+    return nullptr;
+}
+
 // Meta
 bool Meta::isAvailable() const {
     UInt8 introducedIn = this->introducedIn();


### PR DESCRIPTION
First merge https://github.com/NativeScript/ios-metadata-generator/pull/42
This is needed in order to project clang modules as ES6 modules.