### PR TITLE
Remove CocoaPods .xcconfig file #includes

### DIFF
--- a/build/project-template/__PROJECT_NAME__/build-debug.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build-debug.xcconfig
@@ -1,3 +1,2 @@
 #include "build.xcconfig"
-#include "Pods/Target Support Files/Pods/Pods.debug.xcconfig"
 #include "../plugins-debug.xcconfig"

--- a/build/project-template/__PROJECT_NAME__/build-release.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build-release.xcconfig
@@ -1,3 +1,2 @@
 #include "build.xcconfig"
-#include "Pods/Target Support Files/Pods/Pods.release.xcconfig"
 #include "../plugins-release.xcconfig"


### PR DESCRIPTION
The CLI already takes care to include these files' contents inside `plugins-debug` and `plugins-release` xcconfig files, so these includes are gratuitous. Moreover due to an [issue with CocoaPods 1.0.0](https://github.com/NativeScript/nativescript-cli/issues/1611), the referenced CocoaPods .xcconfig file path is wrong.

Ping @jasssonpet @KristinaKoeva 