### PR TITLE
Tabs are not supported in App Inspector so add an empty implementation for the openInNewTab method

### DIFF
--- a/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHost.h
+++ b/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHost.h
@@ -22,4 +22,5 @@
 - (void)startWindowDrag;
 - (void)setZoomFactor:(NSString*)factor;
 - (void)showContextMenu;
+- (void)openInNewTab;
 @end

--- a/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHost.m
+++ b/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHost.m
@@ -69,4 +69,8 @@
     
 }
 
+- (void)openInNewTab {
+    
+}
+
 @end

--- a/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHostProtocol.h
+++ b/src/debugging/Inspector/Inspector/NativeScript Inspector/InspectorFrontendHostProtocol.h
@@ -16,5 +16,6 @@
 - (void)startWindowDrag;
 - (void)setZoomFactor:(NSString *)factor;
 - (void)showContextMenu;
+- (void)openInNewTab;
 
 @end


### PR DESCRIPTION
Fixes - https://github.com/NativeScript/ios-runtime/issues/685