### PR TITLE
Allow iOS runtime to be installed not only on MAC OS

### DIFF
--- a/build/npm/runtime_package.json
+++ b/build/npm/runtime_package.json
@@ -15,9 +15,6 @@
     "name": "Telerik",
     "email": "support@telerik.com"
   },
-  "os": [
-    "darwin"
-  ],
   "directories": {},
   "files": [
     "**/*"


### PR DESCRIPTION
ping @rosen-vladimirov @Mitko-Kerezov 

We need to allow this as a part of the LiveSync functionality for Fusion UI. 

We will not change the behavior for end users in the {N} CLI. Still will be throwing errors on not MAC OS machines, but will be able to LiveSync iOS project on Windows.