### PR TITLE
Mock the usage of unorm_normalize in Webkit without modifing StringPrototype.cpp

### DIFF
--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -417,6 +417,11 @@ describe(module.id, function () {
 
         expect(actual).toEqual(expected);
     });
+    
+    it("should be able to call string.normalize with simple value", function () {
+        var str = 'string value';
+        expect(str.normalize()).toBe(str);
+    });
 
     describe("async", function () {
         it("should work", function (done) {


### PR DESCRIPTION
Related to: https://github.com/NativeScript/webkit/pull/4