### PR TITLE
Build test app in release config

### DIFF
--- a/build/scripts/build-testrunner-application.sh
+++ b/build/scripts/build-testrunner-application.sh
@@ -3,6 +3,8 @@
 set -e
 set -o pipefail
 
+CONFIGURATION="Release"
+
 source "$(dirname "$0")/common.sh"
 
 checkpoint "Building TestRunner application"
@@ -12,15 +14,13 @@ mkdir -p "$WORKSPACE/cmake-build" && pushd "$_"
 # When using CMake 3.1 (which we have to) there is a bug that prevents building applications that link with a shared framework.
 rm -f "CMakeCache.txt"
 cmake .. -G"Xcode"
-# We are building in Debug configuration to trigger any failing asserts in our CI.
-# This also builds the metadata generator in debug mode.
-xcodebuild -configuration "Debug" -sdk "iphoneos" -target "TestRunner" ARCHS="armv7 arm64" ONLY_ACTIVE_ARCH="NO" -quiet
+xcodebuild -configuration "$CONFIGURATION" -sdk "iphoneos" -target "TestRunner" ARCHS="armv7 arm64" ONLY_ACTIVE_ARCH="NO" -quiet
 popd
 
 checkpoint "Packaging TestRunner"
 xcrun -sdk "iphoneos" PackageApplication \
-    "$WORKSPACE/cmake-build/tests/TestRunner/Debug-iphoneos/TestRunner.app" \
-    -o "$WORKSPACE/cmake-build/tests/TestRunner/Debug-iphoneos/TestRunner.ipa"
-cp "$WORKSPACE/cmake-build/tests/TestRunner/Debug-iphoneos/TestRunner.ipa" "$DIST_DIR"
+    "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.app" \
+    -o "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.ipa"
+cp "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.ipa" "$DIST_DIR"
 
 checkpoint "Finished building TestRunner application - $DIST_DIR/TestRunner.ipa"


### PR DESCRIPTION
Reuse the release config runtime cache to speed up the builds.

This will remove all asserts that are enabled in debug config only from the runtime and it's dependencies (metadata generator, WebKit, libffi).