### PR TITLE
Provide runtime implementation for source maps

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -14,6 +14,7 @@ set(HEADER_FILES
     inspector/GlobalObjectConsoleClient.h
     inspector/GlobalObjectDebuggerAgent.h
     inspector/GlobalObjectInspectorController.h
+    inspector/InspectorNetworkAgent.h
     inspector/InspectorPageAgent.h
     inspector/InspectorTimelineAgent.h
     inspector/MimeTypeHelper.h
@@ -102,6 +103,7 @@ set(SOURCE_FILES
     inspector/GlobalObjectConsoleClient.cpp
     inspector/GlobalObjectDebuggerAgent.cpp
     inspector/GlobalObjectInspectorController.cpp
+    inspector/InspectorNetworkAgent.cpp
     inspector/InspectorPageAgent.mm
     inspector/InspectorTimelineAgent.cpp
     inspector/SuppressAllPauses.cpp

--- a/src/NativeScript/inspector/CachedResource.h
+++ b/src/NativeScript/inspector/CachedResource.h
@@ -28,6 +28,8 @@ private:
 
     static Inspector::Protocol::Page::ResourceType resourceTypeByMimeType(WTF::String mimeType);
 };
+
+WTF::HashMap<WTF::String, Inspector::CachedResource>& cachedResources(NativeScript::GlobalObject&);
 }
 
 #endif

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
@@ -47,6 +47,7 @@
 #include "GlobalObjectConsoleClient.h"
 #include "InspectorPageAgent.h"
 #include "InspectorTimelineAgent.h"
+#include "InspectorNetworkAgent.h"
 #include "DomainInspectorAgent.h"
 
 #include <cxxabi.h>
@@ -102,6 +103,7 @@ GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& g
     auto debuggerAgent = std::make_unique<GlobalObjectDebuggerAgent>(m_jsAgentContext, consoleAgent.get());
     auto pageAgent = std::make_unique<InspectorPageAgent>(m_jsAgentContext);
     auto timelineAgent = std::make_unique<InspectorTimelineAgent>(m_jsAgentContext);
+    auto networkAgent = std::make_unique<InspectorNetworkAgent>(m_jsAgentContext);
 
     m_inspectorAgent = inspectorAgent.get();
     m_debuggerAgent = debuggerAgent.get();
@@ -115,6 +117,7 @@ GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& g
     m_agents.append(WTF::move(runtimeAgent));
     m_agents.append(WTF::move(consoleAgent));
     m_agents.append(WTF::move(debuggerAgent));
+    m_agents.append(WTF::move(networkAgent));
 
     m_executionStopwatch->start();
 }

--- a/src/NativeScript/inspector/InspectorNetworkAgent.cpp
+++ b/src/NativeScript/inspector/InspectorNetworkAgent.cpp
@@ -1,0 +1,43 @@
+#include "InspectorNetworkAgent.h"
+#include "CachedResource.h"
+
+namespace Inspector {
+InspectorNetworkAgent::InspectorNetworkAgent(JSAgentContext& context)
+    : Inspector::InspectorAgentBase(ASCIILiteral("Network"))
+    , m_globalObject(*JSC::jsCast<NativeScript::GlobalObject*>(&context.inspectedGlobalObject)) {
+}
+
+void InspectorNetworkAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter* frontendRouter, Inspector::BackendDispatcher* backendDispatcher) {
+    m_frontendDispatcher = std::make_unique<NetworkFrontendDispatcher>(*frontendRouter);
+    m_backendDispatcher = NetworkBackendDispatcher::create(*backendDispatcher, this);
+}
+
+void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {
+}
+
+void InspectorNetworkAgent::enable(ErrorString&) {
+}
+
+void InspectorNetworkAgent::disable(ErrorString&) {
+}
+
+void InspectorNetworkAgent::setExtraHTTPHeaders(ErrorString&, const Inspector::InspectorObject& headers) {
+}
+
+void InspectorNetworkAgent::getResponseBody(ErrorString&, const String& requestId, String* content, bool* base64Encoded) {
+}
+
+void InspectorNetworkAgent::setCacheDisabled(ErrorString&, bool cacheDisabled) {
+}
+
+void InspectorNetworkAgent::loadResource(ErrorString& errorString, const String& frameId, const String& urlString, Ref<LoadResourceCallback>&& callback) {
+    WTF::HashMap<WTF::String, Inspector::CachedResource>& cachedResources = Inspector::cachedResources(this->m_globalObject);
+    auto iterator = cachedResources.find(urlString);
+    if (iterator != cachedResources.end()) {
+        CachedResource& resource = iterator->value;
+        ErrorString out_error;
+        WTF::String content = resource.content(out_error);
+        callback->sendSuccess(content, resource.mimeType(), 200);
+    }
+}
+}

--- a/src/NativeScript/inspector/InspectorNetworkAgent.h
+++ b/src/NativeScript/inspector/InspectorNetworkAgent.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <JavaScriptCore/inspector/InspectorAgentBase.h>
+#include <JavaScriptCore/inspector/InspectorBackendDispatchers.h>
+#include <JavaScriptCore/inspector/InspectorFrontendDispatchers.h>
+
+namespace Inspector {
+class InspectorNetworkAgent final : public InspectorAgentBase, public Inspector::NetworkBackendDispatcherHandler {
+public:
+    InspectorNetworkAgent(JSAgentContext&);
+
+    virtual void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*) override;
+    virtual void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+
+    virtual void enable(ErrorString&) override;
+    virtual void disable(ErrorString&) override;
+    virtual void setExtraHTTPHeaders(ErrorString&, const Inspector::InspectorObject& headers) override;
+    virtual void getResponseBody(ErrorString&, const String& requestId, String* content, bool* base64Encoded) override;
+    virtual void setCacheDisabled(ErrorString&, bool cacheDisabled) override;
+    virtual void loadResource(ErrorString&, const String& frameId, const String& url, Ref<LoadResourceCallback>&&) override;
+
+private:
+    NativeScript::GlobalObject& m_globalObject;
+    std::unique_ptr<NetworkFrontendDispatcher> m_frontendDispatcher;
+    RefPtr<NetworkBackendDispatcher> m_backendDispatcher;
+};
+}

--- a/src/NativeScript/inspector/InspectorPageAgent.h
+++ b/src/NativeScript/inspector/InspectorPageAgent.h
@@ -53,8 +53,6 @@ private:
     NativeScript::GlobalObject& m_globalObject;
     std::unique_ptr<PageFrontendDispatcher> m_frontendDispatcher;
     RefPtr<PageBackendDispatcher> m_backendDispatcher;
-
-    WTF::HashMap<WTF::String, Inspector::CachedResource>& cachedResources();
 };
 }
 


### PR DESCRIPTION
This is necessary for the scenarios where somebody wants to use the runtime without the modules. This agent will be overridden when the modules provide custom network domain implementation