### PR TITLE
Call original domain dispatcher methods when there is no custom implementation

### DIFF
--- a/src/NativeScript/inspector/DomainBackendDispatcher.h
+++ b/src/NativeScript/inspector/DomainBackendDispatcher.h
@@ -14,6 +14,7 @@ public:
 private:
     DomainBackendDispatcher(WTF::String domain, JSC::JSCell* constructorFunction, Inspector::JSAgentContext&);
 
+    RefPtr<SupplementalBackendDispatcher> m_duplicatedDispatcher;
     JSC::JSGlobalObject& m_globalObject;
     JSC::Strong<JSC::JSObject> m_domainDispatcher;
 };


### PR DESCRIPTION
Chrome dev tools calls Runtime.compile method which does not exist on the current webkit Runtime agent. So instead of moving the Runtime agent to our side, enable having one native and one javascript implementation

Merge with: https://github.com/NativeScript/webkit/pull/15