### PR TITLE
TNS Objective-C exception handler

### DIFF
--- a/build/project-template/internal/main.m
+++ b/build/project-template/internal/main.m
@@ -5,6 +5,7 @@
 #include <Foundation/Foundation.h>
 #include <JavaScriptCore/JavaScriptCore.h>
 #include <NativeScript.h>
+#include <TNSExceptionHandler.h>
 
 #if DEBUG
 #include <TNSDebugging.h>
@@ -20,9 +21,11 @@ int main(int argc, char *argv[]) {
 #if DEBUG
     NSString *libraryPath = [NSSearchPathForDirectoriesInDomains(
         NSLibraryDirectory, NSUserDomainMask, YES) firstObject];
-    NSString *liveSyncPath =
-        [NSString pathWithComponents:
-                      @[ libraryPath, @"Application Support", @"LiveSync" ]];
+    NSString *liveSyncPath = [NSString pathWithComponents:@[
+      libraryPath,
+      @"Application Support",
+      @"LiveSync"
+    ]];
     NSString *appFolderPath =
         [NSString pathWithComponents:@[ liveSyncPath, @"app" ]];
 
@@ -35,6 +38,8 @@ int main(int argc, char *argv[]) {
 #endif
 
     [TNSRuntime initializeMetadata:&startOfMetadataSection];
+    TNSInstallExceptionHandler();
+
     runtime = [[TNSRuntime alloc] initWithApplicationPath:applicationPath];
     [runtime scheduleInRunLoop:[NSRunLoop currentRunLoop]
                        forMode:NSRunLoopCommonModes];

--- a/build/scripts/build-runtime.sh
+++ b/build/scripts/build-runtime.sh
@@ -10,13 +10,14 @@ PACKAGE_DIR="$DIST_DIR/package"
 FRAMEWORK_DIR="$PACKAGE_DIR/framework"
 INTERNAL_DIR="$FRAMEWORK_DIR/internal"
 
-. "$WORKSPACE/build/scripts/build.sh" 
+. "$WORKSPACE/build/scripts/build.sh"
 
 mkdir -p "$INTERNAL_DIR/NativeScript/Frameworks"
 
 cp -R "$DIST_DIR/NativeScript/" "$INTERNAL_DIR/NativeScript"
 cp -R "$DIST_DIR/NativeScript.framework" "$INTERNAL_DIR/NativeScript/Frameworks"
 cp -R "$WORKSPACE/src/debugging/TNSDebugging.h" "$INTERNAL_DIR"
+cp -R "$WORKSPACE/src/NativeScript/ObjC/TNSExceptionHandler.h" "$INTERNAL_DIR"
 cp -R "$DIST_DIR/metadataGenerator" "$INTERNAL_DIR/metadata-generator"
 cp -R "$BUILD_DIR/project-template/" "$FRAMEWORK_DIR"
 cp -R "$BUILD_DIR/npm/runtime_package.json" "$PACKAGE_DIR/package.json"

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -57,6 +57,7 @@ NATIVESCRIPT_DIR="$WORKSPACE/src/NativeScript/"
 cp \
     "$NATIVESCRIPT_DIR/NativeScript.h" \
     "$NATIVESCRIPT_DIR/TNSRuntime.h" \
+    "$NATIVESCRIPT_DIR/TNSRuntime+Diagnostics.h" \
     "$NATIVESCRIPT_DIR/TNSRuntime+Inspector.h" \
     "$WORKSPACE/dist/NativeScript/include"
 

--- a/cmake/CreateNativeScriptApp.cmake
+++ b/cmake/CreateNativeScriptApp.cmake
@@ -1,10 +1,11 @@
 function(CreateNativeScriptApp _target _main _plist _resources)
-    include_directories(${RUNTIME_DIR} ${NATIVESCRIPT_DEBUGGING_DIR})
+    include_directories("${RUNTIME_DIR}/**" ${NATIVESCRIPT_DEBUGGING_DIR})
     link_directories(${WEBKIT_LINK_DIRECTORIES} "${LIBFFI_LIB_DIR}")
 
     add_executable(${_target} ${_main} ${_resources})
 
     target_link_libraries(${_target}
+        "-ObjC"
         "-framework CoreGraphics"
         "-framework UIKit"
         "-framework MobileCoreServices"

--- a/cmake/main.m
+++ b/cmake/main.m
@@ -1,4 +1,5 @@
 #import <NativeScript.h>
+#import <TNSExceptionHandler.h>
 
 #ifndef NDEBUG
 #include <TNSDebugging.h>
@@ -15,6 +16,8 @@ int main(int argc, char *argv[]) {
     [runtime scheduleInRunLoop:[NSRunLoop currentRunLoop]
                        forMode:NSRunLoopCommonModes];
     TNSRuntimeInspector.logsToSystemConsole = YES;
+
+    TNSInstallExceptionHandler();
 
 #ifndef NDEBUG
     TNSEnableRemoteInspector(argc, argv);

--- a/examples/BlankApp/main.m
+++ b/examples/BlankApp/main.m
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <JavaScriptCore/JavaScriptCore.h>
 #import <NativeScript.h>
+#import <TNSExceptionHandler.h>
 
 static NSString *toString(JSContextRef context, JSValueRef value) {
   JSStringRef errorMessageRef = JSValueToStringCopy(context, value, NULL);
@@ -35,6 +36,8 @@ int main(int argc, char *argv[]) {
       NSLog(@"%@", error.localizedDescription);
       return 1;
     }
+
+    TNSInstallExceptionHandler();
 
     JSValueRef errorRef = NULL;
 

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -171,6 +171,7 @@ set(SOURCE_FILES
 
 set(NativeScript_PUBLIC_HEADERS
     NativeScript.h
+    TNSRuntime+Diagnostics.h
     TNSRuntime+Inspector.h
     TNSRuntime.h
 )

--- a/src/NativeScript/JSErrors.mm
+++ b/src/NativeScript/JSErrors.mm
@@ -31,7 +31,7 @@ namespace NativeScript {
 using namespace JSC;
 
 static void handleJsUncaughtErrorCallback(ExecState* execState, Exception* exception) {
-    JSValue callback = execState->lexicalGlobalObject()->get(execState, Identifier::fromString(execState, "__onUncaughtError"));
+    JSValue callback = execState->lexicalGlobalObject()->get(execState, Identifier::fromString(execState, "__onUncaughtError")); // Keep in sync with TNSExceptionHandler.h
 
     CallData callData;
     CallType callType = getCallData(callback, callData);

--- a/src/NativeScript/NativeScript.h
+++ b/src/NativeScript/NativeScript.h
@@ -7,4 +7,5 @@
 //
 
 #import "TNSRuntime.h"
+#import "TNSRuntime+Diagnostics.h"
 #import "TNSRuntime+Inspector.h"

--- a/src/NativeScript/ObjC/TNSExceptionHandler.h
+++ b/src/NativeScript/ObjC/TNSExceptionHandler.h
@@ -1,0 +1,63 @@
+//
+//  TNSExceptionHandler.h
+//  NativeScript
+//
+//  Created by Jason Zhekov on 2/1/16.
+//  Copyright © 2016 Telerik. All rights reserved.
+//
+
+#ifndef TNSExceptionHandler_h
+#define TNSExceptionHandler_h
+
+#import <JavaScriptCore/JavaScriptCore.h>
+#import <NativeScript.h>
+
+TNSRuntime* runtime;
+
+static NSUncaughtExceptionHandler* oldExceptionHandler = NULL;
+
+static void TNSObjectiveCUncaughtExceptionHandler(NSException* currentException) {
+    JSGlobalContextRef context = runtime.globalContext;
+    JSObjectRef globalObject = JSContextGetGlobalObject(context);
+
+    JSStringRef uncaughtPropertyName = JSStringCreateWithUTF8CString("__onUncaughtError"); // Keep in sync with JSErrors.mm
+    JSValueRef uncaughtCallback = JSObjectGetProperty(context, globalObject, uncaughtPropertyName, NULL);
+    JSStringRelease(uncaughtPropertyName);
+
+    if (!JSValueIsUndefined(context, uncaughtCallback)) {
+        JSStringRef reason = JSStringCreateWithUTF8CString(currentException.reason.UTF8String);
+        JSObjectRef error = JSObjectMakeError(
+            context, 1, (JSValueRef[]){ JSValueMakeString(context, reason) }, NULL);
+        JSStringRelease(reason);
+
+        JSValueRef wrappedException = [runtime convertObject:currentException];
+        JSStringRef nativeExceptionPropertyName = JSStringCreateWithUTF8CString("nativeException");
+        JSObjectSetProperty(context, error, nativeExceptionPropertyName,
+                            wrappedException, kJSPropertyAttributeNone, NULL);
+        JSStringRelease(nativeExceptionPropertyName);
+
+        JSValueRef callError = NULL;
+        JSObjectCallAsFunction(context, (JSObjectRef)uncaughtCallback, NULL, 1,
+                               (JSValueRef[]){ error }, &callError);
+        if (callError) {
+            JSStringRef callErrorMessage = JSValueToStringCopy(context, callError, NULL);
+            NSLog(@"Error executing uncaught error handler: %@",
+                  CFBridgingRelease(JSStringCopyCFString(CFAllocatorGetDefault(),
+                                                         callErrorMessage)));
+            JSStringRelease(callErrorMessage);
+        }
+    }
+
+    NSLog(@"*** JavaScript call stack:\n(\n%@\n)", [runtime getCurrentStack]);
+
+    if (oldExceptionHandler) {
+        oldExceptionHandler(currentException);
+    }
+}
+
+static void TNSInstallExceptionHandler() {
+    oldExceptionHandler = NSGetUncaughtExceptionHandler();
+    NSSetUncaughtExceptionHandler(TNSObjectiveCUncaughtExceptionHandler);
+}
+
+#endif /* TNSExceptionHandler_h */

--- a/src/NativeScript/TNSRuntime+Diagnostics.h
+++ b/src/NativeScript/TNSRuntime+Diagnostics.h
@@ -10,7 +10,6 @@
 
 @interface TNSRuntime (Diagnostics)
 
-+ (void)_printCurrentStack;
-+ (NSString*)_getCurrentStack;
+- (NSString*)getCurrentStack;
 
 @end

--- a/src/NativeScript/TNSRuntime.h
+++ b/src/NativeScript/TNSRuntime.h
@@ -15,7 +15,7 @@ FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handle
 
 @interface TNSRuntime : NSObject
 
-@property(nonatomic, retain) NSString* applicationPath;
+@property(nonatomic, retain, readonly) NSString* applicationPath;
 
 + (void)initializeMetadata:(void*)metadataPtr;
 
@@ -28,5 +28,7 @@ FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handle
 - (JSGlobalContextRef)globalContext;
 
 - (void)executeModule:(NSString*)entryPointModuleIdentifier;
+
+- (JSValueRef)convertObject:(id)object;
 
 @end

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -26,6 +26,7 @@
 #import "TNSRuntime+Private.h"
 #include "JSErrors.h"
 #include "Metadata/Metadata.h"
+#include "ObjCTypes.h"
 
 using namespace JSC;
 using namespace NativeScript;
@@ -116,6 +117,11 @@ using namespace NativeScript;
 
         reportFatalErrorBeforeShutdown(self->_globalObject->globalExec(), exception);
     }
+}
+
+- (JSValueRef)convertObject:(id)object {
+    JSLockHolder lock(*self->_vm);
+    return toRef(self->_globalObject->globalExec(), toValue(self->_globalObject->globalExec(), object));
 }
 
 - (void)dealloc {

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -153,7 +153,7 @@ static dispatch_source_t TNSCreateInspectorServer(
   return listenSource;
 }
 
-static void TNSObjectiveCUncaughtExceptionHandler(NSException *exception) {
+static void TNSInspectorUncaughtExceptionHandler(NSException *exception) {
   JSStringRef exceptionMessage =
       JSStringCreateWithUTF8CString(exception.description.UTF8String);
 
@@ -211,7 +211,7 @@ static void TNSEnableRemoteInspector(int argc, char **argv) {
 
       inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
 
-      NSSetUncaughtExceptionHandler(&TNSObjectiveCUncaughtExceptionHandler);
+      NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
 
       if (isWaitingForDebugger) {
         isWaitingForDebugger = NO;

--- a/tests/TestFixtures/exported-symbols.txt
+++ b/tests/TestFixtures/exported-symbols.txt
@@ -5,6 +5,7 @@ functionReturningFunctionPtrAsVoidPtr
 functionReturnsCFRetained
 functionReturnsNSRetained
 functionReturnsUnmanaged
+functionThrowsException
 functionWhichReturnsSimpleFunctionPointer
 functionWith_BoolPtr
 functionWith_VoidPtr


### PR DESCRIPTION
Looking forward to some comments.

New output includes JS stack trace. Example with https://github.com/NativeScript/NativeScript/issues/1426:
```
2016-02-03 17:58:13.382 HelloWorldApp[81228:1483108] *** JavaScript call stack:
(
	0   _updateIOSTabBarColorsAndFonts@file:///app/tns_modules/ui/tab-view/tab-view.js:282:30
	1   setFontInternalProperty@file:///app/tns_modules/ui/styling/stylers.js:698:43
	2   applyProperty@file:///app/tns_modules/ui/styling/stylers-common.js:27:28
	3   _applyStyleProperty@file:///app/tns_modules/ui/styling/style.js:715:42
	4   @file:///app/tns_modules/ui/styling/style.js:636:103
	5   forEach@[native code]
	6   _endUpdate@file:///app/tns_modules/ui/styling/style.js:636:40
	7   applySelectors@file:///app/tns_modules/ui/styling/style-scope.js:127:30
	8   checkSelectors@file:///app/tns_modules/ui/page/page-common.js:239:33
	9   localCallback@file:///app/tns_modules/ui/core/view-common.js:56:37
	10  _eachChildView@file:///app/tns_modules/ui/content-view/content-view.js:45:21
	11  _eachChildView@file:///app/tns_modules/ui/page/page-common.js:229:45
	12  eachDescendant@file:///app/tns_modules/ui/core/view-common.js:62:24
	13  _applyCss@file:///app/tns_modules/ui/page/page-common.js:243:28
	14  onLoaded@file:///app/tns_modules/ui/page/page-common.js:31:23
	15  onLoaded@file:///app/tns_modules/ui/page/page.js:131:43
	16  viewWillAppear@file:///app/tns_modules/ui/page/page.js:86:23
	17  UIApplicationMain@[native code]
	18  start@file:///app/tns_modules/application/application.js:200:26
	19  anonymous@file:///app/app.js:9:18
	20  evaluate@[native code]
	21  moduleEvaluation@:1:11
	22  @:8:48
	23  promiseReactionJob@:1:11
)
2016-02-03 17:58:13.383 HelloWorldApp[81228:1483108] *** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[__NSArrayI objectAtIndex:]: index 5 beyond bounds [0 .. 4]'
*** First throw call stack:
(
	0   CoreFoundation                      0x04f7da84 __exceptionPreprocess + 180
	1   libobjc.A.dylib                     0x04a3ce02 objc_exception_throw + 50
	2   CoreFoundation                      0x04e5606e -[__NSArrayI objectAtIndex:] + 206
	3   CoreFoundation                      0x04ec27f8 -[NSArray objectAtIndexedSubscript:] + 40
	4   HelloWorldApp                       0x001159fe _ZN12NativeScript17ObjCWrapperObject25getOwnPropertySlotByIndexEPN3JSC8JSObjectEPNS1_9ExecStateEjRNS1_12PropertySlotE + 110
	5   HelloWorldApp                       0x00117f4b _ZN3JSC8JSObject15getPropertySlotEPNS_9ExecStateEjRNS_12PropertySlotE + 155
	6   HelloWorldApp                       0x00831e07 _ZNK3JSC7JSValue3getEPNS_9ExecStateEjRNS_12PropertySlotE + 279
	7   HelloWorldApp                       0x0082bca5 _ZNK3JSC7JSValue3getEPNS_9ExecStateEj + 101
	8   HelloWorldApp                       0x008f7920 _ZN3JSC5LLInt8getByValEPNS_9ExecStateENS_7JSValueES3_ + 784
	9   HelloWorldApp                       0x008ef039 llint_slow_path_get_by_val + 233
	10  HelloWorldApp                       0x008fc906 llint_entry + 10460
	11  HelloWorldApp                       0x008feffd llint_entry + 20435
	12  HelloWorldApp                       0x008feffd llint_entry + 20435
	13  HelloWorldApp                       0x008fefa6 llint_entry + 20348
	14  HelloWorldApp                       0x008feffd llint_entry + 20435
	15  HelloWorldApp                       0x008f9e7c vmEntryToJavaScript + 284
	16  HelloWorldApp                       0x0086ec9d _ZN3JSC7JITCode7executeEPNS_2VMEPNS_14ProtoCallFrameE + 269
	17  HelloWorldApp                       0x008296b4 _ZN3JSC11Interpreter7executeERNS_16CallFrameClosureE + 804
	18  HelloWorldApp                       0x00c781aa _ZN3JSC10CachedCall4callEv + 122
	19  HelloWorldApp                       0x00c7730d _ZN3JSCL19mapProtoFuncForEachEPNS_9ExecStateE + 1085
	20  HelloWorldApp                       0x008ff712 llint_entry + 22248
	21  HelloWorldApp                       0x008fefa6 llint_entry + 20348
	22  HelloWorldApp                       0x008fefa6 llint_entry + 20348
	23  HelloWorldApp                       0x008fefa6 llint_entry + 20348
	24  HelloWorldApp                       0x008feffd llint_entry + 20435
	25  HelloWorldApp                       0x008feffd llint_entry + 20435
	26  HelloWorldApp                       0x008feffd llint_entry + 20435
	27  HelloWorldApp                       0x008feffd llint_entry + 20435
	28  HelloWorldApp                       0x008feffd llint_entry + 20435
	29  HelloWorldApp                       0x008feffd llint_entry + 20435
	30  HelloWorldApp                       0x008feffd llint_entry + 20435
	31  HelloWorldApp                       0x008feffd llint_entry + 20435
	32  HelloWorldApp                       0x008f9e7c vmEntryToJavaScript + 284
	33  HelloWorldApp                       0x0086ec9d _ZN3JSC7JITCode7executeEPNS_2VMEPNS_14ProtoCallFrameE + 269
	34  HelloWorldApp                       0x008284a4 _ZN3JSC11Interpreter11executeCallEPNS_9ExecStateEPNS_8JSObjectENS_8CallTypeERKNS_8CallDataENS_7JSValueERKNS_7ArgListE + 1684
	35  HelloWorldApp                       0x00a670fd _ZN3JSC4callEPNS_9ExecStateENS_7JSValueENS_8CallTypeERKNS_8CallDataES2_RKNS_7ArgListE + 253
	36  HelloWorldApp                       0x0010d81f _ZN12NativeScript11FFICallbackINS_18ObjCMethodCallbackEE12callFunctionERKN3JSC7JSValueERKNS3_7ArgListEPv + 335
	37  HelloWorldApp                       0x0010cc4d _ZN12NativeScript18ObjCMethodCallback18ffiClosureCallbackEPvPS1_S1_ + 333
	38  HelloWorldApp                       0x0010df78 _ZN12NativeScript11FFICallbackINS_18ObjCMethodCallbackEE18ffiClosureCallbackEP7ffi_cifPvPS5_S5_ + 88
	39  HelloWorldApp                       0x00dce870 ffi_closure_inner + 736
	40  HelloWorldApp                       0x00dcf1c2 ffi_closure_i386 + 50
	41  UIKit                               0x02d7fbff -[UIViewController __viewWillAppear:] + 147
	42  UIKit                               0x02dc5c86 -[UINavigationController _startTransition:fromViewController:toViewController:] + 1075
	43  UIKit                               0x02dc6ce0 -[UINavigationController _startDeferredTransitionIfNeeded:] + 1038
	44  UIKit                               0x02dc7e3b -[UINavigationController __viewWillLayoutSubviews] + 68
	45  UIKit                               0x02fa3193 -[UILayoutContainerView layoutSubviews] + 252
	46  UIKit                               0x02c78eb7 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 813
	47  libobjc.A.dylib                     0x04a51059 -[NSObject performSelector:withObject:] + 70
	48  QuartzCore                          0x07da580a -[CALayer layoutSublayers] + 144
	49  QuartzCore                          0x07d994ee _ZN2CA5Layer16layout_if_neededEPNS_11TransactionE + 388
	50  QuartzCore                          0x07d99352 _ZN2CA5Layer28layout_and_display_if_neededEPNS_11TransactionE + 26
	51  QuartzCore                          0x07d8be8b _ZN2CA7Context18commit_transactionEPNS_11TransactionE + 317
	52  QuartzCore                          0x07dbfe03 _ZN2CA11Transaction6commitEv + 561
	53  QuartzCore                          0x07dc06c4 _ZN2CA11Transaction17observer_callbackEP19__CFRunLoopObservermPv + 92
	54  CoreFoundation                      0x04e9761e __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 30
	55  CoreFoundation                      0x04e9757e __CFRunLoopDoObservers + 398
	56  CoreFoundation                      0x04e8c728 CFRunLoopRunSpecific + 504
	57  CoreFoundation                      0x04e8c51b CFRunLoopRunInMode + 123
	58  UIKit                               0x02ba9854 -[UIApplication _run] + 540
	59  UIKit                               0x02baf1eb UIApplicationMain + 160
	60  HelloWorldApp                       0x00dcf088 ffi_call_i386 + 24
)
```

Closes https://github.com/NativeScript/ios-runtime/issues/434.