### PR TITLE
Fix for debugger connecting after a delay

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -226,7 +226,6 @@ static void TNSEnableRemoteInspector(int argc, char **argv) {
             [inspector pause];
         });
         CFRunLoopWakeUp(runloop);
-        CFRunLoopStop(runloop);
       }
 
       NSArray *inspectorRunloopModes =
@@ -257,9 +256,10 @@ static void TNSEnableRemoteInspector(int argc, char **argv) {
                            dispatch_get_main_queue(), ^(int token) {
       isWaitingForDebugger = YES;
       NSLog(@"NativeScript waiting for debugger.");
-      CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
-          CFRunLoopRunInMode(kCFRunLoopDefaultMode, 30, false);
-      });
+
+      do {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+      } while (isWaitingForDebugger);
   });
 
   int attachRequestSubscription;
@@ -280,6 +280,8 @@ static void TNSEnableRemoteInspector(int argc, char **argv) {
             dispatch_source_cancel(listenSource);
             listenSource = nil;
           }
+
+          isWaitingForDebugger = NO;
       });
   });
 


### PR DESCRIPTION
Currently we have a delay of one second before we pause the application so that the inspector frontend would have enough time to initialize. We schedule the pause logic on the main loop and wake it up in order to execute it. We than call CFRunLoopStop which was supposed to stop the runloop that loops for 30 seconds waiting for an inspector frontend connection. Since the CFRunLoopStop is right after the 1 second pause it stops this pass of the runloop, not the 30 seconds one.  So to fix it we wait until isWaitingForDebugger becomes NO and isWaitingForDebugger is set to NO 30 seconds after the ReadyForAttach notification