### PR TITLE
Open stdout and stderr as text files regardless of python version

### DIFF
--- a/build/scripts/metadata-generation-build-step
+++ b/build/scripts/metadata-generation-build-step
@@ -79,7 +79,7 @@ def generate_metadata(arch):
     generator_call.extend(other_cflags_parsed)  # OTHER_CFLAGS
     generator_call.extend(preprocessor_defs_parsed)  # GCC_PREPROCESSOR_DEFINITIONS
 
-    child_process = subprocess.Popen(generator_call, stderr=subprocess.PIPE)
+    child_process = subprocess.Popen(generator_call, stderr=subprocess.PIPE, universal_newlines=True)
     sys.stdout.flush()
     error_stream_content = child_process.communicate()[1]
 


### PR DESCRIPTION
Fixes #563 