### PR TITLE
Initialize WTF main thread in TNSRuntime constructor

### DIFF
--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -70,6 +70,7 @@ static NSPointerArray* _runtimes;
 + (void)initialize {
     TNSPERF();
     if (self == [TNSRuntime self]) {
+        WTF::initializeMainThread();
         initializeThreading();
         JSC::Options::useJIT() = false;
         _runtimes = [[NSPointerArray alloc] initWithOptions:NSPointerFunctionsOpaquePersonality | NSPointerFunctionsOpaqueMemory];


### PR DESCRIPTION
Bug https://github.com/NativeScript/NativeScript/issues/5019 describes a scenario when WTF may need to dispatch a method on the main thread. It needs a reference to the main run loop which however is never created. With calling `WTF::initializeMainThread()` we make sure all necessary references for the dispatch are created.  