### PR TITLE
Provide a way to execute inspector logic that should run before the first line of the application

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_FILES
     inspector/InspectorPageAgent.h
     inspector/InspectorTimelineAgent.h
     inspector/MimeTypeHelper.h
+    inspector/SuppressAllPauses.h
     Interop.h
     JSErrors.h
     JSWarnings.h
@@ -103,6 +104,7 @@ set(SOURCE_FILES
     inspector/GlobalObjectInspectorController.cpp
     inspector/InspectorPageAgent.mm
     inspector/InspectorTimelineAgent.cpp
+    inspector/SuppressAllPauses.cpp
     Interop.mm
     JSErrors.mm
     JSWarnings.cpp

--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -146,6 +146,10 @@ public:
 
     void drainMicrotasks();
 
+    WTF::Deque<WTF::RefPtr<JSC::Microtask>>& microtasks() {
+        return this->_microtasksQueue;
+    }
+
     WTF::Deque<std::map<std::string, std::unique_ptr<ReleasePoolBase>>>& releasePools() {
         return this->_releasePools;
     }

--- a/src/NativeScript/inspector/DomainBackendDispatcher.cpp
+++ b/src/NativeScript/inspector/DomainBackendDispatcher.cpp
@@ -7,6 +7,7 @@
 #include <JavaScriptCore/runtime/Exception.h>
 #include <JavaScriptCore/runtime/JSONObject.h>
 #include "GlobalObjectInspectorController.h"
+#include "SuppressAllPauses.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -57,9 +58,13 @@ void DomainBackendDispatcher::dispatch(long callId, const String& method, Ref<In
 
     CallData dispatchCallData;
     CallType dispatchCallType = getCallData(functionValue, dispatchCallData);
-
     WTF::NakedPtr<Exception> exception;
-    JSValue dispatchResult = call(globalExec, functionValue, dispatchCallType, dispatchCallData, m_domainDispatcher.get(), dispatchArguments, exception);
+    JSValue dispatchResult;
+
+    {
+        SuppressAllPauses suppressAllPauses(m_globalObject);
+        dispatchResult = call(globalExec, functionValue, dispatchCallType, dispatchCallData, m_domainDispatcher.get(), dispatchArguments, exception);
+    }
 
     RefPtr<Inspector::InspectorObject> messageObject = Inspector::InspectorObject::create();
     Inspector::ErrorString error;

--- a/src/NativeScript/inspector/SuppressAllPauses.cpp
+++ b/src/NativeScript/inspector/SuppressAllPauses.cpp
@@ -1,0 +1,32 @@
+#include "SuppressAllPauses.h"
+#include <JavaScriptCore/Debugger.h>
+
+namespace NativeScript {
+
+static bool suppressAllPauses() {
+    static std::once_flag initializeEnvVariableOnceFlag;
+    static bool dontSupressAllPauses;
+
+    std::call_once(initializeEnvVariableOnceFlag, []() {
+        dontSupressAllPauses = getenv("ТNS_dontSuppressAllPauses");
+    });
+
+    return !dontSupressAllPauses;
+}
+
+SuppressAllPauses::SuppressAllPauses(JSC::JSGlobalObject& globalObject)
+    : m_globalObject(globalObject) {
+    if (suppressAllPauses()) {
+        if (JSC::Debugger* debugger = this->m_globalObject.debugger())
+            debugger->setSuppressAllPauses(true);
+    }
+}
+
+SuppressAllPauses::~SuppressAllPauses() {
+    if (suppressAllPauses()) {
+        if (JSC::Debugger* debugger = this->m_globalObject.debugger()) {
+            debugger->setSuppressAllPauses(false);
+        }
+    }
+}
+};

--- a/src/NativeScript/inspector/SuppressAllPauses.h
+++ b/src/NativeScript/inspector/SuppressAllPauses.h
@@ -1,0 +1,15 @@
+#ifndef SuppressAllPauses_h
+#define SuppressAllPauses_h
+
+namespace NativeScript {
+class SuppressAllPauses {
+public:
+    SuppressAllPauses(JSC::JSGlobalObject& globalObject);
+
+    ~SuppressAllPauses();
+
+private:
+    JSC::JSGlobalObject& m_globalObject;
+};
+}
+#endif /* SuppressAllPauses_h */


### PR DESCRIPTION
In order to have source maps we needed a way to execute some java script that would return the source map content before the first application line. The end user should not see this so we hide it from the debugger. If you want to debug it you should pass a ТNS_dontSuppressAllPauses environment variable