### PR TITLE
Fix module resolution logic

### DIFF
--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -97,13 +97,13 @@ static NSString* resolveAbsolutePath(NSString* absolutePath, WTF::HashMap<WTF::S
     return nil;
 }
 
-NSString* normalizePath(NSString * path) {
-    NSArray *pathComponents = [path componentsSeparatedByString:@"/"];
-    NSMutableArray *stack = [[NSMutableArray alloc] initWithCapacity:pathComponents.count];
-    for (NSString *pathComponent in pathComponents) {
+NSString* normalizePath(NSString* path) {
+    NSArray* pathComponents = [path componentsSeparatedByString:@"/"];
+    NSMutableArray* stack = [[NSMutableArray alloc] initWithCapacity:pathComponents.count];
+    for (NSString* pathComponent in pathComponents) {
         if ([pathComponent isEqualToString:@".."]) {
             [stack removeLastObject];
-        } else if (![pathComponent isEqualToString:@"."] && ![pathComponent isEqualToString: @""]) {
+        } else if (![pathComponent isEqualToString:@"."] && ![pathComponent isEqualToString:@""]) {
             [stack addObject:pathComponent];
         }
     }
@@ -162,14 +162,6 @@ JSInternalPromise* GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObjec
 
     if (isModuleRequire) {
         if (!absoluteFilePath) {
-            absolutePath = [[[static_cast<NSString*>(self->applicationPath()) stringByAppendingPathComponent:@"app/tns_modules"] stringByAppendingPathComponent:path] stringByStandardizingPath];
-            absoluteFilePath = resolveAbsolutePath(absolutePath, self->modulePathCache(), &error);
-            if (error) {
-                return deferred->reject(execState, self->interop()->wrapError(execState, error));
-            }
-        }
-
-        if (!absoluteFilePath) {
             NSString* currentSearchPath = [static_cast<NSString*>(referrerValue.toWTFString(execState)) stringByDeletingLastPathComponent];
             do {
                 NSString* currentNodeModulesPath = [[currentSearchPath stringByAppendingPathComponent:@"node_modules"] stringByStandardizingPath];
@@ -185,6 +177,14 @@ JSInternalPromise* GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObjec
                 }
                 currentSearchPath = [currentSearchPath stringByDeletingLastPathComponent];
             } while (currentSearchPath.length > self->applicationPath().length());
+        }
+
+        if (!absoluteFilePath) {
+            absolutePath = [[[static_cast<NSString*>(self->applicationPath()) stringByAppendingPathComponent:@"app/tns_modules"] stringByAppendingPathComponent:path] stringByStandardizingPath];
+            absoluteFilePath = resolveAbsolutePath(absolutePath, self->modulePathCache(), &error);
+            if (error) {
+                return deferred->reject(execState, self->interop()->wrapError(execState, error));
+            }
         }
     }
 
@@ -392,12 +392,10 @@ EncodedJSValue JSC_HOST_CALL GlobalObject::commonJSRequire(ExecState* execState)
                                                   record = jsCast<JSModuleRecord*>(entry.get(execState, Identifier::fromString(execState, "module")));
 
                                                   return JSValue::encode(jsUndefined());
-                                              }),
-                                              errorHandler);
+                                              }), errorHandler);
 
                       return JSValue::encode(promise);
-                  }),
-                  errorHandler);
+                  }), errorHandler);
     globalObject->drainMicrotasks();
 
     if (exception) {

--- a/tests/TestRunner/app/tns_modules/dummy-package/index.js
+++ b/tests/TestRunner/app/tns_modules/dummy-package/index.js
@@ -1,0 +1,1 @@
+module.exports = "package installed in app/tns_modules folder";

--- a/tests/TestRunner/app/tns_modules/dummy-package/package.json
+++ b/tests/TestRunner/app/tns_modules/dummy-package/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "dummy-package",
+	"version": "1.0.0",
+	"description": "A dummy package"
+}


### PR DESCRIPTION
A package placed in local `node_modules` folder will be required even if a package with the same name exists in `app/tns_modules` folder. This may affect the module loading performance.
Fixes: https://github.com/NativeScript/ios-runtime/issues/762