### PR TITLE
Update TypeScript extends empty constructor regex

### DIFF
--- a/src/NativeScript/ObjC/Inheritance/ObjCTypeScriptExtend.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCTypeScriptExtend.mm
@@ -31,7 +31,8 @@ static bool isPlainTypeScriptConstructor(JSFunction* typeScriptConstructor) {
 
     NSArray* regularExpressions = @[
         @"^\\(\\)\\s?\\{\\s?\\}$",
-        @"^\\(\\)\\s?\\{\\s?\\w+\\.apply\\(this,\\s?arguments\\);?\\s?\\}$"
+        @"^\\(\\)\\s?\\{\\s?\\w+\\.apply\\(this,\\s?arguments\\);?\\s?\\}$",
+        @"^\\(\\)\\s?\\{\\s?\\w+\\.apply\\(this,\\s?arguments\\)\\s?||\\s?this;?\\s?\\}$"
     ];
 
     NSUInteger index = [regularExpressions indexOfObjectPassingTest:^BOOL(id obj, NSUInteger idx, BOOL* stop) {


### PR DESCRIPTION
TypeScript 2.1 generates a constructor of the following type:
```javascript
return _super.apply(this, arguments) || this;
```