### PR TITLE
GlobalObjectInspectorController::reportAPIException logs to DevTools Log agent

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
@@ -122,7 +122,8 @@ GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& g
     m_inspectorAgent = inspectorAgent.get();
     m_debuggerAgent = debuggerAgent.get();
     m_consoleAgent = consoleAgent.get();
-    m_consoleClient = std::make_unique<GlobalObjectConsoleClient>(m_consoleAgent, logAgent.get());
+    m_logAgent = logAgent.get();
+    m_consoleClient = std::make_unique<GlobalObjectConsoleClient>(m_consoleAgent, m_logAgent);
 
     m_agents.append(WTFMove(inspectorAgent));
     m_agents.append(WTFMove(pageAgent));
@@ -260,6 +261,7 @@ void GlobalObjectInspectorController::reportAPIException(ExecState* exec, Except
     }
 
     m_consoleAgent->addMessageToConsole(std::make_unique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage, callStack));
+    m_logAgent->addMessageToConsole(std::make_unique<ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage, callStack));
 }
 
 bool GlobalObjectInspectorController::developerExtrasEnabled() const {

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.h
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.h
@@ -45,6 +45,7 @@ class FrontendChannel;
 class InjectedScriptManager;
 class InspectorAgent;
 class InspectorConsoleAgent;
+class InspectorLogAgent;
 class InspectorDebuggerAgent;
 class InspectorTimelineAgent;
 class JSGlobalObjectConsoleClient;
@@ -146,6 +147,7 @@ private:
     Inspector::AgentRegistry m_agents;
     Inspector::InspectorAgent* m_inspectorAgent{ nullptr };
     Inspector::InspectorConsoleAgent* m_consoleAgent{ nullptr };
+    Inspector::InspectorLogAgent* m_logAgent{ nullptr };
     Inspector::InspectorDebuggerAgent* m_debuggerAgent{ nullptr };
     Inspector::InspectorTimelineAgent* m_timelineAgent{ nullptr };
 


### PR DESCRIPTION
<img width="722" alt="Error reported in Chrome DevTools console" src="https://cloud.githubusercontent.com/assets/305639/21981046/58f0a856-dbee-11e6-9055-a92b0af50a02.png">

Additionally, there are other places where the `ConsoleAgent` is used directly or the `ConsoleClient` is not reporting to the `LogAgent` and these will be addressed in the master branch for the next release.