### PR TITLE
Unify initializers generation logic in ObjCConstructorBase

### DIFF
--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.h
@@ -12,6 +12,10 @@
 #include <functional>
 #include "FFIType.h"
 
+namespace Metadata {
+struct InterfaceMeta;
+}
+
 namespace NativeScript {
 class ObjCConstructorCall;
 
@@ -19,15 +23,12 @@ class ObjCConstructorBase : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
+    static const unsigned StructureFlags;
+
     DECLARE_INFO;
 
     Class klass() const {
         return this->_klass;
-    }
-
-    const WTF::Vector<ObjCConstructorCall*> generateInitializers(JSC::VM& vm, GlobalObject* globalObject, Class target) {
-        JSC::DeferGCForAWhile deferGC(vm.heap);
-        return this->_initializersGenerator(vm, globalObject, target);
     }
 
     JSC::Structure* instancesStructure() const {
@@ -41,6 +42,8 @@ public:
     static WTF::String className(const JSObject* object);
 
     const WTF::Vector<JSC::WriteBarrier<ObjCConstructorCall>>& initializers(JSC::VM&, GlobalObject*);
+
+    const Metadata::InterfaceMeta* metadata();
 
 protected:
     ObjCConstructorBase(JSC::VM& vm, JSC::Structure* structure)
@@ -61,8 +64,6 @@ protected:
 
     static JSC::CallType getCallData(JSC::JSCell*, JSC::CallData&);
 
-    std::function<const WTF::Vector<ObjCConstructorCall*>(JSC::VM&, GlobalObject*, Class)> _initializersGenerator;
-
 private:
     static JSC::JSValue read(JSC::ExecState*, void const*, JSC::JSCell*);
 
@@ -79,6 +80,8 @@ private:
     WTF::Vector<JSC::WriteBarrier<ObjCConstructorCall>> _initializers;
 
     JSC::WriteBarrier<JSC::Structure> _instancesStructure;
+
+    const Metadata::InterfaceMeta* _metadata;
 
     FFITypeMethodTable _ffiTypeMethodTable;
 };

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.cpp
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.cpp
@@ -13,23 +13,4 @@ namespace NativeScript {
 using namespace JSC;
 
 const ClassInfo ObjCConstructorDerived::s_info = { "Function", &Base::s_info, 0, CREATE_METHOD_TABLE(ObjCConstructorDerived) };
-
-const unsigned ObjCConstructorDerived::StructureFlags = OverridesGetOwnPropertySlot | Base::StructureFlags;
-
-void ObjCConstructorDerived::finishCreation(VM& vm, JSGlobalObject* globalObject, JSObject* prototype, Class klass, ObjCConstructorBase* parent) {
-    Base::finishCreation(vm, globalObject, prototype, klass);
-
-    this->_parent.set(vm, this, parent);
-    this->ObjCConstructorBase::_initializersGenerator = std::bind(&ObjCConstructorDerived::initializersGenerator, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-}
-
-void ObjCConstructorDerived::visitChildren(JSCell* cell, SlotVisitor& visitor) {
-    Base::visitChildren(cell, visitor);
-    ObjCConstructorDerived* constructor = jsCast<ObjCConstructorDerived*>(cell);
-    visitor.append(&constructor->_parent);
-}
-
-const WTF::Vector<ObjCConstructorCall*> ObjCConstructorDerived::initializersGenerator(VM& vm, GlobalObject* globalObject, Class target) {
-    return this->_parent.get()->generateInitializers(vm, globalObject, target);
-}
 }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.h
@@ -16,11 +16,9 @@ class ObjCConstructorDerived : public ObjCConstructorBase {
 public:
     typedef ObjCConstructorBase Base;
 
-    static const unsigned StructureFlags;
-
-    static ObjCConstructorDerived* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass, ObjCConstructorBase* parent) {
+    static ObjCConstructorDerived* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
         ObjCConstructorDerived* cell = new (NotNull, JSC::allocateCell<ObjCConstructorDerived>(vm.heap)) ObjCConstructorDerived(vm, structure);
-        cell->finishCreation(vm, globalObject, prototype, klass, parent);
+        cell->finishCreation(vm, globalObject, prototype, klass);
         return cell;
     }
 
@@ -38,15 +36,6 @@ protected:
     static void destroy(JSC::JSCell* cell) {
         JSC::jsCast<ObjCConstructorDerived*>(cell)->~ObjCConstructorDerived();
     }
-
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject* prototype, Class, ObjCConstructorBase* parent);
-
-    static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
-
-private:
-    const WTF::Vector<ObjCConstructorCall*> initializersGenerator(JSC::VM&, GlobalObject*, Class);
-
-    JSC::WriteBarrier<ObjCConstructorBase> _parent;
 };
 }
 

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.h
@@ -11,21 +11,15 @@
 
 #include "ObjCConstructorBase.h"
 
-namespace Metadata {
-struct InterfaceMeta;
-}
-
 namespace NativeScript {
 class ObjCConstructorNative : public ObjCConstructorBase {
 public:
     typedef ObjCConstructorBase Base;
 
-    static const unsigned StructureFlags;
-
-    static ObjCConstructorNative* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass, const Metadata::InterfaceMeta* metadata) {
+    static ObjCConstructorNative* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
         ASSERT(klass);
         ObjCConstructorNative* cell = new (NotNull, JSC::allocateCell<ObjCConstructorNative>(vm.heap)) ObjCConstructorNative(vm, structure);
-        cell->finishCreation(vm, globalObject, prototype, klass, metadata);
+        cell->finishCreation(vm, globalObject, prototype, klass);
         return cell;
     }
 
@@ -35,22 +29,16 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    const Metadata::InterfaceMeta* metadata() const {
-        return this->_metadata;
-    }
-
     JSC::Structure* allocatedPlaceholderStructure() const {
         return _allocatedPlaceholderStructure.get();
     }
-
-    const WTF::Vector<ObjCConstructorCall*> initializersGenerator(JSC::VM&, GlobalObject*, Class);
 
 protected:
     ObjCConstructorNative(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject* prototype, Class, const Metadata::InterfaceMeta*);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject* prototype, Class);
 
     static void getOwnPropertyNames(JSC::JSObject*, JSC::ExecState*, JSC::PropertyNameArray&, JSC::EnumerationMode);
 
@@ -60,8 +48,6 @@ protected:
 
 private:
     static bool getOwnPropertySlot(JSC::JSObject*, JSC::ExecState*, JSC::PropertyName, JSC::PropertySlot&);
-
-    const Metadata::InterfaceMeta* _metadata;
 
     JSC::WriteBarrier<JSC::Structure> _allocatedPlaceholderStructure;
 };

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -207,7 +207,7 @@ ObjCClassBuilder::ObjCClassBuilder(ExecState* execState, JSValue baseConstructor
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     Structure* structure = ObjCConstructorDerived::createStructure(execState->vm(), globalObject, this->_baseConstructor.get());
-    ObjCConstructorDerived* derivedConstructor = ObjCConstructorDerived::create(execState->vm(), globalObject, structure, prototype, klass, this->_baseConstructor.get());
+    ObjCConstructorDerived* derivedConstructor = ObjCConstructorDerived::create(execState->vm(), globalObject, structure, prototype, klass);
 
     prototype->putDirect(execState->vm(), execState->vm().propertyNames->constructor, derivedConstructor, DontEnum);
 

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -35,9 +35,13 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
+    static WTF::String className(const JSObject* object);
+
     void materializeProperties(JSC::VM& vm, GlobalObject* globalObject);
 
-    static WTF::String className(const JSObject* object);
+    const Metadata::BaseClassMeta* metadata() {
+        return this->_metadata;
+    }
 
 private:
     ObjCPrototype(JSC::VM& vm, JSC::Structure* structure)

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -280,7 +280,7 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
     }
 
     Structure* constructorStructure = ObjCConstructorNative::createStructure(vm, globalObject, parentConstructor);
-    ObjCConstructorNative* constructor = ObjCConstructorNative::create(vm, globalObject, constructorStructure, prototype, klass, metadata);
+    ObjCConstructorNative* constructor = ObjCConstructorNative::create(vm, globalObject, constructorStructure, prototype, klass);
     prototype->putDirectWithoutTransition(vm, vm.propertyNames->constructor, constructor, DontEnum | DontDelete | ReadOnly);
 
     auto addResult = this->_cacheId.set(klassName, constructor);


### PR DESCRIPTION
1. Unify initializers generation logic in `ObjCConstructorNative` and `ObjCConstructorDerived`. Conceptually, it is the same, so there is no reason to be in two places.
2. `ObjCConstructor`s don't need `InterfaceMeta` to be initialized. They already require a prototype from where they can get the `InterfaceMeta`.
3. `ObjCConstructorDerived` don't need a parent constructor to be initialized, anymore.

Also, this makes `ObjCConstructorDerived` class almost identical to its base class (`ObjCConstructorBase`). This will allow us to remove it in the future.