### PR TITLE
Generate TypeScript comments in TypeScript declarations

### DIFF
--- a/build/scripts/metadata-generation-build-step
+++ b/build/scripts/metadata-generation-build-step
@@ -34,6 +34,16 @@ other_cflags_parsed = shlex.split(other_cflags)
 preprocessor_defs = env_or_empty("GCC_PREPROCESSOR_DEFINITIONS")
 preprocessor_defs_parsed = map((lambda s: "-D" + s), shlex.split(preprocessor_defs, '\''))
 typescript_output_folder = env_or_none("TNS_TYPESCRIPT_DECLARATIONS_PATH")
+docset_platform = "iOS"
+effective_platofrm_name = env("EFFECTIVE_PLATFORM_NAME")
+
+if effective_platofrm_name is "-macosx":
+    docset_platform = "OSX"
+elif effective_platofrm_name is "-watchos" or effective_platofrm_name is "-watchsimulator":
+    docset_platform = "watchOS"
+elif effective_platofrm_name is "-appletvos" or effective_platofrm_name is "-appletvsimulator":
+    docset_platform = "tvOS"
+docset_path = os.path.join(os.path.expanduser("~"), "Library/Developer/Shared/Documentation/DocSets/com.apple.adc.documentation.{}.docset".format(docset_platform))
 yaml_output_folder = env_or_none("TNS_DEBUG_METADATA_PATH")
 
 
@@ -41,7 +51,8 @@ def generate_metadata(arch):
     # metadata generator arguments
     generator_call = ["./objc-metadata-generator",
                       "-output-bin", "{}/metadata-{}.bin".format(conf_build_dir, arch),
-                      "-output-umbrella", "{}/umbrella-{}.h".format(conf_build_dir, arch)]
+                      "-output-umbrella", "{}/umbrella-{}.h".format(conf_build_dir, arch),
+                      "-docset-path", docset_path]
 
     # optionally add typescript output folder
     if typescript_output_folder is not None:


### PR DESCRIPTION
First merge: https://github.com/NativeScript/ios-metadata-generator/pull/37

TypeScript declarations look like this:

Function:
```typescript
	/**
	 * Creates and returns a new instance of a given class.
	 * @param aClass - The class of which to create an instance.
	 * @param extraBytes - The number of extra bytes required for indexed instance variables (this value is typically 0).
	 * @param zone - The zone in which to create the new instance (pass NULL to specify the default zone).
	 */
	declare function NSAllocateObject(aClass: typeof NSObject, extraBytes: number, zone: interop.Pointer): any;
```

Constant:
```typescript
	/**
	 * All directories where resources can occur.
	 */
	declare const NSAllLibrariesDirectory: number;
```

Interface (with static method, instance method and property):
```typescript
	/**
	 * NSArray and its subclass NSMutableArray manage ordered collections of objects called arrays. NSArray creates static arrays, and NSMutableArray creates dynamic arrays. You can use arrays when you need an ordered collection of objects.
	 */
	declare class NSArray<ObjectType> extends NSObject implements CKRecordValue, NSCopying, NSFastEnumeration, NSMutableCopying, NSSecureCoding {

		/**
		 * Returns a new instance of the receiving class.
		 */
		static alloc<ObjectType>(): NSArray<ObjectType>; // inherited from NSObject

		/**
		 * Returns a new array that is a copy of the receiving array with a given object added to the end.
		 * @param anObject - An object.
		 */
		arrayByAddingObject(anObject: ObjectType): NSArray<ObjectType>;

		/**
		 * The number of objects in the array.
		 */
		/* readonly */ count: number;
```

Protocol:
```typescript
	/**
	 * The delegate of an NSCache object implements this protocol to perform specialized actions when an object is about to be evicted or removed from the cache.
	 */
	interface NSCacheDelegate extends NSObjectProtocol {

		/**
	 	 * Called when an object is about to be evicted or removed from the cache.
	 	 * @param cache - The cache with which the object of interest is associated.
		 * @param obj - The object of interest in the cache.
		 */
		cacheWillEvictObject?(cache: NSCache<any, any>, obj: any): void;
	}
```

Struct:
```typescript
	/**
	 * An audio file region specifies a segment of audio data.
	 */
	interface AudioFileRegion {
		/**
		 * A unique ID associated with the audio file region.
		 */
		mRegionID: number;
		/**
		 * The name of the region.
		 */
		mName: string;
		/**
		 * Audio File Services region flags. For details, see Audio File Region Flags.
		 */
		mFlags: AudioFileRegionFlags;
		/**
		 * The number of markers in the array specified in the  mMarkers parameter.
		 */
		mNumberMarkers: number;
		/**
		 * An array of mNumberMarkers elements describing where the data in the region starts. For details, see Audio File Marker Types.
		 */
		mMarkers: interop.Reference<AudioFileMarker>;
	}
```

Enum:
```typescript
	declare const enum AudioFileStreamPropertyFlags {

		/**
		 * This flag is set when the callback AudioFileStream_PropertyListenerProc is invoked in the case that the value of the property has been cached and can be obtained later.
		 */
		kAudioFileStreamPropertyFlag_PropertyIsCached = 1,

		/**
		 * A property listener sets this flag to instruct the parser to cache the property value so that it remains available after the callback returns.
		 */
		kAudioFileStreamPropertyFlag_CacheProperty = 2
	}
```