### PR TITLE
Initialize the code block when fakeExecState is created

### DIFF
--- a/src/NativeScript/Calling/FFICall.cpp
+++ b/src/NativeScript/Calling/FFICall.cpp
@@ -121,6 +121,7 @@ JSObject* FFICall::async(ExecState* execState, JSValue thisValue, const ArgList&
     fakeExecState->setArgumentCountIncludingThis(arguments.size() + 1);
     fakeExecState->setCallee(this);
     fakeExecState->setThisValue(thisValue);
+    fakeExecState->setCodeBlock(nullptr);
     fakeExecState->setCallerFrame(execState->callerFrame());
     for (size_t i = 0; i < arguments.size(); i++) {
         fakeExecState->setArgument(i, arguments.at(i));


### PR DESCRIPTION
Sometimes in Release builds the code block gets some random values which causes unexpected crashes. So initialize the code block with a default value.