### PR TITLE
Fixes issues with resolution of canonical paths 

### DIFF
--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -48,8 +48,6 @@ static NSString* stat(NSString* path) {
 }
 
 static NSString* resolveAbsolutePath(NSString* absolutePath, WTF::HashMap<WTF::String, WTF::String, WTF::ASCIICaseInsensitiveHash>& cache, NSError** error) {
-  
-
     if (cache.contains(absolutePath)) {
         return cache.get(absolutePath);
     }

--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -48,6 +48,8 @@ static NSString* stat(NSString* path) {
 }
 
 static NSString* resolveAbsolutePath(NSString* absolutePath, WTF::HashMap<WTF::String, WTF::String, WTF::ASCIICaseInsensitiveHash>& cache, NSError** error) {
+  
+
     if (cache.contains(absolutePath)) {
         return cache.get(absolutePath);
     }
@@ -87,7 +89,7 @@ static NSString* resolveAbsolutePath(NSString* absolutePath, WTF::HashMap<WTF::S
             }
         }
 
-        NSString* resolved = resolveAbsolutePath([absolutePath stringByAppendingPathComponent:mainName], cache, error);
+        NSString* resolved = resolveAbsolutePath([[absolutePath stringByAppendingPathComponent:mainName] stringByStandardizingPath], cache, error);
         if (*error) {
             return nil;
         }


### PR DESCRIPTION
This PR addresses an issue with absolute module paths not being resolved correctly in certain cases. For example, paths like ./A/moment.js and ../moment.js  did not resolve to the same path and the `moment.js` module was loaded twice like a different module.

See issue #822 for more details.