### PR TITLE
Load inspector pages modules deterministically before launching app's main module

### DIFF
--- a/build/project-template/internal/main.m
+++ b/build/project-template/internal/main.m
@@ -8,45 +8,55 @@
 #include <TNSExceptionHandler.h>
 
 #if DEBUG
-#include <TNSDebugging.h>
 #include <TKLiveSync.h>
+#include <TNSDebugging.h>
 #endif
 
-int main(int argc, char *argv[]) {
-  @autoreleasepool {
-    TNSRuntime* runtime = [TNSRuntimeInstrumentation profile: @"main" withBlock: ^{
-      __block NSString* applicationPath = [NSBundle mainBundle].bundlePath;
+int main(int argc, char* argv[]) {
+    @autoreleasepool {
+        TNSRuntime* runtime = [TNSRuntimeInstrumentation profile:@"main"
+                                                       withBlock:^{
+                                                         __block NSString* applicationPath = [NSBundle mainBundle].bundlePath;
 
 #if DEBUG
-      [TNSRuntimeInstrumentation profile:@"Debug: Lifesync & Syslog" withBlock: ^{
-        TNSInitializeLiveSync();
-        if (getenv("TNSApplicationPath")) {
-          applicationPath = @(getenv("TNSApplicationPath"));
-        }
-        [TNSRuntimeInstrumentation initWithApplicationPath:applicationPath];
-        [TNSRuntimeInspector setLogsToSystemConsole:YES];
-        return (id)nil;
-      }];
+                                                         [TNSRuntimeInstrumentation profile:@"Debug: Lifesync & Syslog"
+                                                                                  withBlock:^{
+                                                                                    TNSInitializeLiveSync();
+                                                                                    if (getenv("TNSApplicationPath")) {
+                                                                                        applicationPath = @(getenv("TNSApplicationPath"));
+                                                                                    }
+                                                                                    [TNSRuntimeInstrumentation initWithApplicationPath:applicationPath];
+                                                                                    [TNSRuntimeInspector setLogsToSystemConsole:YES];
+                                                                                    return (id)nil;
+                                                                                  }];
 #endif
 
-      extern char startOfMetadataSection __asm("section$start$__DATA$__TNSMetadata");
-      [TNSRuntime initializeMetadata:&startOfMetadataSection];
-      TNSRuntime *runtime = [[TNSRuntime alloc] initWithApplicationPath:applicationPath];
-      [runtime scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
-          
+                                                         extern char startOfMetadataSection __asm("section$start$__DATA$__TNSMetadata");
+                                                         [TNSRuntime initializeMetadata:&startOfMetadataSection];
+                                                         TNSRuntime* runtime = [[TNSRuntime alloc] initWithApplicationPath:applicationPath];
+                                                         [runtime scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
 #if DEBUG
-      [TNSRuntimeInstrumentation profile:@"Debug: Wait for JavaScript debugger" withBlock: ^{
-        TNSEnableRemoteInspector(argc, argv, runtime);
-        return (id)nil;
-      }];
+                                                         [TNSRuntimeInstrumentation profile:@"Debug: Wait for JavaScript debugger"
+                                                                                  withBlock:^{
+                                                                                    TNSEnableRemoteInspector(argc, argv, runtime);
+                                                                                    return (id)nil;
+                                                                                  }];
 #endif
 
-      TNSInstallExceptionHandler();
-      return runtime;
-    }];
+                                                         TNSInstallExceptionHandler();
+                                                         return runtime;
+                                                       }];
 
-    [runtime executeModule:@"./"];
+#if DEBUG
+        // Load inspector pages modules in advance. Loading them asynchronously on inspector client connection
+        // can sporadically break application startup due to the common dependencies between
+        // the application and inspector modules.
+        [runtime executeModule:@"inspector_modules.js"];
+#endif
 
-    return 0;
-  }
+        [runtime executeModule:@"./"];
+
+        return 0;
+    }
 }

--- a/src/NativeScript/TNSRuntime+Inspector.mm
+++ b/src/NativeScript/TNSRuntime+Inspector.mm
@@ -50,8 +50,6 @@ private:
 
 - (instancetype)initWithRuntime:(TNSRuntime*)runtime
                  messageHandler:(TNSRuntimeInspectorMessageHandler)messageHandler;
-- (void)setup;
-
 @end
 
 @implementation TNSRuntime (Inspector)
@@ -59,8 +57,6 @@ private:
 - (TNSRuntimeInspector*)attachInspectorWithHandler:(TNSRuntimeInspectorMessageHandler)messageHandler {
     TNSRuntimeInspector* runtimeInspector = [[TNSRuntimeInspector alloc] initWithRuntime:self
                                                                           messageHandler:messageHandler];
-
-    [runtimeInspector setup];
 
     return [runtimeInspector autorelease];
 }
@@ -97,20 +93,6 @@ private:
 
 - (TNSRuntime*)runtime {
     return self->_runtime;
-}
-
-- (void)setup {
-    JSC::JSLockHolder lock(_runtime->_vm.get());
-
-    WTF::Deque<WTF::RefPtr<JSC::Microtask>> other;
-    GlobalObject* globalObject = self->_runtime->_globalObject.get();
-
-    globalObject->microtasks().swap(other);
-
-    loadAndEvaluateModule(_runtime->_globalObject->globalExec(), WTF::ASCIILiteral("inspector_modules.js"));
-
-    globalObject->drainMicrotasks();
-    globalObject->microtasks().swap(other);
 }
 
 - (void)dispatchMessage:(NSString*)message {


### PR DESCRIPTION
Loading them asynchronously on inspector client connection can sporadically break
application startup due to the common dependencies between the application and
inspector modules.