### PR TITLE
Fix subsequent debugger sessions crash the app

### DIFF
--- a/src/NativeScript/inspector/DomainInspectorAgent.cpp
+++ b/src/NativeScript/inspector/DomainInspectorAgent.cpp
@@ -14,6 +14,9 @@ void DomainInspectorAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter
 
 void DomainInspectorAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {
     m_domainBackendDispatcher = nullptr;
+}
+
+void DomainInspectorAgent::discardAgent() {
     m_constructorFunction.clear();
 }
 }

--- a/src/NativeScript/inspector/DomainInspectorAgent.h
+++ b/src/NativeScript/inspector/DomainInspectorAgent.h
@@ -15,6 +15,7 @@ public:
 
     virtual void didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher*) override;
     virtual void willDestroyFrontendAndBackend(Inspector::DisconnectReason) override;
+    virtual void discardAgent() override;
 
 private:
     Inspector::JSAgentContext& m_context;


### PR DESCRIPTION
willDestroyFrontendAndBackend is called when the debugger detaches from the application. m_constructorFunction is needed for every subsequent debugger session so clear it when the GlobalObjectInspectorController is released

Fixes #575