### PR TITLE
Jasssonpet/nsexception

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -59,7 +59,7 @@ set(HEADER_FILES
     ObjC/Inheritance/ObjCClassBuilder.h
     ObjC/Inheritance/ObjCExtend.h
     ObjC/Inheritance/ObjCTypeScriptExtend.h
-    ObjC/NSErrorWrapperConstructor.h
+    ObjC/NativeErrorWrapperConstructor.h
     ObjC/ObjCMethodCall.h
     ObjC/ObjCMethodCallback.h
     ObjC/ObjCPrimitiveTypes.h
@@ -94,7 +94,7 @@ set(SOURCE_FILES
     Calling/FFIFunctionCall.mm
     Calling/FFIFunctionCallback.cpp
     GlobalObject.mm
-	GlobalObject.moduleLoader.mm
+    GlobalObject.moduleLoader.mm
     inspector/CachedResource.mm
     inspector/DomainBackendDispatcher.cpp
     inspector/DomainInspectorAgent.cpp
@@ -143,7 +143,7 @@ set(SOURCE_FILES
     ObjC/Inheritance/ObjCClassBuilder.mm
     ObjC/Inheritance/ObjCExtend.mm
     ObjC/Inheritance/ObjCTypeScriptExtend.mm
-    ObjC/NSErrorWrapperConstructor.mm
+    ObjC/NativeErrorWrapperConstructor.mm
     ObjC/ObjCMethodCall.mm
     ObjC/ObjCMethodCallback.mm
     ObjC/ObjCPrimitiveTypes.mm

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -89,7 +89,7 @@ set(HEADER_FILES
 )
 
 set(SOURCE_FILES
-    Calling/FFICall.cpp
+    Calling/FFICall.mm
     Calling/FFICallPrototype.cpp
     Calling/FFIFunctionCall.mm
     Calling/FFIFunctionCallback.cpp

--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -61,6 +61,8 @@ public:
 
 #ifdef __OBJC__
     JSC::ErrorInstance* wrapError(JSC::ExecState*, NSError*) const;
+
+    JSC::ErrorInstance* wrapException(JSC::ExecState*, NSException*) const;
 #endif
 
 private:

--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -15,7 +15,7 @@
 namespace NativeScript {
 class PointerInstance;
 class ReferenceInstance;
-class NSErrorWrapperConstructor;
+class NativeErrorWrapperConstructor;
 
 void* tryHandleofValue(const JSC::JSValue&, bool*);
 
@@ -82,7 +82,7 @@ private:
 
     JSC::WriteBarrier<JSC::Structure> _functionReferenceInstanceStructure;
 
-    JSC::WriteBarrier<NSErrorWrapperConstructor> _nsErrorWrapperConstructor;
+    JSC::WriteBarrier<NativeErrorWrapperConstructor> _nsErrorWrapperConstructor;
 
     JSC::WeakGCMap<const void*, PointerInstance> _pointerToInstance;
 

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -335,8 +335,13 @@ void Interop::visitChildren(JSCell* cell, SlotVisitor& visitor) {
     visitor.append(&interop->_nsErrorWrapperConstructor);
 }
 
+#ifdef __OBJC__
 ErrorInstance* Interop::wrapError(ExecState* execState, NSError* error) const {
     return this->_nsErrorWrapperConstructor->createError(execState, error);
+}
+
+ErrorInstance* Interop::wrapException(ExecState* execState, NSException* exception) const {
+    return this->_nsErrorWrapperConstructor->createError(execState, exception);
 }
 
 JSArrayBuffer* Interop::bufferFromData(ExecState* execState, NSData* data) const {
@@ -346,4 +351,5 @@ JSArrayBuffer* Interop::bufferFromData(ExecState* execState, NSData* data) const
     arrayBuffer->putDirect(execState->vm(), execState->propertyNames().homeObjectPrivateName, NativeScript::toValue(execState, data));
     return arrayBuffer;
 }
+#endif
 }

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -38,7 +38,7 @@
 #include "FunctionReferenceTypeInstance.h"
 #include "FunctionReferenceTypeConstructor.h"
 #include "ObjCTypes.h"
-#include "NSErrorWrapperConstructor.h"
+#include "NativeErrorWrapperConstructor.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -244,8 +244,8 @@ void Interop::finishCreation(VM& vm, GlobalObject* globalObject) {
     this->putDirect(vm, Identifier::fromString(&vm, functionReferenceConstructor->name(globalObject->globalExec())), functionReferenceConstructor, ReadOnly | DontDelete);
     functionReferencePrototype->putDirect(vm, vm.propertyNames->constructor, functionReferenceConstructor, DontEnum);
 
-    this->_nsErrorWrapperConstructor.set(vm, this, NSErrorWrapperConstructor::create(vm, NSErrorWrapperConstructor::createStructure(vm, globalObject, globalObject->functionPrototype())));
-    this->putDirect(vm, Identifier::fromString(&vm, "NSErrorWrapper"), this->_nsErrorWrapperConstructor.get());
+    this->_nsErrorWrapperConstructor.set(vm, this, NativeErrorWrapperConstructor::create(vm, NativeErrorWrapperConstructor::createStructure(vm, globalObject, globalObject->functionPrototype())));
+    this->putDirect(vm, Identifier::fromString(&vm, "NativeErrorWrapper"), this->_nsErrorWrapperConstructor.get());
 
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(&vm, WTF::ASCIILiteral("alloc")), 0, &interopFuncAlloc, NoIntrinsic, ReadOnly | DontDelete);
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(&vm, WTF::ASCIILiteral("free")), 0, &interopFuncFree, NoIntrinsic, ReadOnly | DontDelete);

--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
@@ -33,6 +33,7 @@ public:
 
     JSC::ErrorInstance* createError(JSC::ExecState*, NSError*) const;
 
+    JSC::ErrorInstance* createError(JSC::ExecState*, NSException*) const;
 private:
     NSErrorWrapperConstructor(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {

--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
@@ -13,19 +13,19 @@
 namespace NativeScript {
 using namespace JSC;
 
-const ClassInfo NSErrorWrapperConstructor::s_info = { "NSErrorWrapper", &Base::s_info, 0, CREATE_METHOD_TABLE(NSErrorWrapperConstructor) };
+const ClassInfo NSErrorWrapperConstructor::s_info = { "NativeException", &Base::s_info, 0, CREATE_METHOD_TABLE(NSErrorWrapperConstructor) };
 
 void NSErrorWrapperConstructor::destroy(JSCell* cell) {
     jsCast<NSErrorWrapperConstructor*>(cell)->~NSErrorWrapperConstructor();
 }
 
 void NSErrorWrapperConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject) {
-    Base::finishCreation(vm, WTF::ASCIILiteral("NSError"));
+    Base::finishCreation(vm, WTF::ASCIILiteral("NativeException"));
 
     ErrorPrototype* prototype = ErrorPrototype::create(vm, globalObject, ErrorPrototype::createStructure(vm, globalObject, globalObject->errorPrototype()));
     prototype->putDirect(vm, vm.propertyNames->constructor, this);
     this->putDirect(vm, vm.propertyNames->prototype, prototype);
-    prototype->putDirect(vm, vm.propertyNames->name, jsString(&vm, WTF::ASCIILiteral("NSErrorWrapper")));
+    prototype->putDirect(vm, vm.propertyNames->name, jsString(&vm, WTF::ASCIILiteral("NativeException")));
 
     this->_errorStructure.set(vm, this, ErrorInstance::createStructure(vm, globalObject, prototype));
 }
@@ -39,8 +39,13 @@ void NSErrorWrapperConstructor::visitChildren(JSCell* cell, SlotVisitor& slotVis
 
 ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSError* error) const {
     ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, error.localizedDescription));
-    wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "error"), NativeScript::toValue(execState, error));
+    wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "nativeException"), NativeScript::toValue(execState, error));
+    return wrappedError;
+}
 
+ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSException* exception) const {
+    ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, exception.reason));
+    wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "nativeException"), NativeScript::toValue(execState, exception));
     return wrappedError;
 }
 

--- a/src/NativeScript/ObjC/NativeErrorWrapperConstructor.h
+++ b/src/NativeScript/ObjC/NativeErrorWrapperConstructor.h
@@ -1,5 +1,5 @@
 //
-//  NSErrorWrapperConstructor.h
+//  NativeErrorWrapperConstructor.h
 //  NativeScript
 //
 //  Created by Yavor Georgiev on 30.12.15 г..
@@ -11,12 +11,12 @@
 @class NSError;
 
 namespace NativeScript {
-class NSErrorWrapperConstructor : public JSC::InternalFunction {
+class NativeErrorWrapperConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static NSErrorWrapperConstructor* create(JSC::VM& vm, JSC::Structure* structure) {
-        NSErrorWrapperConstructor* cell = new (NotNull, JSC::allocateCell<NSErrorWrapperConstructor>(vm.heap)) NSErrorWrapperConstructor(vm, structure);
+    static NativeErrorWrapperConstructor* create(JSC::VM& vm, JSC::Structure* structure) {
+        NativeErrorWrapperConstructor* cell = new (NotNull, JSC::allocateCell<NativeErrorWrapperConstructor>(vm.heap)) NativeErrorWrapperConstructor(vm, structure);
         cell->finishCreation(vm, structure->globalObject());
         return cell;
     }
@@ -34,8 +34,9 @@ public:
     JSC::ErrorInstance* createError(JSC::ExecState*, NSError*) const;
 
     JSC::ErrorInstance* createError(JSC::ExecState*, NSException*) const;
+
 private:
-    NSErrorWrapperConstructor(JSC::VM& vm, JSC::Structure* structure)
+    NativeErrorWrapperConstructor(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {
     }
 

--- a/src/NativeScript/ObjC/NativeErrorWrapperConstructor.mm
+++ b/src/NativeScript/ObjC/NativeErrorWrapperConstructor.mm
@@ -1,25 +1,25 @@
 //
-//  NSErrorWrapperConstructor.mm
+//  NativeErrorWrapperConstructor.mm
 //  NativeScript
 //
 //  Created by Yavor Georgiev on 30.12.15 г..
 //  Copyright (c) 2015 Telerik. All rights reserved.
 //
 
-#include "NSErrorWrapperConstructor.h"
+#include "NativeErrorWrapperConstructor.h"
 #include "ObjCTypes.h"
 #include <JavaScriptCore/ErrorPrototype.h>
 
 namespace NativeScript {
 using namespace JSC;
 
-const ClassInfo NSErrorWrapperConstructor::s_info = { "NativeException", &Base::s_info, 0, CREATE_METHOD_TABLE(NSErrorWrapperConstructor) };
+const ClassInfo NativeErrorWrapperConstructor::s_info = { "NativeException", &Base::s_info, 0, CREATE_METHOD_TABLE(NativeErrorWrapperConstructor) };
 
-void NSErrorWrapperConstructor::destroy(JSCell* cell) {
-    jsCast<NSErrorWrapperConstructor*>(cell)->~NSErrorWrapperConstructor();
+void NativeErrorWrapperConstructor::destroy(JSCell* cell) {
+    jsCast<NativeErrorWrapperConstructor*>(cell)->~NativeErrorWrapperConstructor();
 }
 
-void NSErrorWrapperConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject) {
+void NativeErrorWrapperConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject) {
     Base::finishCreation(vm, WTF::ASCIILiteral("NativeException"));
 
     ErrorPrototype* prototype = ErrorPrototype::create(vm, globalObject, ErrorPrototype::createStructure(vm, globalObject, globalObject->errorPrototype()));
@@ -30,27 +30,27 @@ void NSErrorWrapperConstructor::finishCreation(VM& vm, JSGlobalObject* globalObj
     this->_errorStructure.set(vm, this, ErrorInstance::createStructure(vm, globalObject, prototype));
 }
 
-void NSErrorWrapperConstructor::visitChildren(JSCell* cell, SlotVisitor& slotVisitor) {
+void NativeErrorWrapperConstructor::visitChildren(JSCell* cell, SlotVisitor& slotVisitor) {
     Base::visitChildren(cell, slotVisitor);
 
-    NSErrorWrapperConstructor* self = jsCast<NSErrorWrapperConstructor*>(cell);
+    NativeErrorWrapperConstructor* self = jsCast<NativeErrorWrapperConstructor*>(cell);
     slotVisitor.append(&self->_errorStructure);
 }
 
-ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSError* error) const {
+ErrorInstance* NativeErrorWrapperConstructor::createError(ExecState* execState, NSError* error) const {
     ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, error.localizedDescription));
     wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "nativeException"), NativeScript::toValue(execState, error));
     return wrappedError;
 }
 
-ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSException* exception) const {
+ErrorInstance* NativeErrorWrapperConstructor::createError(ExecState* execState, NSException* exception) const {
     ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, exception.reason));
     wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "nativeException"), NativeScript::toValue(execState, exception));
     return wrappedError;
 }
 
 static EncodedJSValue JSC_HOST_CALL constructErrorWrapper(ExecState* execState) {
-    NSErrorWrapperConstructor* self = jsCast<NSErrorWrapperConstructor*>(execState->callee());
+    NativeErrorWrapperConstructor* self = jsCast<NativeErrorWrapperConstructor*>(execState->callee());
     NSError* error = NativeScript::toObject(execState, execState->argument(0));
 
     if (!error || ![error isKindOfClass:[NSError class]]) {
@@ -60,12 +60,12 @@ static EncodedJSValue JSC_HOST_CALL constructErrorWrapper(ExecState* execState) 
     return JSValue::encode(self->createError(execState, error));
 }
 
-ConstructType NSErrorWrapperConstructor::getConstructData(JSCell*, ConstructData& constructData) {
+ConstructType NativeErrorWrapperConstructor::getConstructData(JSCell*, ConstructData& constructData) {
     constructData.native.function = &constructErrorWrapper;
     return ConstructTypeHost;
 }
 
-CallType NSErrorWrapperConstructor::getCallData(JSCell*, CallData& callData) {
+CallType NativeErrorWrapperConstructor::getCallData(JSCell*, CallData& callData) {
     callData.native.function = &constructErrorWrapper;
     return CallTypeHost;
 }

--- a/tests/TestFixtures/exported-symbols.txt
+++ b/tests/TestFixtures/exported-symbols.txt
@@ -5,6 +5,7 @@ functionReturningFunctionPtrAsVoidPtr
 functionReturnsCFRetained
 functionReturnsNSRetained
 functionReturnsUnmanaged
+functionThrowsException
 functionWhichReturnsSimpleFunctionPointer
 functionWith_BoolPtr
 functionWith_VoidPtr

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -239,7 +239,7 @@ describe(module.id, function () {
             TNSApi.new().methodError(1);
         } catch (e) {
             isThrown = true;
-            expect(e instanceof interop.NSErrorWrapper).toBe(true);
+            expect(e instanceof interop.NativeErrorWrapper).toBe(true);
             expect(e.stack).toEqual(jasmine.any(String));
         } finally {
             expect(isThrown).toBe(true);
@@ -435,7 +435,7 @@ describe(module.id, function () {
             var api = TNSApi.new();
             api.methodError.async(api, [1])
             .catch(error => {
-                expect(error).toEqual(jasmine.any(interop.NSErrorWrapper));
+                expect(error).toEqual(jasmine.any(interop.NativeErrorWrapper));
                 done();
             });
         });


### PR DESCRIPTION
Related to: https://github.com/NativeScript/ios-runtime/issues/434.

The following code:
```javascript
global.__onUncaughtError = function(error) {
    console.log(error.stack);
    console.log(error.nativeException);
};

functionThrowsException();
```

shows this nice log:
```
CONSOLE LOG app/index.js:2:16: functionThrowsException@[native code]
global code@app/index.js:6:24
CONSOLE LOG app/index.js:3:16: Exception message
***** Fatal JavaScript exception - application has been terminated. *****
Native stack trace:
1   0xd12e2 NativeScript::reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*)
2   0x830a0 NativeScript::FFICall::call(JSC::ExecState*)
3   0x8db9e1 JSC::LLInt::handleHostCall(JSC::ExecState*, JSC::Instruction*, JSC::JSValue, JSC::CodeSpecializationKind)
4   0x8dd06d JSC::LLInt::setUpCall(JSC::ExecState*, JSC::Instruction*, JSC::CodeSpecializationKind, JSC::JSValue, JSC::LLIntCallLinkInfo*)
5   0x8dcfb8 JSC::LLInt::genericCall(JSC::ExecState*, JSC::Instruction*, JSC::CodeSpecializationKind)
6   0x8d900f llint_slow_path_call
7   0x8e41f7 llint_entry
8   0x8df08c vmEntryToJavaScript
9   0x853f6d JSC::JITCode::execute(JSC::VM*, JSC::ProtoCallFrame*)
10  0x80d611 JSC::Interpreter::execute(JSC::ProgramExecutable*, JSC::ExecState*, JSC::JSObject*)
11  0xa8c831 JSC::evaluate(JSC::ExecState*, JSC::SourceCode const&, JSC::JSValue, WTF::NakedPtr<JSC::Exception>&)
12  0x26e00f JSEvaluateScript
13  0x82304 main
14  0x5771a21 start
15  0x1
JavaScript stack trace:
1   functionThrowsException@app/index.js:6:24
2   global code@app/index.js:6:24
JavaScript error:
app/index.js:6:24: JS ERROR NativeException: Exception message
```