### PR TITLE
Fix struct marshalling by using libffi calculations

### DIFF
--- a/src/NativeScript/Calling/FFICall.h
+++ b/src/NativeScript/Calling/FFICall.h
@@ -34,6 +34,8 @@ protected:
 
     ~FFICall();
 
+    ffi_cif* _cif;
+
     class Invocation {
         WTF_MAKE_NONCOPYABLE(Invocation)
         WTF_MAKE_FAST_ALLOCATED;
@@ -133,8 +135,6 @@ protected:
     WTF::Vector<FFITypeMethodTable> _parameterTypes;
 
     size_t _initialArgumentIndex;
-
-    ffi_cif* _cif;
 
     size_t _argsCount;
     size_t _stackSize;

--- a/tests/TestFixtures/Marshalling/TNSRecords.h
+++ b/tests/TestFixtures/Marshalling/TNSRecords.h
@@ -11,6 +11,24 @@ typedef struct TNSSimpleStruct {
     int y;
 } TNSSimpleStruct;
 
+typedef struct TNSStruct16 {
+    int64_t x;
+    int32_t y;
+    int32_t z;
+} TNSStruct16;
+
+typedef struct TNSStruct24 {
+    int64_t x;
+    int32_t y;
+    int64_t z;
+} TNSStruct24;
+
+typedef struct TNSStruct32 {
+    int64_t x;
+    int64_t y;
+    int64_t z;
+} TNSStruct32;
+
 typedef struct TNSNestedStruct {
     struct TNSSimpleStruct a;
     struct TNSSimpleStruct b;

--- a/tests/TestFixtures/TNSTestNativeCallbacks.h
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.h
@@ -48,6 +48,12 @@
 
 + (TNSSimpleStruct)recordsSimpleStruct:(TNSSimpleStruct)object;
 
++ (TNSStruct16)recordsStruct16:(TNSStruct16)object;
+
++ (TNSStruct24)recordsStruct24:(TNSStruct24)object;
+
++ (TNSStruct32)recordsStruct32:(TNSStruct32)object;
+
 + (TNSNestedStruct)recordsNestedStruct:(TNSNestedStruct)object;
 
 + (TNSStructWithArray)recordsStructWithArray:(TNSStructWithArray)object;

--- a/tests/TestFixtures/TNSTestNativeCallbacks.m
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.m
@@ -242,6 +242,21 @@
     return object;
 }
 
++ (TNSStruct16)recordsStruct16:(TNSStruct16)object {
+    TNSLog([NSString stringWithFormat:@"%lld %d %d", object.x, object.y, object.z]);
+    return object;
+}
+
++ (TNSStruct24)recordsStruct24:(TNSStruct24)object {
+    TNSLog([NSString stringWithFormat:@"%lld %d %lld", object.x, object.y, object.z]);
+    return object;
+}
+
++ (TNSStruct32)recordsStruct32:(TNSStruct32)object {
+    TNSLog([NSString stringWithFormat:@"%lld %lld %lld", object.x, object.y, object.z]);
+    return object;
+}
+
 + (TNSNestedStruct)recordsNestedStruct:(TNSNestedStruct)object {
     TNSLog([NSString stringWithFormat:@"%d %d %d %d", object.a.x, object.a.y, object.b.x, object.b.y]);
     return object;

--- a/tests/TestRunner/app/Marshalling/RecordTests.js
+++ b/tests/TestRunner/app/Marshalling/RecordTests.js
@@ -97,6 +97,39 @@ describe(module.id, function () {
         expect(result.y).toBe(object.y);
     });
 
+    it("recordsStruct16", function() {
+        var object = { x: 1, y: 2, z: 3 };
+
+        var result = TNSTestNativeCallbacks.recordsStruct16(object);
+        expect(TNSGetOutput()).toBe('1 2 3');
+
+        expect(result.x).toBe(object.x);
+        expect(result.y).toBe(object.y);
+        expect(result.z).toBe(object.z);
+    });
+
+    it("recordsStruct24", function() {
+        var object = { x: 1, y: 2, z: 3 };
+
+        var result = TNSTestNativeCallbacks.recordsStruct24(object);
+        expect(TNSGetOutput()).toBe('1 2 3');
+
+        expect(result.x).toBe(object.x);
+        expect(result.y).toBe(object.y);
+        expect(result.z).toBe(object.z);
+    });
+
+    it("recordsStruct32", function() {
+        var object = { x: 1, y: 2, z: 3 };
+
+        var result = TNSTestNativeCallbacks.recordsStruct32(object);
+        expect(TNSGetOutput()).toBe('1 2 3');
+
+        expect(result.x).toBe(object.x);
+        expect(result.y).toBe(object.y);
+        expect(result.z).toBe(object.z);
+    });
+
     it("InvalidStruct", function () {
         expect(function() {
             TNSTestNativeCallbacks.recordsSimpleStruct(3);


### PR DESCRIPTION
Tested on all 4 architectures. The tests should catch regressions.

Close #622 