### PR TITLE
When an error is thrown in a chained native promise the printed stack is insufficient

### DIFF
--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -365,13 +365,9 @@ EncodedJSValue JSC_HOST_CALL GlobalObject::commonJSRequire(ExecState* execState)
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     JSInternalPromise* promise = globalObject->moduleLoader()->resolve(execState, moduleName, refererKey, refererKey);
 
-    Exception* exception = nullptr;
-    JSFunction* errorHandler = JSNativeStdFunction::create(execState->vm(), globalObject, 1, String(), [&exception](ExecState* execState) {
-        JSValue error = execState->argument(0);
-        exception = jsDynamicCast<Exception*>(error);
-        if (!exception && !error.isUndefinedOrNull()) {
-            exception = Exception::create(execState->vm(), error);
-        }
+    JSValue error;
+    JSFunction* errorHandler = JSNativeStdFunction::create(execState->vm(), globalObject, 1, String(), [&error](ExecState* execState) {
+        error = execState->argument(0);
         return JSValue::encode(jsUndefined());
     });
 
@@ -413,9 +409,8 @@ EncodedJSValue JSC_HOST_CALL GlobalObject::commonJSRequire(ExecState* execState)
                   }), errorHandler);
     globalObject->drainMicrotasks();
 
-    if (exception) {
-        scope.throwException(execState, exception);
-        return JSValue::encode(exception);
+    if (!error.isUndefinedOrNull() && error.isCell() && error.asCell() != nullptr) {
+        return JSValue::encode(scope.throwException(execState, error));
     }
 
     // maybe the require'd module is a CommonJS module?

--- a/src/NativeScript/JSErrors.mm
+++ b/src/NativeScript/JSErrors.mm
@@ -63,7 +63,7 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
         std::cerr << "Native stack trace:\n";
         WTFReportBacktrace();
 
-        std::cerr << "JavaScript stack trace:\n";
+        std::cerr << "\nJavaScript stack trace:\n";
         RefPtr<Inspector::ScriptCallStack> callStack = Inspector::createScriptCallStackFromException(execState, exception, Inspector::ScriptCallStack::maxCallStackSizeToCapture);
         for (size_t i = 0; i < callStack->size(); ++i) {
             Inspector::ScriptCallFrame frame = callStack->at(i);
@@ -72,6 +72,34 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
                 std::cerr << ":" << frame.lineNumber() << ":" << frame.columnNumber();
             }
             std::cerr << "\n";
+        }
+        
+        //OBSERVATION:
+        //When programmatically creating and chaining promises using the JSC API
+        //Exception objects contain limited stack trace depending on the depth of the promise chain
+        //at the execution point when the exception is thrown. When an exception is thrown during the
+        //module resolution stage it is handled by the top-level promise's error handler which creates a new Exception instance that
+        //captures the current Interpreter stack trace which is scarce on information.
+        //See: https://github.com/nativescript/ios-runtime/issues/807
+        JSValue error = exception->value();
+        if (error.isObject()) {
+            JSObject* errorAsObject = error.toObject(execState);
+            if (errorAsObject->hasProperty(execState, execState->vm().propertyNames->stack)) {
+                JSValue stackValue = errorAsObject->get(execState, execState->vm().propertyNames->stack);
+                if (!stackValue.isUndefined() && !stackValue.isNull() && stackValue.isString()) {
+                    String stackString = stackValue.getString(execState);
+                    
+                    if (!stackString.is8Bit()) {
+                        stackString = WTF::String::make8BitFrom16BitSource(stackString.characters16(), stackString.length());
+                    }
+                    Vector<String> results;
+                    stackString.split("\n", false, results);
+                    std::cerr << "\nJavaScript error stack dump (may be duplicate or more accurate than previous stack trace): \n";
+                    for (size_t i = 0; i < results.size(); i ++) {
+                        std::cerr << std::setw(4) << std::left << std::setfill(' ') << (i + 1) << results.at(i).characters8() << "\n";
+                    }
+                }
+            }
         }
 
         std::cerr << "JavaScript error:\n";

--- a/src/NativeScript/JSErrors.mm
+++ b/src/NativeScript/JSErrors.mm
@@ -73,34 +73,6 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
             }
             std::cerr << "\n";
         }
-        
-        //OBSERVATION:
-        //When programmatically creating and chaining promises using the JSC API
-        //Exception objects contain limited stack trace depending on the depth of the promise chain
-        //at the execution point when the exception is thrown. When an exception is thrown during the
-        //module resolution stage it is handled by the top-level promise's error handler which creates a new Exception instance that
-        //captures the current Interpreter stack trace which is scarce on information.
-        //See: https://github.com/nativescript/ios-runtime/issues/807
-        JSValue error = exception->value();
-        if (error.isObject()) {
-            JSObject* errorAsObject = error.toObject(execState);
-            if (errorAsObject->hasProperty(execState, execState->vm().propertyNames->stack)) {
-                JSValue stackValue = errorAsObject->get(execState, execState->vm().propertyNames->stack);
-                if (!stackValue.isUndefined() && !stackValue.isNull() && stackValue.isString()) {
-                    String stackString = stackValue.getString(execState);
-                    
-                    if (!stackString.is8Bit()) {
-                        stackString = WTF::String::make8BitFrom16BitSource(stackString.characters16(), stackString.length());
-                    }
-                    Vector<String> results;
-                    stackString.split("\n", false, results);
-                    std::cerr << "\nJavaScript error stack dump (may be duplicate or more accurate than previous stack trace): \n";
-                    for (size_t i = 0; i < results.size(); i ++) {
-                        std::cerr << std::setw(4) << std::left << std::setfill(' ') << (i + 1) << results.at(i).characters8() << "\n";
-                    }
-                }
-            }
-        }
 
         std::cerr << "JavaScript error:\n";
         // System logs are disabled in release app builds, but we want the error to be printed in crash logs

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -149,6 +149,7 @@ static NSPointerArray* _runtimes;
     return [self executeModule:entryPointModuleIdentifier referredBy:@""];
 }
 
+
 - (void)executeModule:(NSString*)entryPointModuleIdentifier referredBy:(NSString*)referrer {
     JSLockHolder lock(*self->_vm);
     JSInternalPromise* promise = loadAndEvaluateModule(self->_globalObject->globalExec(), entryPointModuleIdentifier, referrer);
@@ -164,9 +165,11 @@ static NSPointerArray* _runtimes;
     if (error) {
         Exception* exception = jsDynamicCast<Exception*>(error);
         if (!exception) {
-            exception = Exception::create(*self->_vm.get(), error, Exception::DoNotCaptureStack);
+            exception = jsDynamicCast<Exception*>(error.getObject()->getDirect(*self->_vm.get(), Identifier::fromString(self->_vm.get(), Exception::NS_EXCEPTION_IDENTIFIER_STRING)));
+            if (!exception) {
+                exception = Exception::create(*self->_vm.get(), error, Exception::DoNotCaptureStack);
+            }
         }
-
         reportFatalErrorBeforeShutdown(self->_globalObject->globalExec(), exception);
     }
 }


### PR DESCRIPTION
Discussion: #807 