### PR TITLE
Update metadata generator to use LLVM 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ git clone --recursive git@github.com:NativeScript/ios-runtime.git
  - OS X 10.10.3+
  - [Xcode 7+](https://developer.apple.com/xcode/)
  - [CMake 3.1.3](http://www.cmake.org/) - It is available in [Homebrew](http://brew.sh) as `homebrew/versions/cmake31`.
- - [llvm 3.7](http://www.llvm.org/releases/download.html#3.7.0) - used to build the [metadata generator](https://github.com/NativeScript/ios-metadata-generator) submodule. Be sure to have `llvm-config` in `PATH` or otherwise export the `LLVM_CONFIG_PATH` environment variable to point to the folder that contains it.
+ - [llvm 3.8](http://www.llvm.org/releases/download.html#3.8.0) - used to build the [metadata generator](https://github.com/NativeScript/ios-metadata-generator) submodule. Be sure to have `llvm-config` in `PATH` or otherwise export the `LLVM_CONFIG_PATH` environment variable to point to the folder that contains it.
  - [Automake](https://www.gnu.org/software/automake/) - available in [Homebrew](http://brew.sh) as `automake`
  - [GNU Libtool](http://www.gnu.org/software/libtool/) - available in [Homebrew](http://brew.sh) as `libtool`
 


### PR DESCRIPTION
Fixes: https://github.com/NativeScript/ios-runtime/issues/546
The PR will be merged after all build machines are updated to llvm 3.8. 

To update to llvm 3.8:
1. Download the [pre-build binary of Clang for Mac OS X](http://www.llvm.org/releases/download.html#3.8.0).
2. Extract the content of the package (`/usr/local/lib` is a good candidate for a destination folder)
3. Include the path to `{llvm-root}/bin/llvm-config` or symlink to it in your `PATH`
4. Reset the cmake cache of the metadata generator project. This way the generator will be linked with the new version of Clang/LLVM.