### PR TITLE
Generate debug symbols for the libffi target by default

### DIFF
--- a/src/libffi.cmake
+++ b/src/libffi.cmake
@@ -9,3 +9,7 @@ add_custom_target(libffi
 
 include(SetActiveArchitectures)
 SetActiveArchitectures(libffi)
+
+set_target_properties(libffi PROPERTIES
+    XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYMBOLS[variant=Debug] YES
+)


### PR DESCRIPTION
This allows debugging libffi source:
<img width="1051" alt="This allows debugging libffi source" src="https://cloud.githubusercontent.com/assets/305639/17852438/102f605e-6870-11e6-81bb-0ac23a9a3b0b.png">

https://github.com/NativeScript/ios-runtime/blob/da8f70c76170e38fe300327a9a6831665cc469e1/build/scripts/build-libffi.sh#L39-L41