### PR TITLE
Revert "Always invoke build script for WebKit and MetadataGenerator targets"

### DIFF
--- a/src/MetadataGenerator.cmake
+++ b/src/MetadataGenerator.cmake
@@ -5,7 +5,6 @@ ExternalProject_Add(MetadataGenerator
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/metadataGenerator
         -DCMAKE_BUILD_TYPE=$<CONFIG>
         "${CMAKE_SOURCE_DIR}/src/metadata-generator"
-    BUILD_ALWAYS 1
     BUILD_COMMAND env -i "${CMAKE_COMMAND}"
         --build .
         --target install

--- a/src/WebKit.cmake
+++ b/src/WebKit.cmake
@@ -58,7 +58,6 @@ ExternalProject_Add(
     SOURCE_DIR ${WEBKIT_SOURCE_DIR}
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS ${WEBKIT_CMAKE_ARGS}
-    BUILD_ALWAYS 1
     BUILD_COMMAND ${CMAKE_SOURCE_DIR}/build/scripts/build-step-webkit.sh
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION

This reverts commit c53b972763f77ab315dae137f9fc045d9e4e8280.

When JSC project is being always rebuilt some symbols are
missing from the .a file for some reason

We're temporarily disabling this setting until we manage to fix the WK build.
