### PR TITLE
Make LLIntAssembly.h get regenerated after changing architecture target

### DIFF
--- a/src/MetadataGenerator.cmake
+++ b/src/MetadataGenerator.cmake
@@ -5,6 +5,7 @@ ExternalProject_Add(MetadataGenerator
         -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/metadataGenerator
         -DCMAKE_BUILD_TYPE=$<CONFIG>
         "${CMAKE_SOURCE_DIR}/src/metadata-generator"
+    BUILD_ALWAYS 1
     BUILD_COMMAND env -i "${CMAKE_COMMAND}"
         --build .
         --target install

--- a/src/WebKit.cmake
+++ b/src/WebKit.cmake
@@ -62,6 +62,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WEBKIT_SOURCE_DIR}
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS ${WEBKIT_CMAKE_ARGS}
+    BUILD_ALWAYS 1
     BUILD_COMMAND ${CMAKE_SOURCE_DIR}/build/scripts/build-step-webkit.sh
     INSTALL_COMMAND ""
 )


### PR DESCRIPTION
The ${LLIntOutput} file is architecture-specific but resides in a common place. When we build for Simulator, it is created for the x86/x86_64 processor architectures. Afterwards all device builds will start failing because they need arm7/arm64 architectures but the file will be considered up-to-date and won't be regenerated. As a workaround we're creating an additional dependency of a stamp file per architecture. Whenever a specific architecture is generated, all other ones will be invalidated by touching the corresponding dependency files.