### PR TITLE
Resolve swift-style initializers by searching in metadata instead of guessing the initializer name.

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -574,6 +574,7 @@ struct MethodMeta : MemberMeta {
 
 private:
     PtrTo<TypeEncodingsList<ArrayCount>> _encodings;
+    String _constructorTokens;
 
 public:
     bool isVariadic() const {
@@ -592,6 +593,10 @@ public:
         return this->flag(MetaFlags::MethodIsInitializer);
     }
 
+    bool ownsReturnedCocoaObject() const {
+        return this->flag(MetaFlags::MethodOwnsReturnedCocoaObject);
+    }
+
     SEL selector() const {
         return sel_registerName(this->selectorAsString());
     }
@@ -605,8 +610,8 @@ public:
         return this->_encodings.valuePtr();
     }
 
-    bool ownsReturnedCocoaObject() const {
-        return this->flag(MetaFlags::MethodOwnsReturnedCocoaObject);
+    const char* constructorTokens() const {
+        return this->_constructorTokens.valuePtr();
     }
 };
 

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -33,12 +33,6 @@ static UInt8 getSystemVersion() {
     return iosVersion;
 }
 
-static bool startsWith(const char* pre, const char* str) {
-    size_t lenpre = strlen(pre),
-           lenstr = strlen(str);
-    return lenstr < lenpre ? false : strncmp(pre, str, lenpre) == 0;
-}
-
 static int compareIdentifiers(const char* nullTerminated, const char* notNullTerminated, size_t length) {
     int result = strncmp(nullTerminated, notNullTerminated, length);
     return (result == 0) ? strlen(nullTerminated) - length : result;
@@ -131,7 +125,7 @@ vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>&
     if (firstInitIndex != -1) {
         for (int i = firstInitIndex; i < instanceMethods->count; i++) {
             const MethodMeta* method = instanceMethods.value()[i].valuePtr();
-            if (startsWith("init", method->jsName())) {
+            if (method->isInitializer()) {
                 container.push_back(method);
             } else {
                 break;


### PR DESCRIPTION
First this must be merged: https://github.com/NativeScript/ios-metadata-generator/pull/51
Fixes: https://github.com/NativeScript/ios-runtime/issues/504