### PR TITLE
Prevent crashing in StackVisitor::readFrame if built in release

### DIFF
--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.mm
@@ -38,7 +38,7 @@ void NSErrorWrapperConstructor::visitChildren(JSCell* cell, SlotVisitor& slotVis
 }
 
 ErrorInstance* NSErrorWrapperConstructor::createError(ExecState* execState, NSError* error) const {
-    ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, error.localizedDescription));
+    ErrorInstance* wrappedError = ErrorInstance::create(execState, this->errorStructure(), jsString(execState, error.localizedDescription), nullptr, TypeNothing, false);
     wrappedError->putDirect(execState->vm(), Identifier::fromString(execState, "error"), NativeScript::toValue(execState, error));
 
     return wrappedError;


### PR DESCRIPTION
After [updating webkit](https://github.com/NativeScript/ios-runtime/pull/671) the runtime started to crash randomly in `StackVisitor::readFrame` in case it is built for release. It seems that the top frame of the call stack is the buggy one which causes the crash. Setting `useCurrentFrame` to `false` on error creation skips the top call frame(the buggy one) when constructing the call stack. Although the crash appears only in release, we skip the top call frame for both debug and release in order to keep having the same behaviour in both configurations.