### PR TITLE
Debugging from Xcode documentation and improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,4 +149,7 @@ JavaScript code:
 
 C/C++/Objective-C code:
 
-Use [Clang Format](https://github.com/andrewseidl/githook-clang-format/tree/master) to check your code on every commit. For more information how to configure Clang Format as pre-commit hook check [here](https://github.com/andrewseidl/githook-clang-format/blob/master/README.md).
+Use [Clang Format](https://github.com/andrewseidl/githook-clang-format/tree/master) to check your code on every commit. You can install it with Homebrew and set up our pre-commit hook by copying it from the `tools/` directory:
+
+* `brew install clang-format`
+* `cp ./tools/pre-commit-clang-format ./.git/hooks/pre-commit`.

--- a/src/debugging/README.md
+++ b/src/debugging/README.md
@@ -1,5 +1,30 @@
-To run in Google Chrome:
+# Attach JS Debugger on Run from Xcode
+1. `cd src/debugging`
+2. `./launch-proxy.sh`
+3. In Xcode add `--nativescript-debug-brk` command line arg in the app scheme of the NativeScript application to be debugged
+4. Launch the application with Xcode and (within the 30 seconds timeout for the frontend to attach) open one of the following:
+
+
+### In {N} inspector application:
+* Launch `src/debugging/Inspector/Inspector` application with arguments: `full-path-to-src/debugging/WebInspectorUI/Main.html '{N} Debugger'`
+
+###### For currently unknown reasons you may start receiving error ***Unable to connect error 36*** when launching the application. Restarting the iOS simulator can solve the issue.
+
+### In Chrome DevTools:
+* Paste `chrome-devtools://devtools/remote/serve_file/@02e6bde1bbe34e43b309d4ef774b1168d25fd024/inspector.html?experiments=true&ws=localhost:8080` in the address bar
+
+`02e6bde1bbe34e43b309d4ef774b1168d25fd024` is the [SHA of Chromium commit](https://chromium.googlesource.com/chromium/src.git/+/02e6bde1bbe34e43b309d4ef774b1168d25fd024) for the currently tested vesion of Chrome (55.0.2883.100). When we upgrade the [tools version used by CLI](https://github.com/NativeScript/nativescript-cli/blob/0b89d3efe4630feb3270babf6294857bac93bee5/lib/services/debug-service-base.ts#L37) we will need to accordingly change it.
+
+### In Safari:
+
+* Open `WebInspectorUI/Main.html` in latest Safari version
+
+[***Safari 11***] Ensure that ***Disable local file restrictions*** option is turned on in the ***Develop*** menu.
+###### Note that if you've just updated the WebKit version even the   [Safari Technology Preview version](https://developer.apple.com/safari/download/) may be missing some features used by the frontend. [The latest nightly WebKit version](https://webkit.org/nightly/archives/) that uses that specific JavaScriptCore must be used in this case. Updating and re-building `src/debugging/Inspector/Inspector` application should always work as well.
+
+#To run in Google Chrome:
 
 ```shell
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome dist/WebInspectorUI/Chrome/Main.html --allow-file-access-from-files -incognito
 ```
+

--- a/src/debugging/launch-proxy.sh
+++ b/src/debugging/launch-proxy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -d node_modules ]; then
+    echo Installing npm dependencies
+    npm install --production
+fi
+
+while true; do
+    echo Launching WebSocket proxy server
+    node debugger-proxy.js
+    sleep 5
+done

--- a/src/debugging/package.json
+++ b/src/debugging/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "debugging-proxy",
+  "version": "0.0.1",
+  "description": "WebSockets proxy for debugging NativeScript iOS runtime",
+  "main": "debugger-proxy.js",
+  "dependencies": {
+    "ws": "1.1.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/tools/pre-commit-clang-format
+++ b/tools/pre-commit-clang-format
@@ -16,7 +16,8 @@
 # SETTINGS
 # set path to clang-format binary
 # CLANG_FORMAT="/usr/bin/clang-format"
-CLANG_FORMAT=`git config clangFormat.binary`
+# CLANG_FORMAT=`git config clangFormat.binary`
+CLANG_FORMAT=$(which clang-format)
 
 # remove any older patches from previous commits. Set to true or false.
 # DELETE_OLD_PATCHES=false


### PR DESCRIPTION
* Add `launch-proxy.sh` which npm installs and lauches the proxy in a `while true` block
* Add package.json for dependencies of proxy
* Add instructions for debugging from Xcode to README.md