### PR TITLE
Add a high resolution __time on the global object

### DIFF
--- a/tests/TestRunner/app/RuntimeImplementedAPIs.js
+++ b/tests/TestRunner/app/RuntimeImplementedAPIs.js
@@ -1,0 +1,18 @@
+describe("Runtime exposes", function () {
+  it("__time a low overhead, high resolution, time in ms.", function() {
+    var dateTimeStart = Date.now();
+    var timeStart = __time();
+    var acc = 0;
+    var s = CACurrentMediaTime();
+    for (var i = 0; i < 1000; i++) {
+      var c = CACurrentMediaTime();
+      acc += (c - s);
+      s = c;
+    }
+    var dateTimeEnd = Date.now();
+    var timeEnd = __time();
+    var dateDelta = dateTimeEnd - dateTimeStart;
+    var timeDelta = timeEnd - timeStart;
+    expect(Math.abs(dateDelta - timeDelta) < dateDelta * 0.25).toBe(true);
+  });
+});

--- a/tests/TestRunner/app/index.js
+++ b/tests/TestRunner/app/index.js
@@ -61,6 +61,8 @@ import "./DeclarationConflicts";
 import "./Promises";
 import "./Modules";
 
+import "./RuntimeImplementedAPIs";
+
 execute();
 
 UIApplicationMain(0, null, null, null);


### PR DESCRIPTION
Calling
```
var n = __time();
``` 
Will get the current time in milliseconds but it is accuracy goes beyond millis. About 3 digit micro secs. are stored as fraction. Date.now() truncates to milis and is about 6 times slower.