### PR TITLE
Remove NativeScript static library from the distributed package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-iphoneos;-iphonesimulator;-macosx")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "NO")
 set(CMAKE_OSX_SYSROOT $(PLATFORM_NAME))
 
-set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "7.0")
+set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "8.0")
 
 # TODO: Versions, license, etc
 
@@ -30,9 +30,6 @@ execute_process(
 )
 
 # TODO: Clang Analyzer, Tidy ...
-
-option(BUILD_SHARED_LIBS "Build NativeScript as a Cocoa Framework" OFF)
-option(EMBED_STATIC_DEPENDENCIES "Embed JavaScriptCore and libffi in the NativeScript static library" OFF)
 
 include(src/WebKit.cmake)
 include(src/MetadataGenerator.cmake)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone --recursive git@github.com:NativeScript/ios-runtime.git
  - [GNU Libtool](http://www.gnu.org/software/libtool/) - available in [Homebrew](http://brew.sh) as `libtool`
 
 ## Building
-Run `build/scripts/build.sh` in the root of the repository. This will produce a static library and Cocoa Framework versions of the iOS runtime and a build of the metadata generator and place them in the `dist` folder. The script depends on the repo's git submodules, so if you run into issues make sure to update them using `git submodule update --init`.
+Run `build/scripts/build.sh` in the root of the repository. This will produce a Cocoa Framework version of the iOS runtime and a build of the metadata generator and place them in the `dist` folder. The script depends on the repo's git submodules, so if you run into issues make sure to update them using `git submodule update --init`.
 
 ## Creating an Xcode Project
 ```shell
@@ -23,7 +23,7 @@ cmake .. -G Xcode
 
 ## NPM Package
 
-To build the npm package run ```sh build/script/build-runtime.sh``` in the **root** of the repository. This should produce a `dist/tns-ios-*.tgz` file, which should contain the NativeScript static library and Cocoa Framework, the NativeScript CLI template project, the API metadata generator and the Web Inspector frontend.
+To build the npm package run ```sh build/script/build-runtime.sh``` in the **root** of the repository. This should produce a `dist/tns-ios-*.tgz` file, which should contain the Cocoa Framework, the NativeScript CLI template project, the API metadata generator and the Web Inspector frontend.
 
 ## Tests
 To run the tests build and run the TestRunner target from the generated Xcode project as described above.

--- a/build/project-template/internal/nativescript-build.xcconfig
+++ b/build/project-template/internal/nativescript-build.xcconfig
@@ -1,7 +1,7 @@
 // * NativeScript build related flags
 // * Add [sdk=*] after each one to avoid conflict with CocoaPods flags
 HEADER_SEARCH_PATHS[sdk=*] = $(inherited) "$(SRCROOT)/internal" "$(SRCROOT)/internal/NativeScript/include"
-OTHER_LDFLAGS[sdk=*] = $(inherited) -ObjC -sectcreate __DATA __TNSMetadata "$(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin" -lNativeScript -L"$(SRCROOT)/internal/NativeScript/lib" -licucore -lz -lc++ -framework Foundation -framework UIKit -framework CoreGraphics -framework MobileCoreServices -framework Security
+OTHER_LDFLAGS[sdk=*] = $(inherited) -ObjC -sectcreate __DATA __TNSMetadata "$(CONFIGURATION_BUILD_DIR)/metadata-$(CURRENT_ARCH).bin" -framework NativeScript -F"$(SRCROOT)/internal/NativeScript" -licucore -lz -lc++ -framework Foundation -framework UIKit -framework CoreGraphics -framework MobileCoreServices -framework Security
 
 // TODO: Move this to the CLI
 OTHER_LDFLAGS[config=Debug] = -framework TKLiveSync -F$(SRCROOT)/internal/

--- a/build/project-template/internal/nativescript-post-build
+++ b/build/project-template/internal/nativescript-post-build
@@ -9,6 +9,8 @@ else
     rm -rf "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/TKLiveSync.framework"
 fi
 
+rsync -a "${SRCROOT}/internal/NativeScript/NativeScript.framework" "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
+
 pushd "$SRCROOT/internal"
 ./strip-dynamic-framework-architectures.sh
 popd

--- a/build/scripts/build-runtime.sh
+++ b/build/scripts/build-runtime.sh
@@ -17,10 +17,7 @@ cp -R "$DIST_DIR/TKLiveSync.framework" "$INTERNAL_DIR"
 
 . "$WORKSPACE/build/scripts/build.sh"
 
-mkdir -p "$INTERNAL_DIR/NativeScript/Frameworks"
-
-cp -R "$DIST_DIR/NativeScript/" "$INTERNAL_DIR/NativeScript"
-cp -R "$DIST_DIR/NativeScript.framework" "$INTERNAL_DIR/NativeScript/Frameworks"
+cp -R "$DIST_DIR/NativeScript.framework" "$INTERNAL_DIR/NativeScript"
 cp -R "$WORKSPACE/src/debugging/TNSDebugging.h" "$INTERNAL_DIR"
 cp -R "$WORKSPACE/src/NativeScript/ObjC/TNSExceptionHandler.h" "$INTERNAL_DIR"
 cp -R "$DIST_DIR/metadataGenerator" "$INTERNAL_DIR/metadata-generator"

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -21,7 +21,7 @@ echo "Building NativeScript.framework..."
 rm -f CMakeCache.txt
 rm -f "$WORKSPACE/build.log"
 echo -e "\tConfiguring..."
-cmake .. $CMAKE_FLAGS -DBUILD_SHARED_LIBS=ON 2>&1 | tee -a "$WORKSPACE/build.log"
+cmake .. $CMAKE_FLAGS 2>&1 | tee -a "$WORKSPACE/build.log"
 echo -e "\tiPhoneOS..."
 xcodebuild_pretty -configuration Release -sdk iphoneos -target NativeScript
 echo -e "\tiPhoneSimulator..."
@@ -35,31 +35,6 @@ lipo -create -output "$WORKSPACE/dist/NativeScript.framework/NativeScript" \
     "$WORKSPACE/cmake-build/src/NativeScript/Release-iphonesimulator/NativeScript.framework/NativeScript" \
     "$WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/NativeScript.framework/NativeScript" \
          >> "$WORKSPACE/build.log" 2>&1
-
-echo "Building libNativeScript..."
-rm -f CMakeCache.txt
-echo -e "\tConfiguring..."
-cmake .. $CMAKE_FLAGS -DEMBED_STATIC_DEPENDENCIES=ON 2>&1 | tee -a "$WORKSPACE/build.log"
-echo -e "\tiPhoneOS..."
-xcodebuild_pretty -configuration Release -sdk iphoneos -target NativeScript
-echo -e "\tiPhoneSimulator..."
-xcodebuild_pretty -configuration Release -sdk iphonesimulator -target NativeScript
-
-echo "Packaging libNativeScript..."
-mkdir -p "$WORKSPACE/dist/NativeScript/lib"
-lipo -create -output "$WORKSPACE/dist/NativeScript/lib/libNativeScript.a" \
-    "$WORKSPACE/cmake-build/src/NativeScript/Release-iphonesimulator/libNativeScript.a" \
-    "$WORKSPACE/cmake-build/src/NativeScript/Release-iphoneos/libNativeScript.a" \
-         >> "$WORKSPACE/build.log" 2>&1
-
-mkdir -p "$WORKSPACE/dist/NativeScript/include"
-NATIVESCRIPT_DIR="$WORKSPACE/src/NativeScript/"
-cp \
-    "$NATIVESCRIPT_DIR/NativeScript.h" \
-    "$NATIVESCRIPT_DIR/TNSRuntime.h" \
-    "$NATIVESCRIPT_DIR/TNSRuntime+Diagnostics.h" \
-    "$NATIVESCRIPT_DIR/TNSRuntime+Inspector.h" \
-    "$WORKSPACE/dist/NativeScript/include"
 
 echo "Building objc-metadata-generator..."
 xcodebuild_pretty -configuration Release -target MetadataGenerator

--- a/cmake/CreateNativeScriptApp.cmake
+++ b/cmake/CreateNativeScriptApp.cmake
@@ -13,18 +13,6 @@ function(CreateNativeScriptApp _target _main _plist _resources)
         NativeScript
     )
 
-    if(NOT ${BUILD_SHARED_LIBS})
-        target_link_libraries(${_target}
-            libicucore.dylib
-            libz.dylib
-            libc++.dylib
-        )
-
-        if(NOT ${EMBED_STATIC_DEPENDENCIES})
-            target_link_libraries(${_target} ${WEBKIT_LIBRARIES} ffi)
-        endif()
-    endif()
-
     set_target_properties(${_target} PROPERTIES
         MACOSX_BUNDLE YES
         MACOSX_BUNDLE_INFO_PLIST "${_plist}"

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -188,7 +188,7 @@ set(JSFILES
 include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/**" "${LIBFFI_INCLUDE_DIR}" "${WEBKIT_INCLUDE_DIRECTORIES}")
 link_directories("${LIBFFI_LIB_DIR}" ${WEBKIT_LINK_DIRECTORIES})
 
-add_library(NativeScript ${SOURCE_FILES} ${HEADER_FILES} ${JSFILES})
+add_library(NativeScript SHARED ${SOURCE_FILES} ${HEADER_FILES} ${JSFILES})
 
 add_dependencies(NativeScript WebKit libffi)
 
@@ -202,37 +202,24 @@ set_target_properties(NativeScript PROPERTIES
 
 target_compile_definitions(NativeScript PUBLIC "NATIVESCRIPT_VERSION=${NATIVESCRIPT_VERSION}")
 
-if(${BUILD_SHARED_LIBS})
-    set_target_properties(NativeScript PROPERTIES
-        FRAMEWORK TRUE
-        FRAMEWORK_VERSION "1.0" # TODO
-        PUBLIC_HEADER "${NativeScript_PUBLIC_HEADERS}"
-        INSTALL_NAME_DIR "@executable_path/Frameworks"
-        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
-        MACOSX_FRAMEWORK_IDENTIFIER "org.nativescript.NativeScript"
-    )
-    target_link_libraries(NativeScript
-        ${WEBKIT_LIBRARIES}
-        ffi
-        libicucore.dylib
-        libz.dylib
-        libc++.dylib
-        "-framework UIKit"
-        "-framework MobileCoreServices"
-        "-framework Security"
-    )
-elseif(${EMBED_STATIC_DEPENDENCIES})
-    foreach(_directory ${WEBKIT_LINK_DIRECTORIES})
-        set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${_directory}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)")
-    endforeach()
-    foreach(_library ${WEBKIT_LIBRARIES})
-        set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -l${_library}")
-    endforeach()
-
-    set_target_properties(NativeScript PROPERTIES
-        STATIC_LIBRARY_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${LIBFFI_LIB_DIR} -lffi"
-    )
-endif()
+set_target_properties(NativeScript PROPERTIES
+    FRAMEWORK TRUE
+    # FRAMEWORK_VERSION "1.0" # TODO
+    PUBLIC_HEADER "${NativeScript_PUBLIC_HEADERS}"
+    INSTALL_NAME_DIR "@executable_path/Frameworks"
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer"
+    MACOSX_FRAMEWORK_IDENTIFIER "org.nativescript.NativeScript"
+)
+target_link_libraries(NativeScript
+    ${WEBKIT_LIBRARIES}
+    ffi
+    libicucore.dylib
+    libz.dylib
+    libc++.dylib
+    "-framework UIKit"
+    "-framework MobileCoreServices"
+    "-framework Security"
+)
 
 include(EmbedResourceInHeader)
 foreach(_jsfile ${JSFILES})


### PR DESCRIPTION
Status: Work in progress
This PR removes the NativeScript static library from the ios runtime package. This way the package size will be decreased with 67MB.

Don't forget to:
- [ ] Update documentation where needed

Closes https://github.com/NativeScript/ios-runtime/issues/162
