### PR TITLE
Sign frameworks for iOS simulator

### DIFF
--- a/build/project-template/internal/strip-dynamic-framework-architectures.sh
+++ b/build/project-template/internal/strip-dynamic-framework-architectures.sh
@@ -61,7 +61,7 @@ for file in $(find . -type f); do
   done
   if [[ "$stripped" != "" ]]; then
     echo "Stripped $file of architectures:$stripped"
-    if [ "${CODE_SIGNING_REQUIRED}" == "YES" ]; then
+    if [ "${CODE_SIGNING_ALLOWED}" == "YES" ]; then
       code_sign "${file}"
     fi
   fi


### PR DESCRIPTION
It seems that in Xcode beta 4 it is required to sign the application and frameworks when building for iOS simulator platform. Otherwise the app crashes at runtime.

Xcode 7.3 settings:
```shell
$ xcodebuild -sdk "iphoneos" -showBuildSettings | grep "CODE_SIGN"
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_IDENTITY = iPhone Developer
$ xcodebuild -sdk "iphonesimulator" -showBuildSettings | grep "CODE_SIGN"
    CODE_SIGNING_ALLOWED = NO
```

Xcode 8 - beta 4 settings:
```shell
$ xcodebuild -sdk "iphoneos" -showBuildSettings | grep "CODE_SIGN"
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGNING_REQUIRED = YES
    CODE_SIGN_IDENTITY = iPhone Developer
$ xcodebuild -sdk "iphonesimulator" -showBuildSettings | grep "CODE_SIGN"
    CODE_SIGNING_ALLOWED = YES
    CODE_SIGN_IDENTITY = -
```