### PR TITLE
chore: Fix build with NPM 5

### DIFF
--- a/build/scripts/package-tns-ios.sh
+++ b/build/scripts/package-tns-ios.sh
@@ -31,7 +31,7 @@ cp -R "$WORKSPACE/build/npm/runtime_package.json" "$PACKAGE_DIR/package.json"
 python "$WORKSPACE/build/scripts/update-version.py" "$PACKAGE_DIR/package.json"
 
 pushd "$DIST_DIR"
-npm pack "package"
+npm pack ./package
 popd
 
 VERSION=$(python "$WORKSPACE/build/scripts/get_version.py" "$PACKAGE_DIR/package.json" 2>&1)


### PR DESCRIPTION
`npm pack package` now treats `package` as a npm published package
instead of a local directory name. Disambiguate by changing it to `./package`