### PR TITLE
Fix debugging for code that was already executed

### DIFF
--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -140,6 +140,10 @@ public:
         return this->_microtaskRunLoopSource.get();
     }
 
+    CFRunLoopObserverRef runLoopBeforeWaitingObserver() const {
+        return this->_runLoopBeforeWaitingObserver.get();
+    }
+
     std::list<WTF::RetainPtr<CFRunLoopRef>>& microtaskRunLoops() {
         return this->_microtaskRunLoops;
     }
@@ -192,6 +196,7 @@ private:
 
     std::list<WTF::RetainPtr<CFRunLoopRef>> _microtaskRunLoops;
     WTF::RetainPtr<CFRunLoopSourceRef> _microtaskRunLoopSource;
+    WTF::RetainPtr<CFRunLoopObserverRef> _runLoopBeforeWaitingObserver;
 
     JSC::WriteBarrier<FFICallPrototype> _ffiCallPrototype;
     JSC::WriteBarrier<JSC::Structure> _objCMethodCallStructure;

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -76,13 +76,17 @@ using namespace NativeScript;
 }
 
 - (void)scheduleInRunLoop:(NSRunLoop*)runLoop forMode:(NSString*)mode {
-    CFRunLoopAddSource(runLoop.getCFRunLoop, self->_globalObject->microtaskRunLoopSource(), (CFStringRef)mode);
-    self->_globalObject->microtaskRunLoops().push_back(WTF::retainPtr(runLoop.getCFRunLoop));
+    CFRunLoopRef cfRunLoop = runLoop.getCFRunLoop;
+    CFRunLoopAddSource(cfRunLoop, self->_globalObject->microtaskRunLoopSource(), (CFStringRef)mode);
+    CFRunLoopAddObserver(cfRunLoop, self->_globalObject->runLoopBeforeWaitingObserver(), (CFStringRef)mode);
+    self->_globalObject->microtaskRunLoops().push_back(WTF::retainPtr(cfRunLoop));
 }
 
 - (void)removeFromRunLoop:(NSRunLoop*)runLoop forMode:(NSString*)mode {
-    CFRunLoopRemoveSource(runLoop.getCFRunLoop, self->_globalObject->microtaskRunLoopSource(), (CFStringRef)mode);
-    self->_globalObject->microtaskRunLoops().remove(WTF::retainPtr(runLoop.getCFRunLoop));
+    CFRunLoopRef cfRunLoop = runLoop.getCFRunLoop;
+    CFRunLoopRemoveSource(cfRunLoop, self->_globalObject->microtaskRunLoopSource(), (CFStringRef)mode);
+    CFRunLoopRemoveObserver(cfRunLoop, self->_globalObject->runLoopBeforeWaitingObserver(), (CFStringRef)mode);
+    self->_globalObject->microtaskRunLoops().remove(WTF::retainPtr(cfRunLoop));
 }
 
 - (JSGlobalContextRef)globalContext {


### PR DESCRIPTION
Typical iOS application is always in an entry scope, because the UIApplicationMain method never finishes. On debugger attach the debugger agent tries to recreate the bytecode so that it could insert all opt debug codes. Since the vm is in an entry scope the recreation never happens. So to workaround this problem we execute all listeners when the run loop is idle and if the current entry scope is the UIApplicationMain

Fixes #315 