### PR TITLE
Always invoke build script for WebKit and MetadataGenerator targets

### DIFF
--- a/src/MetadataGenerator.cmake
+++ b/src/MetadataGenerator.cmake
@@ -5,6 +5,7 @@ ExternalProject_Add(MetadataGenerator
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/metadataGenerator
         -DCMAKE_BUILD_TYPE=$<CONFIG>
         "${CMAKE_SOURCE_DIR}/src/metadata-generator"
+    BUILD_ALWAYS 1
     BUILD_COMMAND env -i "${CMAKE_COMMAND}"
         --build .
         --target install

--- a/src/WebKit.cmake
+++ b/src/WebKit.cmake
@@ -58,6 +58,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WEBKIT_SOURCE_DIR}
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS ${WEBKIT_CMAKE_ARGS}
+    BUILD_ALWAYS 1
     BUILD_COMMAND ${CMAKE_SOURCE_DIR}/build/scripts/build-step-webkit.sh
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
They manage their dependencies correctly and do not rebuild anything when no changes are made.
With the current scheme these are being built only once after the project is generated and
never again until the timestamps files are removed. If you change anything or have another reason
to rebuild, you have to manually delete the timestamps.