### PR TITLE
Add methods to Objective-C protocol wrappers

### DIFF
--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -91,6 +91,12 @@ static bool isJavaScriptDerived(JSC::JSValue value) {
 
 void ObjCMethodCall::preInvocation(FFICall* callee, ExecState* execState, FFICall::Invocation& invocation) {
     ObjCMethodCall* call = jsCast<ObjCMethodCall*>(callee);
+
+    if (!(execState->thisValue().inherits(ObjCConstructorBase::info()) || execState->thisValue().inherits(ObjCWrapperObject::info()) || execState->thisValue().inherits(AllocatedPlaceholder::info()) || execState->thisValue().inherits(ObjCSuperObject::info()))) {
+        throwVMError(execState, createError(execState, WTF::ASCIILiteral("This value is not a native object.")));
+        return;
+    }
+
     id target = NativeScript::toObject(execState, execState->thisValue());
 
     if (call->_hasErrorOutParameter && call->_parameterTypesCells.size() - 1 == execState->argumentCount()) {

--- a/src/NativeScript/ObjC/ObjCProtocolWrapper.h
+++ b/src/NativeScript/ObjC/ObjCProtocolWrapper.h
@@ -14,16 +14,19 @@ struct ProtocolMeta;
 }
 
 namespace NativeScript {
+class ObjCPrototype;
 
 class ObjCProtocolWrapper : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
+    static const unsigned StructureFlags = JSC::OverridesGetOwnPropertySlot | Base::StructureFlags;
+
     DECLARE_INFO;
 
-    static ObjCProtocolWrapper* create(JSC::VM& vm, JSC::Structure* structure, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol = nil) {
+    static ObjCProtocolWrapper* create(JSC::VM& vm, JSC::Structure* structure, ObjCPrototype* prototype, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol = nil) {
         ObjCProtocolWrapper* cell = new (NotNull, JSC::allocateCell<ObjCProtocolWrapper>(vm.heap)) ObjCProtocolWrapper(vm, structure);
-        cell->finishCreation(vm, metadata, aProtocol);
+        cell->finishCreation(vm, prototype, metadata, aProtocol);
         return cell;
     }
 
@@ -46,7 +49,9 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM& vm, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol);
+    void finishCreation(JSC::VM& vm, ObjCPrototype* prototype, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol);
+
+    static bool getOwnPropertySlot(JSC::JSObject*, JSC::ExecState*, JSC::PropertyName, JSC::PropertySlot&);
 
     const Metadata::ProtocolMeta* _metadata;
 

--- a/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
+++ b/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
@@ -8,6 +8,9 @@
 
 #include "ObjCProtocolWrapper.h"
 #include "Metadata.h"
+#include "SymbolLoader.h"
+#include "ObjCMethodCall.h"
+#include "ObjCPrototype.h"
 
 namespace NativeScript {
 using namespace JSC;
@@ -15,8 +18,9 @@ using namespace Metadata;
 
 const ClassInfo ObjCProtocolWrapper::s_info = { "ObjCProtocolWrapper", &Base::s_info, 0, CREATE_METHOD_TABLE(ObjCProtocolWrapper) };
 
-void ObjCProtocolWrapper::finishCreation(VM& vm, const ProtocolMeta* metadata, Protocol* aProtocol) {
+void ObjCProtocolWrapper::finishCreation(VM& vm, ObjCPrototype* prototype, const ProtocolMeta* metadata, Protocol* aProtocol) {
     Base::finishCreation(vm);
+    this->putDirect(vm, vm.propertyNames->prototype, prototype, DontEnum | DontDelete | ReadOnly);
     this->_metadata = metadata;
     this->_protocol = aProtocol;
 }
@@ -25,5 +29,29 @@ WTF::String ObjCProtocolWrapper::className(const JSObject* object) {
     ObjCProtocolWrapper* protocolWrapper = (ObjCProtocolWrapper*)object;
     const char* protocolName = protocolWrapper->metadata()->name();
     return protocolName;
+}
+
+bool ObjCProtocolWrapper::getOwnPropertySlot(JSObject* object, ExecState* execState, PropertyName propertyName, PropertySlot& propertySlot) {
+    if (Base::getOwnPropertySlot(object, execState, propertyName, propertySlot)) {
+        return true;
+    }
+
+    if (UNLIKELY(!propertyName.publicName())) {
+        return false;
+    }
+
+    ObjCProtocolWrapper* protocol = jsCast<ObjCProtocolWrapper*>(object);
+
+    if (const MethodMeta* method = protocol->_metadata->staticMethod(propertyName.publicName())) {
+        SymbolLoader::instance().ensureModule(method->topLevelModule());
+
+        GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
+        ObjCMethodCall* call = ObjCMethodCall::create(execState->vm(), globalObject, globalObject->objCMethodCallStructure(), method);
+        object->putDirect(execState->vm(), propertyName, call);
+        propertySlot.setValue(object, None, call);
+        return true;
+    }
+
+    return false;
 }
 };

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -13,7 +13,7 @@
 #include <wtf/RetainPtr.h>
 
 namespace Metadata {
-struct InterfaceMeta;
+struct BaseClassMeta;
 }
 
 namespace NativeScript {
@@ -23,7 +23,7 @@ public:
 
     static const unsigned StructureFlags;
 
-    static ObjCPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::InterfaceMeta* metadata) {
+    static ObjCPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::BaseClassMeta* metadata) {
         ObjCPrototype* prototype = new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure);
         prototype->finishCreation(vm, globalObject, metadata);
         return prototype;
@@ -44,7 +44,7 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, const Metadata::InterfaceMeta*);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, const Metadata::BaseClassMeta*);
 
     static bool getOwnPropertySlot(JSC::JSObject*, JSC::ExecState*, JSC::PropertyName, JSC::PropertySlot&);
 
@@ -54,7 +54,7 @@ private:
 
     static void getOwnPropertyNames(JSC::JSObject*, JSC::ExecState*, JSC::PropertyNameArray&, JSC::EnumerationMode);
 
-    const Metadata::InterfaceMeta* _metadata;
+    const Metadata::BaseClassMeta* _metadata;
 };
 }
 

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -39,7 +39,7 @@ static EncodedJSValue JSC_HOST_CALL getIterator(ExecState* execState) {
     return JSValue::encode(iterator);
 }
 
-void ObjCPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject, const InterfaceMeta* metadata) {
+void ObjCPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject, const BaseClassMeta* metadata) {
     Base::finishCreation(vm);
 
     this->_metadata = metadata;

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -485,18 +485,22 @@ describe(module.id, function () {
     it("ApiIterator", function () {
         var counter = 0;
 
-        Object.getOwnPropertyNames(global).forEach(function (x) {
-            // console.debug(x);
+        Object.getOwnPropertyNames(global).forEach(function (name) {
+            // console.debug(name);
 
             // according to SDK headers kCFAllocatorUseContext is of type id, but in fact it is not
-            if (x == "kCFAllocatorUseContext") {
+            if (name == "kCFAllocatorUseContext") {
+                return;
+            }
+
+            if (name == "JSExport") {
                 return;
             }
 
             counter++;
 
             try {
-                var symbol = global[x];
+                var symbol = global[name];
             } catch (e) {
                 if (e instanceof ReferenceError) {
                     return;
@@ -513,7 +517,7 @@ describe(module.id, function () {
 
                 Object.getOwnPropertyNames(klass).forEach(function (y) {
                     if (klass.respondsToSelector(y)) {
-                        // console.debug(x, y);
+                        // console.debug(name, y);
 
                         var method = klass[y];
                         expect(method).toBeDefined();
@@ -524,7 +528,7 @@ describe(module.id, function () {
 
                 Object.getOwnPropertyNames(klass.prototype).forEach(function (y) {
                     if (klass.instancesRespondToSelector(y)) {
-                        // console.debug(x, "proto", y);
+                        // console.debug(name, "proto", y);
 
                         var property = Object.getOwnPropertyDescriptor(klass.prototype, y);
 

--- a/tests/TestRunner/app/Marshalling/ProtocolTests.js
+++ b/tests/TestRunner/app/Marshalling/ProtocolTests.js
@@ -1,0 +1,51 @@
+describe(module.id, function () {
+    afterEach(function () {
+        TNSClearOutput();
+    });
+
+    it("Base methods", function () {
+        expect(TNSBaseProtocol1).toBeDefined();
+
+        expect(TNSBaseProtocol1.baseProtocolMethod1).toBeDefined();
+        expect(TNSBaseProtocol1.baseProtocolMethod1Optional).toBeDefined();
+        expect(TNSBaseProtocol1.prototype.baseProtocolMethod1).toBeDefined();
+        expect(TNSBaseProtocol1.prototype.baseProtocolMethod1Optional).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol1.prototype, 'baseProtocolProperty1')).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol1.prototype, 'baseProtocolProperty1Optional')).toBeDefined();
+    });
+
+    it("Derived methods", function () {
+        expect(TNSBaseProtocol2).toBeDefined();
+
+        expect(TNSBaseProtocol2.baseProtocolMethod1).toBeDefined();
+        expect(TNSBaseProtocol2.baseProtocolMethod1Optional).toBeDefined();
+        expect(TNSBaseProtocol2.prototype.baseProtocolMethod1).toBeDefined();
+        expect(TNSBaseProtocol2.prototype.baseProtocolMethod1Optional).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol2.prototype, 'baseProtocolProperty1')).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol2.prototype, 'baseProtocolProperty1Optional')).toBeDefined();
+
+        expect(TNSBaseProtocol2.baseProtocolMethod2).toBeDefined();
+        expect(TNSBaseProtocol2.baseProtocolMethod2Optional).toBeDefined();
+        expect(TNSBaseProtocol2.prototype.baseProtocolMethod2).toBeDefined();
+        expect(TNSBaseProtocol2.prototype.baseProtocolMethod2Optional).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol2.prototype, 'baseProtocolProperty2')).toBeDefined();
+        expect(Object.getOwnPropertyDescriptor(TNSBaseProtocol2.prototype, 'baseProtocolProperty2Optional')).toBeDefined();
+    });
+
+    it("Calling protocol methods", function () {
+        var instance = TNSDerivedInterface.alloc().init();
+
+        expect(TNSBaseProtocol2.baseProtocolMethod1.call(TNSDerivedInterface));
+        expect(TNSBaseProtocol2.prototype.baseProtocolMethod1.call(instance));
+
+        var descriptor = Object.getOwnPropertyDescriptor(TNSBaseProtocol1.prototype, 'baseProtocolProperty1');
+        descriptor.set.call(instance, 1);
+        descriptor.get.call(instance);
+
+        expect(TNSGetOutput()).toBe(
+            'static baseProtocolMethod1 called' +
+            'instance baseProtocolMethod1 called' +
+            'instance setBaseProtocolProperty1: called' +
+            'instance baseProtocolProperty1 called');
+    });
+});

--- a/tests/TestRunner/app/index.js
+++ b/tests/TestRunner/app/index.js
@@ -38,6 +38,7 @@ import "./Marshalling/PointerTests";
 import "./Marshalling/ReferenceTests";
 import "./Marshalling/FunctionPointerTests";
 import "./Marshalling/EnumTests";
+import "./Marshalling/ProtocolTests";
 
 // import "./Inheritance/ConstructorResolutionTests";
 import "./Inheritance/InheritanceTests";


### PR DESCRIPTION
The following methods and properties are now available to all Objective-C protocol wrappers:
```javascript
var staticMethod = TNSBaseProtocol1.baseProtocolMethod1;
var instanceMethod = TNSBaseProtocol1.prototype.baseProtocolMethod1;
var instanceProperty = Object.getOwnPropertyDescriptor(TNSBaseProtocol1.prototype, 'baseProtocolProperty1');
```

This allows methods like https://github.com/NativeScript/NativeScript/pull/1531/files to be called in the following way:
```javascript
UIViewControllerContextTransitioning.prototype.containerView.call(transitionContext);
```

Close https://github.com/NativeScript/ios-runtime/issues/466