### PR TITLE
Name conflict tests

### DIFF
--- a/tests/TestFixtures/Api/TNSApi.h
+++ b/tests/TestFixtures/Api/TNSApi.h
@@ -60,3 +60,11 @@ typedef UIColor NIKColor;
 + (int)staticMethod:(int)x;
 - (int)instanceMethod:(int)x;
 @end
+
+@protocol TNSPropertyMethodConflictProtocol
+- (BOOL)conflict;
+@end
+
+@interface TNSPropertyMethodConflictClass : NSObject <TNSPropertyMethodConflictProtocol>
+@property BOOL conflict;
+@end

--- a/tests/TestFixtures/Api/TNSApi.m
+++ b/tests/TestFixtures/Api/TNSApi.m
@@ -79,3 +79,7 @@ void functionThrowsException() {
     return x;
 }
 @end
+
+@implementation TNSPropertyMethodConflictClass
+
+@end

--- a/tests/TestFixtures/TNSTestNativeCallbacks.h
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.h
@@ -44,6 +44,8 @@
 
 + (void)protocolImplementationProperties:(id<TNSBaseProtocol1, NSObject>)object;
 
++ (BOOL)protocolWithNameConflict:(id<TNSPropertyMethodConflictProtocol, NSObject>)object;
+
 + (TNSSimpleStruct)recordsSimpleStruct:(TNSSimpleStruct)object;
 
 + (TNSNestedStruct)recordsNestedStruct:(TNSNestedStruct)object;

--- a/tests/TestFixtures/TNSTestNativeCallbacks.m
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.m
@@ -233,6 +233,10 @@
     UNUSED(object.baseProtocolProperty1Optional);
 }
 
++ (BOOL)protocolWithNameConflict:(id<TNSPropertyMethodConflictProtocol, NSObject>)object {
+    return object.conflict;
+}
+
 + (TNSSimpleStruct)recordsSimpleStruct:(TNSSimpleStruct)object {
     TNSLog([NSString stringWithFormat:@"%d %d", object.x, object.y]);
     return object;

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -1846,7 +1846,7 @@ describe(module.id, function () {
         expect(NSString.stringWithCString(encoding).toString()).toBe("v@:");
     });
 
-    it("should project Symbol.iterable as NSFastEnumeration", function () {
+    it("should project Symbol.iterable as NSFastEnumeration", function() {
         var start = 1;
         var end = 10;
         var lastStep = 0;
@@ -1855,15 +1855,16 @@ describe(module.id, function () {
                 return {
                     step: start,
 
-                    next() {
+                        next() {
                         if (this.step <= end) {
-                            return { value: this.step++, done: false };
+                            return { value : this.step++, done : false };
                         } else {
-                            return { done: true };
+                            return { done : true };
                         }
-                    },
+                    }
+                    ,
 
-                    return() {
+                        return () {
                         lastStep = this.step;
                         return {};
                     }
@@ -1880,5 +1881,15 @@ describe(module.id, function () {
         expect(lastStep).toEqual(end + 1);
 
         TNSClearOutput();
-    })
+    });
+
+    it("Method and property with the same name", function() {
+        var JSObject = NSObject.extend({ get conflict() { return true; } },
+                                       { protocols : [ TNSPropertyMethodConflictProtocol ] });
+
+        var derived = JSObject.new();
+        var result = TNSTestNativeCallbacks.protocolWithNameConflict(derived);
+
+        expect(result).toBe(true);
+    });
 });


### PR DESCRIPTION
When we see a method from a base class with the same name as a property in a derived class, we change the method metadata in the base class to property metadata, so tests that assert this behavior are added.