### PR TITLE
Change executionContextId assert to know of Chrome DevTools

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectDebuggerAgent.mm
+++ b/src/NativeScript/inspector/GlobalObjectDebuggerAgent.mm
@@ -142,10 +142,7 @@ void GlobalObjectDebuggerAgent::setScriptSource(Inspector::ErrorString& error, c
 }
 
 InjectedScript GlobalObjectDebuggerAgent::injectedScriptForEval(ErrorString& error, const int* executionContextId) {
-    if (executionContextId) {
-        error = ASCIILiteral("Execution context id is not supported for JSContext inspection as there is only one execution context.");
-        return InjectedScript();
-    }
+    ASSERT_UNUSED(executionContextId, (!executionContextId || *executionContextId == 1));
 
     ExecState* exec = static_cast<JSGlobalObjectScriptDebugServer&>(scriptDebugServer()).globalObject().globalExec();
     return injectedScriptManager().injectedScriptFor(exec);


### PR DESCRIPTION
These assertions fail when evaluating in the console when not on a breakpoint.

Assert that `executionContextId` is unused when debugging with Web Inspector and is equal to 1 when debugging with Chrome DevTools.

https://github.com/NativeScript/NativeScript/blob/0bb51e60653a865921f12a70c60c6671582a99a5/tns-core-modules/debugger/webinspector.ios.ts#L255

Merge with: https://github.com/NativeScript/webkit/pull/17