### PR TITLE
fix(inspector):  Fix app crashes on second debugger attach

### DIFF
--- a/src/NativeScript/Calling/FFICall.cpp
+++ b/src/NativeScript/Calling/FFICall.cpp
@@ -172,11 +172,11 @@ JSObject* FFICall::async(ExecState* execState, JSValue thisValue, const ArgList&
     dispatch_async(dispatch_get_global_queue(0, 0), ^{
 
       JSC::VM& vm = fakeExecState->vm();
+      JSLockHolder lockHolder(vm);
       auto scope = DECLARE_CATCH_SCOPE(vm);
 
       ffi_call(callee->_cif.get(), FFI_FN(invocation->function), invocation->resultBuffer(), reinterpret_cast<void**>(invocation->_buffer + callee->_argsArrayOffset));
 
-      JSLockHolder lockHolder(fakeExecState);
       // we no longer have a valid caller on the stack, what with being async and all
       fakeExecState->setCallerFrame(CallFrame::noCaller());
 

--- a/src/NativeScript/Calling/FFICallbackInlines.h
+++ b/src/NativeScript/Calling/FFICallbackInlines.h
@@ -21,11 +21,11 @@ template <class DerivedCallback>
 inline void FFICallback<DerivedCallback>::ffiClosureCallback(ffi_cif* cif, void* retValue, void** argValues, void* userData) {
     FFICallback* callback = static_cast<FFICallback*>(userData);
     JSC::ExecState* execState = callback->_globalExecState;
-
     JSC::VM& vm = execState->vm();
+    JSC::JSLockHolder lock(vm);
+
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
-    JSC::JSLockHolder lock(execState->vm());
     static_cast<DerivedCallback*>(callback)->ffiClosureCallback(retValue, argValues, userData);
 
     reportErrorIfAny(execState, scope);
@@ -120,6 +120,6 @@ inline FFICallback<DerivedCallback>::~FFICallback() {
     delete[] this->_cif->arg_types;
     delete this->_cif;
 }
-}
+} // namespace NativeScript
 
 #endif /* defined(__NativeScript__FFICallbackInlines__) */

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -49,8 +49,8 @@
 #include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/inspector/JSGlobalObjectConsoleClient.h>
 #include <JavaScriptCore/runtime/VMEntryScope.h>
-#include <string>
 #include <chrono>
+#include <string>
 
 namespace NativeScript {
 using namespace JSC;
@@ -105,7 +105,7 @@ static EncodedJSValue JSC_HOST_CALL collectGarbage(ExecState* execState) {
     JSSynchronousGarbageCollectForDebugging(execState->lexicalGlobalObject()->globalExec());
     return JSValue::encode(jsUndefined());
 }
-    
+
 static EncodedJSValue JSC_HOST_CALL time(ExecState* execState) {
     auto nano = std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now());
     double duration = nano.time_since_epoch().count() / 1000000.0;
@@ -120,6 +120,7 @@ static void microtaskRunLoopSourcePerformWork(void* context) {
 
 static void runLoopBeforeWaitingPerformWork(CFRunLoopObserverRef observer, CFRunLoopActivity activity, void* info) {
     GlobalObject* self = static_cast<GlobalObject*>(info);
+    JSC::JSLockHolder lock(self->vm());
     VMEntryScope* currentEntryScope = self->vm().entryScope;
     if (self->vm().topCallFrame && currentEntryScope && !currentEntryScope->didPopListeners().isEmpty()) {
         FFIFunctionCall* function_call = jsDynamicCast<FFIFunctionCall*>(self->vm().topCallFrame->callee());

--- a/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.mm
+++ b/src/NativeScript/ObjC/Enumeration/TNSFastEnumerationAdapter.mm
@@ -29,9 +29,9 @@ NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id 
         RELEASE_ASSERT(wrapper);
 
         JSC::VM& vm = execState->vm();
-        auto scope = DECLARE_CATCH_SCOPE(vm);
-
         JSLockHolder lock(execState);
+
+        auto scope = DECLARE_CATCH_SCOPE(vm);
 
         JSValue iteratorFunction = wrapper->get(execState, execState->propertyNames().iteratorSymbol);
         reportErrorIfAny(execState, scope);
@@ -60,8 +60,8 @@ NSUInteger TNSFastEnumerationAdapter(id self, NSFastEnumerationState* state, id 
 
     ExecState* execState = reinterpret_cast<ExecState*>(state->extra[0]);
     JSValue iterator(reinterpret_cast<JSCell*>(state->extra[1]));
-    JSLockHolder lock(execState);
     JSC::VM& vm = execState->vm();
+    JSLockHolder lock(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
 
     if (state->state == State::Done) {

--- a/src/NativeScript/ObjC/Inheritance/ObjCTypeScriptExtend.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCTypeScriptExtend.mm
@@ -100,9 +100,9 @@ EncodedJSValue ObjCTypeScriptExtendFunction(ExecState* execState) {
       if (self != [derivedClass self]) {
           return;
       }
+      JSLockHolder lock(globalObject->vm());
       auto catchScope = DECLARE_CATCH_SCOPE(globalObject->vm());
 
-      JSLockHolder lock(globalObject->vm());
       ExecState* globalExec = globalObject->globalExec();
 
       JSObject* instanceMethods = jsCast<JSObject*>(derivedConstructor->get(globalExec, globalExec->vm().propertyNames->prototype));

--- a/src/NativeScript/ObjC/TNSDataAdapter.mm
+++ b/src/NativeScript/ObjC/TNSDataAdapter.mm
@@ -56,8 +56,8 @@ using namespace JSC;
 - (NSUInteger)length {
     RELEASE_ASSERT_WITH_MESSAGE([TNSRuntime runtimeForVM:self->_vm], "The runtime is deallocated.");
     VM& vm = self->_execState->vm();
-    auto scope = DECLARE_CATCH_SCOPE(vm);
     JSLockHolder lock(self->_execState);
+    auto scope = DECLARE_CATCH_SCOPE(vm);
     NSUInteger length = self->_object->get(self->_execState, self->_execState->propertyNames().byteLength).toUInt32(self->_execState);
     reportErrorIfAny(self->_execState, scope);
     return length;

--- a/src/NativeScript/TNSRuntime+Inspector.h
+++ b/src/NativeScript/TNSRuntime+Inspector.h
@@ -24,8 +24,6 @@ FOUNDATION_EXPORT NSString* const TNSInspectorRunLoopMode;
 
 - (void)pause;
 
-- (bool)hasFrontends;
-
 @end
 
 typedef void (^TNSRuntimeInspectorMessageHandler)(NSString* message);

--- a/src/NativeScript/TNSRuntime+Inspector.h
+++ b/src/NativeScript/TNSRuntime+Inspector.h
@@ -24,6 +24,8 @@ FOUNDATION_EXPORT NSString* const TNSInspectorRunLoopMode;
 
 - (void)pause;
 
+- (bool)hasFrontends;
+
 @end
 
 typedef void (^TNSRuntimeInspectorMessageHandler)(NSString* message);

--- a/src/NativeScript/TNSRuntime+Inspector.mm
+++ b/src/NativeScript/TNSRuntime+Inspector.mm
@@ -132,6 +132,10 @@ private:
     self->_inspectorController->pause();
 }
 
+- (bool)hasFrontends {
+    return self->_inspectorController->frontendRouter().hasFrontends();
+}
+
 - (void)dealloc {
     self->_inspectorController->disconnectFrontend(_frontendChannel.get());
     [self->_runtime release];

--- a/src/NativeScript/TNSRuntime+Inspector.mm
+++ b/src/NativeScript/TNSRuntime+Inspector.mm
@@ -57,6 +57,8 @@ private:
 @implementation TNSRuntime (Inspector)
 
 - (TNSRuntimeInspector*)attachInspectorWithHandler:(TNSRuntimeInspectorMessageHandler)messageHandler {
+    JSC::JSLockHolder lock(self->_vm.get());
+
     TNSRuntimeInspector* runtimeInspector = [[TNSRuntimeInspector alloc] initWithRuntime:self
                                                                           messageHandler:messageHandler];
 
@@ -133,10 +135,14 @@ private:
 }
 
 - (bool)hasFrontends {
+    JSC::JSLockHolder lock(_runtime->_vm.get());
+
     return self->_inspectorController->frontendRouter().hasFrontends();
 }
 
 - (void)dealloc {
+    JSC::JSLockHolder lock(_runtime->_vm.get());
+
     self->_inspectorController->disconnectFrontend(_frontendChannel.get());
     [self->_runtime release];
     [super dealloc];

--- a/src/NativeScript/TNSRuntime+Inspector.mm
+++ b/src/NativeScript/TNSRuntime+Inspector.mm
@@ -134,12 +134,6 @@ private:
     self->_inspectorController->pause();
 }
 
-- (bool)hasFrontends {
-    JSC::JSLockHolder lock(_runtime->_vm.get());
-
-    return self->_inspectorController->frontendRouter().hasFrontends();
-}
-
 - (void)dealloc {
     JSC::JSLockHolder lock(_runtime->_vm.get());
 

--- a/src/NativeScript/inspector/DomainBackendDispatcher.cpp
+++ b/src/NativeScript/inspector/DomainBackendDispatcher.cpp
@@ -2,9 +2,9 @@
 #include "GlobalObjectInspectorController.h"
 #include "SuppressAllPauses.h"
 #include <JavaScriptCore/Completion.h>
+#include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/inspector/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/inspector/InspectorFrontendDispatchers.h>
-#include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/runtime/Exception.h>
 #include <JavaScriptCore/runtime/JSONObject.h>
 #include <stdio.h>
@@ -29,7 +29,7 @@ DomainBackendDispatcher::DomainBackendDispatcher(WTF::String domain, JSCell* con
     const HashMap<String, SupplementalBackendDispatcher*>& dispatchers = m_backendDispatcher->dispatchers();
     auto result = dispatchers.find(domain);
     if (result != dispatchers.end()) {
-        m_duplicatedDispatcher = adoptRef(*result->value);
+        m_duplicatedDispatcher = result->value;
     }
     m_backendDispatcher->registerDispatcherForDomain(domain, this);
 }
@@ -88,4 +88,4 @@ void DomainBackendDispatcher::dispatch(long callId, const String& method, Ref<In
 
     m_backendDispatcher->sendResponse(callId, WTFMove(messageObject));
 }
-}
+} // namespace NativeScript

--- a/src/NativeScript/inspector/DomainInspectorAgent.cpp
+++ b/src/NativeScript/inspector/DomainInspectorAgent.cpp
@@ -9,14 +9,15 @@ DomainInspectorAgent::DomainInspectorAgent(WTF::String domainName, JSC::JSCell* 
     , m_constructorFunction(m_context.inspectedGlobalObject.vm(), constructorFunction) {}
 
 void DomainInspectorAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher* backendDispatcher) {
-    this->m_domainBackendDispatcher = DomainBackendDispatcher::create(this->domainName(), m_constructorFunction.get(), m_context);
+    if (!this->m_domainBackendDispatcher) {
+        this->m_domainBackendDispatcher = DomainBackendDispatcher::create(this->domainName(), m_constructorFunction.get(), m_context);
+    }
 }
 
 void DomainInspectorAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {
-    m_domainBackendDispatcher = nullptr;
 }
 
 void DomainInspectorAgent::discardAgent() {
     m_constructorFunction.clear();
 }
-}
+} // namespace NativeScript

--- a/src/NativeScript/inspector/DomainInspectorAgent.cpp
+++ b/src/NativeScript/inspector/DomainInspectorAgent.cpp
@@ -6,12 +6,12 @@ namespace NativeScript {
 DomainInspectorAgent::DomainInspectorAgent(WTF::String domainName, JSC::JSCell* constructorFunction, Inspector::JSAgentContext& context)
     : Inspector::InspectorAgentBase(domainName)
     , m_context(context)
-    , m_constructorFunction(m_context.inspectedGlobalObject.vm(), constructorFunction) {}
+    , m_constructorFunction(m_context.inspectedGlobalObject.vm(), constructorFunction) {
+
+    this->m_domainBackendDispatcher = DomainBackendDispatcher::create(this->domainName(), m_constructorFunction.get(), m_context);
+}
 
 void DomainInspectorAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter*, Inspector::BackendDispatcher* backendDispatcher) {
-    if (!this->m_domainBackendDispatcher) {
-        this->m_domainBackendDispatcher = DomainBackendDispatcher::create(this->domainName(), m_constructorFunction.get(), m_context);
-    }
 }
 
 void DomainInspectorAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {

--- a/src/NativeScript/inspector/InspectorLogAgent.cpp
+++ b/src/NativeScript/inspector/InspectorLogAgent.cpp
@@ -64,13 +64,12 @@ InspectorLogAgent::InspectorLogAgent(Inspector::JSAgentContext& context)
     : InspectorAgentBase(ASCIILiteral("Log"))
     , m_injectedScriptManager(context.injectedScriptManager)
     , m_globalObject(*JSC::jsCast<NativeScript::GlobalObject*>(&context.inspectedGlobalObject)) {
+
+    this->m_frontendDispatcher = std::make_unique<LogFrontendDispatcher>(context.frontendRouter);
+    this->m_backendDispatcher = LogBackendDispatcher::create(context.backendDispatcher, this);
 }
 
 void InspectorLogAgent::didCreateFrontendAndBackend(FrontendRouter* frontendDispatcher, BackendDispatcher* backendDispatcher) {
-    this->m_frontendDispatcher = std::make_unique<LogFrontendDispatcher>(*frontendDispatcher);
-    if (!this->m_backendDispatcher) {
-        this->m_backendDispatcher = LogBackendDispatcher::create(*backendDispatcher, this);
-    }
 }
 
 void InspectorLogAgent::willDestroyFrontendAndBackend(DisconnectReason) {

--- a/src/NativeScript/inspector/InspectorLogAgent.cpp
+++ b/src/NativeScript/inspector/InspectorLogAgent.cpp
@@ -68,7 +68,9 @@ InspectorLogAgent::InspectorLogAgent(Inspector::JSAgentContext& context)
 
 void InspectorLogAgent::didCreateFrontendAndBackend(FrontendRouter* frontendDispatcher, BackendDispatcher* backendDispatcher) {
     this->m_frontendDispatcher = std::make_unique<LogFrontendDispatcher>(*frontendDispatcher);
-    this->m_backendDispatcher = LogBackendDispatcher::create(*backendDispatcher, this);
+    if (!this->m_backendDispatcher) {
+        this->m_backendDispatcher = LogBackendDispatcher::create(*backendDispatcher, this);
+    }
 }
 
 void InspectorLogAgent::willDestroyFrontendAndBackend(DisconnectReason) {
@@ -153,4 +155,4 @@ void InspectorLogAgent::addMessageToFrontend(ConsoleMessage* consoleMessage) {
     }
     m_frontendDispatcher->entryAdded(WTFMove(jsonObj));
 }
-}
+} // namespace Inspector

--- a/src/NativeScript/inspector/InspectorNetworkAgent.cpp
+++ b/src/NativeScript/inspector/InspectorNetworkAgent.cpp
@@ -9,10 +9,13 @@ InspectorNetworkAgent::InspectorNetworkAgent(JSAgentContext& context)
 
 void InspectorNetworkAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter* frontendRouter, Inspector::BackendDispatcher* backendDispatcher) {
     m_frontendDispatcher = std::make_unique<NetworkFrontendDispatcher>(*frontendRouter);
-    m_backendDispatcher = NetworkBackendDispatcher::create(*backendDispatcher, this);
+    if (!this->m_backendDispatcher) {
+        this->m_backendDispatcher = NetworkBackendDispatcher::create(*backendDispatcher, this);
+    }
 }
 
 void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {
+    m_frontendDispatcher = nullptr;
 }
 
 void InspectorNetworkAgent::enable(ErrorString&) {
@@ -40,4 +43,4 @@ void InspectorNetworkAgent::loadResource(ErrorString& errorString, const String&
         callback->sendSuccess(content, resource.mimeType(), 200);
     }
 }
-}
+} // namespace Inspector

--- a/src/NativeScript/inspector/InspectorNetworkAgent.cpp
+++ b/src/NativeScript/inspector/InspectorNetworkAgent.cpp
@@ -13,7 +13,6 @@ void InspectorNetworkAgent::didCreateFrontendAndBackend(Inspector::FrontendRoute
 }
 
 void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {
-    m_frontendDispatcher = nullptr;
 }
 
 void InspectorNetworkAgent::enable(ErrorString&) {

--- a/src/NativeScript/inspector/InspectorNetworkAgent.cpp
+++ b/src/NativeScript/inspector/InspectorNetworkAgent.cpp
@@ -5,13 +5,11 @@ namespace Inspector {
 InspectorNetworkAgent::InspectorNetworkAgent(JSAgentContext& context)
     : Inspector::InspectorAgentBase(ASCIILiteral("Network"))
     , m_globalObject(*JSC::jsCast<NativeScript::GlobalObject*>(&context.inspectedGlobalObject)) {
+    this->m_frontendDispatcher = std::make_unique<NetworkFrontendDispatcher>(context.frontendRouter);
+    this->m_backendDispatcher = NetworkBackendDispatcher::create(context.backendDispatcher, this);
 }
 
 void InspectorNetworkAgent::didCreateFrontendAndBackend(Inspector::FrontendRouter* frontendRouter, Inspector::BackendDispatcher* backendDispatcher) {
-    m_frontendDispatcher = std::make_unique<NetworkFrontendDispatcher>(*frontendRouter);
-    if (!this->m_backendDispatcher) {
-        this->m_backendDispatcher = NetworkBackendDispatcher::create(*backendDispatcher, this);
-    }
 }
 
 void InspectorNetworkAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason) {

--- a/src/NativeScript/inspector/InspectorPageAgent.mm
+++ b/src/NativeScript/inspector/InspectorPageAgent.mm
@@ -14,17 +14,15 @@ InspectorPageAgent::InspectorPageAgent(JSAgentContext& context)
     , m_frameIdentifier("NativeScriptMainFrameIdentifier")
     , m_frameUrl("http://main.xml")
     , m_globalObject(*JSC::jsCast<NativeScript::GlobalObject*>(&context.inspectedGlobalObject)) {
+
+    this->m_frontendDispatcher = std::make_unique<PageFrontendDispatcher>(context.frontendRouter);
+    this->m_backendDispatcher = PageBackendDispatcher::create(context.backendDispatcher, this);
 }
 
 void InspectorPageAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher) {
-    m_frontendDispatcher = std::make_unique<PageFrontendDispatcher>(*frontendRouter);
-    if (!this->m_backendDispatcher) {
-        this->m_backendDispatcher = PageBackendDispatcher::create(*backendDispatcher, this);
-    }
 }
 
 void InspectorPageAgent::willDestroyFrontendAndBackend(DisconnectReason) {
-    this->m_frontendDispatcher = nullptr;
 }
 
 void InspectorPageAgent::enable(ErrorString&) {

--- a/src/NativeScript/inspector/InspectorPageAgent.mm
+++ b/src/NativeScript/inspector/InspectorPageAgent.mm
@@ -18,12 +18,13 @@ InspectorPageAgent::InspectorPageAgent(JSAgentContext& context)
 
 void InspectorPageAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher) {
     m_frontendDispatcher = std::make_unique<PageFrontendDispatcher>(*frontendRouter);
-    m_backendDispatcher = PageBackendDispatcher::create(*backendDispatcher, this);
+    if (!this->m_backendDispatcher) {
+        this->m_backendDispatcher = PageBackendDispatcher::create(*backendDispatcher, this);
+    }
 }
 
 void InspectorPageAgent::willDestroyFrontendAndBackend(DisconnectReason) {
-    m_frontendDispatcher = nullptr;
-    m_backendDispatcher = nullptr;
+    this->m_frontendDispatcher = nullptr;
 }
 
 void InspectorPageAgent::enable(ErrorString&) {

--- a/src/NativeScript/inspector/InspectorTimelineAgent.cpp
+++ b/src/NativeScript/inspector/InspectorTimelineAgent.cpp
@@ -29,15 +29,18 @@ void InspectorTimelineAgent::sendEvent(RefPtr<InspectorObject>&& event) {
 }
 
 void InspectorTimelineAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher) {
-    m_frontendDispatcher = std::make_unique<TimelineFrontendDispatcher>(*frontendRouter);
-    m_backendDispatcher = TimelineBackendDispatcher::create(*backendDispatcher, this);
+    this->m_frontendDispatcher = std::make_unique<TimelineFrontendDispatcher>(*frontendRouter);
+
+    if (!this->m_backendDispatcher) {
+        this->m_backendDispatcher = TimelineBackendDispatcher::create(*backendDispatcher, this);
+    }
 
     this->m_globalObject.inspectorController().setTimelineAgent(this);
 }
 
 void InspectorTimelineAgent::willDestroyFrontendAndBackend(DisconnectReason) {
-    m_frontendDispatcher = nullptr;
-    m_backendDispatcher = nullptr;
+
+    this->m_frontendDispatcher = nullptr;
 
     ErrorString unused;
     stop(unused);
@@ -327,4 +330,4 @@ void InspectorTimelineAgent::addRecordToTimeline(RefPtr<InspectorObject>&& recor
     auto recordObject = BindingTraits<Inspector::Protocol::Timeline::TimelineEvent>::runtimeCast(WTFMove(record));
     sendEvent(WTFMove(recordObject));
 }
-}
+} // namespace Inspector

--- a/src/NativeScript/inspector/InspectorTimelineAgent.cpp
+++ b/src/NativeScript/inspector/InspectorTimelineAgent.cpp
@@ -37,8 +37,6 @@ void InspectorTimelineAgent::didCreateFrontendAndBackend(FrontendRouter* fronten
 
 void InspectorTimelineAgent::willDestroyFrontendAndBackend(DisconnectReason) {
 
-    this->m_frontendDispatcher = nullptr;
-
     ErrorString unused;
     stop(unused);
 

--- a/src/NativeScript/inspector/InspectorTimelineAgent.cpp
+++ b/src/NativeScript/inspector/InspectorTimelineAgent.cpp
@@ -17,6 +17,9 @@ InspectorTimelineAgent::InspectorTimelineAgent(JSAgentContext& context, Inspecto
     , m_consoleRecordEntry()
     , m_maxCallStackDepth(5)
     , m_enabled(false) {
+
+    this->m_frontendDispatcher = std::make_unique<TimelineFrontendDispatcher>(context.frontendRouter);
+    this->m_backendDispatcher = TimelineBackendDispatcher::create(context.backendDispatcher, this);
 }
 
 void InspectorTimelineAgent::sendEvent(RefPtr<InspectorObject>&& event) {
@@ -29,12 +32,6 @@ void InspectorTimelineAgent::sendEvent(RefPtr<InspectorObject>&& event) {
 }
 
 void InspectorTimelineAgent::didCreateFrontendAndBackend(FrontendRouter* frontendRouter, BackendDispatcher* backendDispatcher) {
-    this->m_frontendDispatcher = std::make_unique<TimelineFrontendDispatcher>(*frontendRouter);
-
-    if (!this->m_backendDispatcher) {
-        this->m_backendDispatcher = TimelineBackendDispatcher::create(*backendDispatcher, this);
-    }
-
     this->m_globalObject.inspectorController().setTimelineAgent(this);
 }
 

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -26,301 +26,353 @@ typedef void (^TNSInspectorProtocolHandler)(NSString *message, NSError *error);
 typedef void (^TNSInspectorSendMessageBlock)(NSString *message);
 
 typedef TNSInspectorProtocolHandler (^TNSInspectorFrontendConnectedHandler)(
-    TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error);
+                                                                            TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error);
+
+typedef void (^TNSInspectorIoErrorHandler)(NSObject* dummy/*make compatible with CheckError macro*/, NSError *error);
 
 #define CheckError(retval, handler)                                            \
-  ({                                                                           \
-    int errorCode = (int)retval;                                               \
-    BOOL success = NO;                                                         \
-    if (errorCode == 0)                                                        \
-      success = YES;                                                           \
-    else if (errorCode == -1)                                                  \
-      errorCode = errno;                                                       \
-    if (!success)                                                              \
-      handler(nil, [NSError errorWithDomain:NSPOSIXErrorDomain                 \
-                                       code:errorCode                          \
-                                   userInfo:nil]);                             \
-    success;                                                                   \
-  })
+({                                                                           \
+int errorCode = (int)retval;                                               \
+BOOL success = NO;                                                         \
+if (errorCode == 0)                                                        \
+success = YES;                                                           \
+else if (errorCode == -1)                                                  \
+errorCode = errno;                                                       \
+if (!success)                                                              \
+handler(nil, [NSError errorWithDomain:NSPOSIXErrorDomain                 \
+code:errorCode                          \
+userInfo:nil]);                             \
+success;                                                                   \
+})
 
 #define NOTIFICATION(name)                                                     \
-  [[NSString stringWithFormat:@"%@:NativeScript.Debug.%s",                     \
-                              [[NSBundle mainBundle] bundleIdentifier], name]  \
-      UTF8String]
+[[NSString stringWithFormat:@"%@:NativeScript.Debug.%s",                     \
+[[NSBundle mainBundle] bundleIdentifier], name]  \
+UTF8String]
 
 static dispatch_source_t TNSCreateInspectorServer(
-    TNSInspectorFrontendConnectedHandler connectedHandler) {
-  dispatch_queue_t queue = dispatch_get_global_queue(0, 0);
-
-  dispatch_fd_t listenSocket = socket(PF_INET, SOCK_STREAM, 0);
-  int so_reuseaddr = 1;
-  setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &so_reuseaddr,
-             sizeof(so_reuseaddr));
-  struct sockaddr_in addr = {
-      sizeof(addr), AF_INET, htons(18181), {INADDR_ANY}, {0}};
-  if (!CheckError(
-          bind(listenSocket, (const struct sockaddr *)&addr, sizeof(addr)),
-          connectedHandler)) {
-    return nil;
-  }
-
-  if (!CheckError(listen(listenSocket, 0), connectedHandler)) {
-    return nil;
-  }
-
-  __block dispatch_source_t listenSource =
-      dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
-
-  dispatch_source_set_event_handler(listenSource, ^{
-    dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
-    dispatch_source_cancel(listenSource);
-    dispatch_io_t io =
-        dispatch_io_create(DISPATCH_IO_STREAM, newSocket, queue, ^(int error) {
-          CheckError(error, connectedHandler);
-        });
-
-    TNSInspectorSendMessageBlock sender = ^(NSString *message) {
-
-      NSUInteger length = [message
-          lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
-
-      uint8_t *buffer = (uint8_t *)malloc(length + sizeof(uint32_t));
-
-      *(uint32_t *)buffer = htonl(length);
-
-      [message getBytes:&buffer[sizeof(uint32_t)]
-               maxLength:length
-              usedLength:NULL
-                encoding:NSUTF16LittleEndianStringEncoding
-                 options:0
-                   range:NSMakeRange(0, message.length)
-          remainingRange:NULL];
-
-      dispatch_data_t data =
-          dispatch_data_create(buffer, length + sizeof(uint32_t), queue, ^{
-            free(buffer);
-          });
-
-      dispatch_io_write(io, 0, data, queue,
-                        ^(bool done, dispatch_data_t data, int error) {
-                          CheckError(error, connectedHandler);
-                        });
-    };
-
-    __block TNSInspectorProtocolHandler handler = connectedHandler(sender, nil);
-    if (!handler) {
-      dispatch_io_close(io, DISPATCH_IO_STOP);
-      close(newSocket);
-      return;
+                                                  TNSInspectorFrontendConnectedHandler connectedHandler,
+                                                  TNSInspectorIoErrorHandler ioErrorHandler) {
+    dispatch_queue_t queue = dispatch_get_global_queue(0, 0);
+    
+    dispatch_fd_t listenSocket = socket(PF_INET, SOCK_STREAM, 0);
+    int so_reuseaddr = 1;
+    setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &so_reuseaddr,
+               sizeof(so_reuseaddr));
+    struct sockaddr_in addr = {
+        sizeof(addr), AF_INET, htons(18181), {INADDR_ANY}, {0}};
+    if (!CheckError(
+                    bind(listenSocket, (const struct sockaddr *)&addr, sizeof(addr)),
+                    connectedHandler)) {
+        return nil;
     }
-
-    __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
-                                                int error) {
-      if (!CheckError(error, handler)) {
-        return;
-      }
-
-      const void *bytes = [(NSData *)data bytes];
-      if (!bytes) {
-        dispatch_io_close(io, DISPATCH_IO_STOP);
-        close(newSocket);
-        handler(nil, nil);
-        return;
-      }
-
-      uint32_t length = ntohl(*(uint32_t *)bytes);
-      dispatch_io_set_low_water(io, length);
-      dispatch_io_read(io, 0, length, queue,
-                       ^(bool done, dispatch_data_t data, int error) {
-                         if (!CheckError(error, handler)) {
-                           return;
-                         }
-
-                         NSString *payload = [[NSString alloc]
-                             initWithData:(NSData *)data
-                                 encoding:NSUTF16LittleEndianStringEncoding];
-                         handler(payload, nil);
-
+    
+    if (!CheckError(listen(listenSocket, 0), connectedHandler)) {
+        return nil;
+    }
+    
+    __block dispatch_source_t listenSource =
+    dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
+    
+    dispatch_source_set_event_handler(listenSource, ^{
+        if (inspector && [inspector hasFrontends]) {
+            // Only one connection is supported at a time. Accept and immediately close new attempt's socket
+            dispatch_fd_t secondInspectorSocket = accept(listenSocket, NULL, NULL);
+            close(secondInspectorSocket);
+            return;
+        }
+        
+        __block dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
+        
+        __block dispatch_io_t io = 0;
+        __block TNSInspectorProtocolHandler protocolHandler = nil;
+        __block TNSInspectorIoErrorHandler dataSocketErrorHandler =
+        ^(NSObject* dummy, NSError* error) {
+            assert(io);
+            if (io) {
+                dispatch_io_close(io, DISPATCH_IO_STOP);
+                io = 0;
+            }
+            assert(newSocket);
+            if (newSocket) {
+                close(newSocket);
+                newSocket = 0;
+            }
+            
+            if (protocolHandler) {
+                protocolHandler(nil, error);
+            }
+            
+            if (ioErrorHandler) {
+                ioErrorHandler(nil, error);
+            }
+        };
+        
+        io = dispatch_io_create(DISPATCH_IO_STREAM, newSocket, queue, ^(int error) {
+            CheckError(error, dataSocketErrorHandler);
+        });
+        
+        TNSInspectorSendMessageBlock sender = ^(NSString *message) {
+            if (!io) {
+                return;
+            }
+            
+            NSUInteger length = [message
+                                 lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
+            
+            uint8_t *buffer = (uint8_t *)malloc(length + sizeof(uint32_t));
+            
+            *(uint32_t *)buffer = htonl(length);
+            
+            [message getBytes:&buffer[sizeof(uint32_t)]
+                    maxLength:length
+                   usedLength:NULL
+                     encoding:NSUTF16LittleEndianStringEncoding
+                      options:0
+                        range:NSMakeRange(0, message.length)
+               remainingRange:NULL];
+            
+            dispatch_data_t data =
+            dispatch_data_create(buffer, length + sizeof(uint32_t), queue, ^{
+                free(buffer);
+            });
+            
+            dispatch_io_write(io, 0, data, queue,
+                              ^(bool done, dispatch_data_t data, int error) {
+                                  CheckError(error, dataSocketErrorHandler);
+                              });
+        };
+        
+        protocolHandler = connectedHandler(sender, nil);
+        if (!protocolHandler) {
+            dataSocketErrorHandler(nil, nil);
+            return;
+        }
+        
+        __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
+                                                    int error) {
+            if (!CheckError(error, dataSocketErrorHandler)) {
+                return;
+            }
+            
+            const void *bytes = [(NSData *)data bytes];
+            if (!bytes) {
+                dataSocketErrorHandler(nil, nil);
+                return;
+            }
+            
+            uint32_t length = ntohl(*(uint32_t *)bytes);
+            dispatch_io_set_low_water(io, length);
+            dispatch_io_read(io, 0, length, queue,
+                             ^(bool done, dispatch_data_t data, int error) {
+                                 if (!CheckError(error, dataSocketErrorHandler)) {
+                                     return;
+                                 }
+                                 
+                                 NSString *payload = [[NSString alloc]
+                                                      initWithData:(NSData *)data
+                                                      encoding:NSUTF16LittleEndianStringEncoding];
+                                 protocolHandler(payload, nil);
+                                 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-                         dispatch_io_read(io, 0, 4, queue, ioHandler);
+                                 dispatch_io_read(io, 0, 4, queue, ioHandler);
 #pragma clang diagnostic pop
-                       });
-    };
-
-    dispatch_io_read(io, 0, 4, queue, ioHandler);
-  });
-  dispatch_source_set_cancel_handler(listenSource, ^{
-    isWaitingForDebugger = NO;
-    listenSource = nil;
-    close(listenSocket);
-  });
-  dispatch_resume(listenSource);
-
-  return listenSource;
+                             });
+        };
+        
+        dispatch_io_read(io, 0, 4, queue, ioHandler);
+    });
+    dispatch_source_set_cancel_handler(listenSource, ^{
+        isWaitingForDebugger = NO;
+        listenSource = nil;
+        close(listenSocket);
+    });
+    dispatch_resume(listenSource);
+    
+    return listenSource;
 }
 
 static void TNSInspectorUncaughtExceptionHandler(NSException *exception) {
-  JSStringRef exceptionMessage =
-      JSStringCreateWithUTF8CString(exception.description.UTF8String);
-
-  JSValueRef errorArguments[] = {
-      JSValueMakeString(inspector.runtime.globalContext, exceptionMessage)};
-  JSObjectRef error = JSObjectMakeError(inspector.runtime.globalContext, 1,
-                                        errorArguments, NULL);
-
-  [inspector reportFatalError:error];
+    JSStringRef exceptionMessage =
+    JSStringCreateWithUTF8CString(exception.description.UTF8String);
+    
+    JSValueRef errorArguments[] = {
+        JSValueMakeString(inspector.runtime.globalContext, exceptionMessage)};
+    JSObjectRef error = JSObjectMakeError(inspector.runtime.globalContext, 1,
+                                          errorArguments, NULL);
+    
+    [inspector reportFatalError:error];
 }
 
 static void TNSEnableRemoteInspector(int argc, char **argv,
                                      TNSRuntime *runtime) {
-  __block dispatch_source_t listenSource = nil;
-
-  dispatch_block_t clear = ^{
-    dispatch_source_cancel(listenSource);
-    listenSource = nil;
-    inspector = nil;
-    NSSetUncaughtExceptionHandler(NULL);
-  };
-
-  [[NSNotificationCenter defaultCenter]
-      addObserverForName:UIApplicationWillResignActiveNotification
-                  object:nil
-                   queue:[NSOperationQueue mainQueue]
-              usingBlock:^(NSNotification *note) {
-                notify_post(NOTIFICATION("ApplicationWillResignActive"));
-              }];
-
-  [[NSNotificationCenter defaultCenter]
-      addObserverForName:UIApplicationDidBecomeActiveNotification
-                  object:nil
-                   queue:[NSOperationQueue mainQueue]
-              usingBlock:^(NSNotification *note) {
-                notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
-              }];
-
-  TNSInspectorFrontendConnectedHandler connectionHandler =
-      ^TNSInspectorProtocolHandler(
-          TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error) {
-        if (error) {
-          if (listenSource) {
-            clear();
-          }
-
-          NSLog(@"NativeScript debugger encountered %@.", error);
-          return nil;
-        }
-
+    __block dispatch_source_t listenSource = nil;
+    
+    dispatch_block_t clearInspector = ^{
         if (inspector) {
-          return nil;
+            inspector = nil;
         }
-
+        
+        NSSetUncaughtExceptionHandler(NULL);
+    };
+    
+    dispatch_block_t clear = ^{
+        if (listenSource) {
+            dispatch_source_cancel(listenSource);
+            listenSource = nil;
+        }
+        
+        clearInspector();
+    };
+    
+    [[NSNotificationCenter defaultCenter]
+     addObserverForName:UIApplicationWillResignActiveNotification
+     object:nil
+     queue:[NSOperationQueue mainQueue]
+     usingBlock:^(NSNotification *note) {
+         notify_post(NOTIFICATION("ApplicationWillResignActive"));
+     }];
+    
+    [[NSNotificationCenter defaultCenter]
+     addObserverForName:UIApplicationDidBecomeActiveNotification
+     object:nil
+     queue:[NSOperationQueue mainQueue]
+     usingBlock:^(NSNotification *note) {
+         notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
+     }];
+    
+    TNSInspectorFrontendConnectedHandler connectionHandler =
+    ^TNSInspectorProtocolHandler(
+                                 TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error) {
+        if (error) {
+            if (listenSource) {
+                clear();
+            }
+            
+            NSLog(@"NativeScript debugger encountered %@.", error);
+            return nil;
+        }
+        
+        if (inspector) {
+            return nil;
+        }
+        
         NSLog(@"NativeScript debugger attached.");
-
+        
         inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
-
+        
         NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
-
+        
         if (isWaitingForDebugger) {
-          isWaitingForDebugger = NO;
-
-          CFRunLoopRef runloop = CFRunLoopGetMain();
-          CFRunLoopPerformBlock(
-              runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
-                // If we pause right away the debugger messages that are send
-                // are not handled because the frontend is not yet initialized
-                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
-
-                [inspector pause];
-              });
-          CFRunLoopWakeUp(runloop);
-        }
-
-        NSArray *inspectorRunloopModes =
-            @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
-        return ^(NSString *message, NSError *error) {
-          if (message) {
+            isWaitingForDebugger = NO;
+            
             CFRunLoopRef runloop = CFRunLoopGetMain();
             CFRunLoopPerformBlock(
-                runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
-                  [inspector dispatchMessage:message];
-                });
+                                  runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
+                                      // If we pause right away the debugger messages that are send
+                                      // are not handled because the frontend is not yet initialized
+                                      CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+                                      
+                                      [inspector pause];
+                                  });
             CFRunLoopWakeUp(runloop);
-          } else {
-            clear();
-
-            if (error) {
-              NSLog(@"NativeScript debugger received %@. Disconnecting.",
-                    error);
-            } else {
-              NSLog(@"NativeScript debugger detached.");
-            }
-          }
-        };
-      };
-
-  int waitForDebuggerSubscription;
-  notify_register_dispatch(
-      NOTIFICATION("WaitForDebugger"), &waitForDebuggerSubscription,
-      dispatch_get_main_queue(), ^(int token) {
-        isWaitingForDebugger = YES;
-        NSLog(@"NativeScript waiting for debugger.");
-
-        CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
-          do {
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
-          } while (isWaitingForDebugger);
-        });
-        CFRunLoopWakeUp(CFRunLoopGetMain());
-      });
-
-  int attachRequestSubscription;
-  notify_register_dispatch(
-      NOTIFICATION("AttachRequest"), &attachRequestSubscription,
-      dispatch_get_main_queue(), ^(int token) {
-        if (listenSource) {
-          return;
         }
-
-        listenSource = TNSCreateInspectorServer(connectionHandler);
-        notify_post(NOTIFICATION("ReadyForAttach"));
-      });
-
-  int attachAvailabilityQuerySubscription;
-  notify_register_dispatch(NOTIFICATION("AttachAvailabilityQuery"),
-                           &attachAvailabilityQuerySubscription,
-                           dispatch_get_main_queue(), ^(int token) {
-                             if (inspector) {
-                               notify_post(NOTIFICATION("AlreadyConnected"));
-                             } else if (listenSource) {
-                               notify_post(NOTIFICATION("ReadyForAttach"));
-                             } else {
-                               notify_post(NOTIFICATION("AttachAvailable"));
-                             }
-                           });
-
-  notify_post(NOTIFICATION("AppLaunching"));
-
-  for (int i = 1; i < argc; i++) {
-    BOOL startListening = NO;
-    BOOL shouldWaitForDebugger = NO;
-
-    if (strcmp(argv[i], "--nativescript-debug-brk") == 0) {
-      shouldWaitForDebugger = YES;
-    } else if (strcmp(argv[i], "--nativescript-debug-start") == 0) {
-      startListening = YES;
+        
+        NSArray *inspectorRunloopModes =
+        @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
+        return ^(NSString *message, NSError *error) {
+            if (message) {
+                CFRunLoopRef runloop = CFRunLoopGetMain();
+                CFRunLoopPerformBlock(
+                                      runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
+                                          [inspector dispatchMessage:message];
+                                      });
+                CFRunLoopWakeUp(runloop);
+            } else {
+                clearInspector();
+                
+                if (error) {
+                    NSLog(@"NativeScript debugger received %@. Disconnecting.",
+                          error);
+                } else {
+                    NSLog(@"NativeScript debugger detached.");
+                }
+            }
+        };
+    };
+    
+    TNSInspectorIoErrorHandler ioErrorHandler =
+    ^(NSObject* dummy, NSError *error) {
+        clearInspector();
+        if (error) {
+            NSLog(@"NativeScript debugger encountered %@.", error);
+        }
+    };
+    
+    
+    int waitForDebuggerSubscription;
+    notify_register_dispatch(
+                             NOTIFICATION("WaitForDebugger"), &waitForDebuggerSubscription,
+                             dispatch_get_main_queue(), ^(int token) {
+                                 isWaitingForDebugger = YES;
+                                 NSLog(@"NativeScript waiting for debugger.");
+                                 
+                                 CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
+                                     do {
+                                         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+                                     } while (isWaitingForDebugger);
+                                 });
+                                 CFRunLoopWakeUp(CFRunLoopGetMain());
+                             });
+    
+    int attachRequestSubscription;
+    notify_register_dispatch(
+                             NOTIFICATION("AttachRequest"), &attachRequestSubscription,
+                             dispatch_get_main_queue(), ^(int token) {
+                                 if (listenSource) {
+                                     clear();
+                                 }
+                                 
+                                 listenSource = TNSCreateInspectorServer(connectionHandler, ioErrorHandler);
+                                 notify_post(NOTIFICATION("ReadyForAttach"));
+                             });
+    
+    int attachAvailabilityQuerySubscription;
+    notify_register_dispatch(NOTIFICATION("AttachAvailabilityQuery"),
+                             &attachAvailabilityQuerySubscription,
+                             dispatch_get_main_queue(), ^(int token) {
+                                 if (inspector) {
+                                     notify_post(NOTIFICATION("AlreadyConnected"));
+                                 } else if (listenSource) {
+                                     notify_post(NOTIFICATION("ReadyForAttach"));
+                                 } else {
+                                     notify_post(NOTIFICATION("AttachAvailable"));
+                                 }
+                             });
+    
+    notify_post(NOTIFICATION("AppLaunching"));
+    
+    for (int i = 1; i < argc; i++) {
+        BOOL startListening = NO;
+        BOOL shouldWaitForDebugger = NO;
+        
+        if (strcmp(argv[i], "--nativescript-debug-brk") == 0) {
+            shouldWaitForDebugger = YES;
+        } else if (strcmp(argv[i], "--nativescript-debug-start") == 0) {
+            startListening = YES;
+        }
+        
+        if (startListening || shouldWaitForDebugger) {
+            notify_post(NOTIFICATION("AttachRequest"));
+            if (shouldWaitForDebugger) {
+                notify_post(NOTIFICATION("WaitForDebugger"));
+            }
+            
+            break;
+        }
     }
-
-    if (startListening || shouldWaitForDebugger) {
-      notify_post(NOTIFICATION("AttachRequest"));
-      if (shouldWaitForDebugger) {
-        notify_post(NOTIFICATION("WaitForDebugger"));
-      }
-
-      break;
-    }
-  }
-
-  CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);
-  notify_cancel(waitForDebuggerSubscription);
+    
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);
+    notify_cancel(waitForDebuggerSubscription);
 }

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -18,361 +18,356 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-static TNSRuntimeInspector *inspector = nil;
+static TNSRuntimeInspector* inspector = nil;
 static BOOL isWaitingForDebugger = NO;
 
-typedef void (^TNSInspectorProtocolHandler)(NSString *message, NSError *error);
+typedef void (^TNSInspectorProtocolHandler)(NSString* message, NSError* error);
 
-typedef void (^TNSInspectorSendMessageBlock)(NSString *message);
+typedef void (^TNSInspectorSendMessageBlock)(NSString* message);
 
 typedef TNSInspectorProtocolHandler (^TNSInspectorFrontendConnectedHandler)(
-                                                                            TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error);
+    TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error);
 
-typedef void (^TNSInspectorIoErrorHandler)(NSObject* dummy/*make compatible with CheckError macro*/, NSError *error);
+typedef void (^TNSInspectorIoErrorHandler)(NSObject* dummy /*make compatible with CheckError macro*/, NSError* error);
 
-#define CheckError(retval, handler)                                            \
-({                                                                           \
-int errorCode = (int)retval;                                               \
-BOOL success = NO;                                                         \
-if (errorCode == 0)                                                        \
-success = YES;                                                           \
-else if (errorCode == -1)                                                  \
-errorCode = errno;                                                       \
-if (!success)                                                              \
-handler(nil, [NSError errorWithDomain:NSPOSIXErrorDomain                 \
-code:errorCode                          \
-userInfo:nil]);                             \
-success;                                                                   \
-})
+#define CheckError(retval, handler)                                  \
+    ({                                                               \
+        int errorCode = (int)retval;                                 \
+        BOOL success = NO;                                           \
+        if (errorCode == 0)                                          \
+            success = YES;                                           \
+        else if (errorCode == -1)                                    \
+            errorCode = errno;                                       \
+        if (!success)                                                \
+            handler(nil, [NSError errorWithDomain:NSPOSIXErrorDomain \
+                                             code:errorCode          \
+                                         userInfo:nil]);             \
+        success;                                                     \
+    })
 
-#define NOTIFICATION(name)                                                     \
-[[NSString stringWithFormat:@"%@:NativeScript.Debug.%s",                     \
-[[NSBundle mainBundle] bundleIdentifier], name]  \
-UTF8String]
+#define NOTIFICATION(name)                                                      \
+    [[NSString stringWithFormat:@"%@:NativeScript.Debug.%s",                    \
+                                [[NSBundle mainBundle] bundleIdentifier], name] \
+        UTF8String]
 
 static dispatch_source_t TNSCreateInspectorServer(
-                                                  TNSInspectorFrontendConnectedHandler connectedHandler,
-                                                  TNSInspectorIoErrorHandler ioErrorHandler) {
+    TNSInspectorFrontendConnectedHandler connectedHandler,
+    TNSInspectorIoErrorHandler ioErrorHandler) {
     dispatch_queue_t queue = dispatch_get_global_queue(0, 0);
-    
+
     dispatch_fd_t listenSocket = socket(PF_INET, SOCK_STREAM, 0);
     int so_reuseaddr = 1;
     setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &so_reuseaddr,
                sizeof(so_reuseaddr));
     struct sockaddr_in addr = {
-        sizeof(addr), AF_INET, htons(18181), {INADDR_ANY}, {0}};
+        sizeof(addr), AF_INET, htons(18181), { INADDR_ANY }, { 0 }
+    };
     if (!CheckError(
-                    bind(listenSocket, (const struct sockaddr *)&addr, sizeof(addr)),
-                    connectedHandler)) {
+            bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)),
+            connectedHandler)) {
         return nil;
     }
-    
+
     if (!CheckError(listen(listenSocket, 0), connectedHandler)) {
         return nil;
     }
-    
-    __block dispatch_source_t listenSource =
-    dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
-    
+
+    __block dispatch_source_t listenSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
+
     dispatch_source_set_event_handler(listenSource, ^{
-        if (inspector && [inspector hasFrontends]) {
-            // Only one connection is supported at a time. Accept and immediately close new attempt's socket
-            dispatch_fd_t secondInspectorSocket = accept(listenSocket, NULL, NULL);
-            close(secondInspectorSocket);
+      if (inspector && [inspector hasFrontends]) {
+          // Only one connection is supported at a time. Accept and immediately close new attempt's socket
+          dispatch_fd_t secondInspectorSocket = accept(listenSocket, NULL, NULL);
+          close(secondInspectorSocket);
+          return;
+      }
+
+      __block dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
+
+      __block dispatch_io_t io = 0;
+      __block TNSInspectorProtocolHandler protocolHandler = nil;
+      __block TNSInspectorIoErrorHandler dataSocketErrorHandler = ^(NSObject* dummy, NSError* error) {
+        assert(io);
+        if (io) {
+            dispatch_io_close(io, DISPATCH_IO_STOP);
+            io = 0;
+        }
+        assert(newSocket);
+        if (newSocket) {
+            close(newSocket);
+            newSocket = 0;
+        }
+
+        if (protocolHandler) {
+            protocolHandler(nil, error);
+        }
+
+        if (ioErrorHandler) {
+            ioErrorHandler(nil, error);
+        }
+      };
+
+      io = dispatch_io_create(DISPATCH_IO_STREAM, newSocket, queue, ^(int error) {
+        CheckError(error, dataSocketErrorHandler);
+      });
+
+      TNSInspectorSendMessageBlock sender = ^(NSString* message) {
+        if (!io) {
             return;
         }
-        
-        __block dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
-        
-        __block dispatch_io_t io = 0;
-        __block TNSInspectorProtocolHandler protocolHandler = nil;
-        __block TNSInspectorIoErrorHandler dataSocketErrorHandler =
-        ^(NSObject* dummy, NSError* error) {
-            assert(io);
-            if (io) {
-                dispatch_io_close(io, DISPATCH_IO_STOP);
-                io = 0;
-            }
-            assert(newSocket);
-            if (newSocket) {
-                close(newSocket);
-                newSocket = 0;
-            }
-            
-            if (protocolHandler) {
-                protocolHandler(nil, error);
-            }
-            
-            if (ioErrorHandler) {
-                ioErrorHandler(nil, error);
-            }
-        };
-        
-        io = dispatch_io_create(DISPATCH_IO_STREAM, newSocket, queue, ^(int error) {
-            CheckError(error, dataSocketErrorHandler);
+
+        NSUInteger length = [message
+            lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
+
+        uint8_t* buffer = (uint8_t*)malloc(length + sizeof(uint32_t));
+
+        *(uint32_t*)buffer = htonl(length);
+
+        [message getBytes:&buffer[sizeof(uint32_t)]
+                 maxLength:length
+                usedLength:NULL
+                  encoding:NSUTF16LittleEndianStringEncoding
+                   options:0
+                     range:NSMakeRange(0, message.length)
+            remainingRange:NULL];
+
+        dispatch_data_t data = dispatch_data_create(buffer, length + sizeof(uint32_t), queue, ^{
+          free(buffer);
         });
-        
-        TNSInspectorSendMessageBlock sender = ^(NSString *message) {
-            if (!io) {
-                return;
-            }
-            
-            NSUInteger length = [message
-                                 lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
-            
-            uint8_t *buffer = (uint8_t *)malloc(length + sizeof(uint32_t));
-            
-            *(uint32_t *)buffer = htonl(length);
-            
-            [message getBytes:&buffer[sizeof(uint32_t)]
-                    maxLength:length
-                   usedLength:NULL
-                     encoding:NSUTF16LittleEndianStringEncoding
-                      options:0
-                        range:NSMakeRange(0, message.length)
-               remainingRange:NULL];
-            
-            dispatch_data_t data =
-            dispatch_data_create(buffer, length + sizeof(uint32_t), queue, ^{
-                free(buffer);
-            });
-            
-            dispatch_io_write(io, 0, data, queue,
-                              ^(bool done, dispatch_data_t data, int error) {
-                                  CheckError(error, dataSocketErrorHandler);
-                              });
-        };
-        
-        protocolHandler = connectedHandler(sender, nil);
-        if (!protocolHandler) {
+
+        dispatch_io_write(io, 0, data, queue,
+                          ^(bool done, dispatch_data_t data, int error) {
+                            CheckError(error, dataSocketErrorHandler);
+                          });
+      };
+
+      protocolHandler = connectedHandler(sender, nil);
+      if (!protocolHandler) {
+          dataSocketErrorHandler(nil, nil);
+          return;
+      }
+
+      __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
+                                                  int error) {
+        if (!CheckError(error, dataSocketErrorHandler)) {
+            return;
+        }
+
+        const void* bytes = [(NSData*)data bytes];
+        if (!bytes) {
             dataSocketErrorHandler(nil, nil);
             return;
         }
-        
-        __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
-                                                    int error) {
-            if (!CheckError(error, dataSocketErrorHandler)) {
-                return;
-            }
-            
-            const void *bytes = [(NSData *)data bytes];
-            if (!bytes) {
-                dataSocketErrorHandler(nil, nil);
-                return;
-            }
-            
-            uint32_t length = ntohl(*(uint32_t *)bytes);
-            dispatch_io_set_low_water(io, length);
-            dispatch_io_read(io, 0, length, queue,
-                             ^(bool done, dispatch_data_t data, int error) {
-                                 if (!CheckError(error, dataSocketErrorHandler)) {
-                                     return;
-                                 }
-                                 
-                                 NSString *payload = [[NSString alloc]
-                                                      initWithData:(NSData *)data
-                                                      encoding:NSUTF16LittleEndianStringEncoding];
-                                 protocolHandler(payload, nil);
-                                 
+
+        uint32_t length = ntohl(*(uint32_t*)bytes);
+        dispatch_io_set_low_water(io, length);
+        dispatch_io_read(io, 0, length, queue,
+                         ^(bool done, dispatch_data_t data, int error) {
+                           if (!CheckError(error, dataSocketErrorHandler)) {
+                               return;
+                           }
+
+                           NSString* payload = [[NSString alloc]
+                               initWithData:(NSData*)data
+                                   encoding:NSUTF16LittleEndianStringEncoding];
+                           protocolHandler(payload, nil);
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-                                 dispatch_io_read(io, 0, 4, queue, ioHandler);
+                           dispatch_io_read(io, 0, 4, queue, ioHandler);
 #pragma clang diagnostic pop
-                             });
-        };
-        
-        dispatch_io_read(io, 0, 4, queue, ioHandler);
+                         });
+      };
+
+      dispatch_io_read(io, 0, 4, queue, ioHandler);
     });
     dispatch_source_set_cancel_handler(listenSource, ^{
-        isWaitingForDebugger = NO;
-        listenSource = nil;
-        close(listenSocket);
+      isWaitingForDebugger = NO;
+      listenSource = nil;
+      close(listenSocket);
     });
     dispatch_resume(listenSource);
-    
+
     return listenSource;
 }
 
-static void TNSInspectorUncaughtExceptionHandler(NSException *exception) {
-    JSStringRef exceptionMessage =
-    JSStringCreateWithUTF8CString(exception.description.UTF8String);
-    
+static void TNSInspectorUncaughtExceptionHandler(NSException* exception) {
+    JSStringRef exceptionMessage = JSStringCreateWithUTF8CString(exception.description.UTF8String);
+
     JSValueRef errorArguments[] = {
-        JSValueMakeString(inspector.runtime.globalContext, exceptionMessage)};
+        JSValueMakeString(inspector.runtime.globalContext, exceptionMessage)
+    };
     JSObjectRef error = JSObjectMakeError(inspector.runtime.globalContext, 1,
                                           errorArguments, NULL);
-    
+
     [inspector reportFatalError:error];
 }
 
-static void TNSEnableRemoteInspector(int argc, char **argv,
-                                     TNSRuntime *runtime) {
+static void TNSEnableRemoteInspector(int argc, char** argv,
+                                     TNSRuntime* runtime) {
     __block dispatch_source_t listenSource = nil;
-    
+
     dispatch_block_t clearInspector = ^{
-        if (inspector) {
-            inspector = nil;
-        }
-        
-        NSSetUncaughtExceptionHandler(NULL);
+      if (inspector) {
+          inspector = nil;
+      }
+
+      NSSetUncaughtExceptionHandler(NULL);
     };
-    
+
     dispatch_block_t clear = ^{
-        if (listenSource) {
-            dispatch_source_cancel(listenSource);
-            listenSource = nil;
-        }
-        
-        clearInspector();
+      if (listenSource) {
+          dispatch_source_cancel(listenSource);
+          listenSource = nil;
+      }
+
+      clearInspector();
     };
-    
+
     [[NSNotificationCenter defaultCenter]
-     addObserverForName:UIApplicationWillResignActiveNotification
-     object:nil
-     queue:[NSOperationQueue mainQueue]
-     usingBlock:^(NSNotification *note) {
-         notify_post(NOTIFICATION("ApplicationWillResignActive"));
-     }];
-    
+        addObserverForName:UIApplicationWillResignActiveNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(NSNotification* note) {
+                  notify_post(NOTIFICATION("ApplicationWillResignActive"));
+                }];
+
     [[NSNotificationCenter defaultCenter]
-     addObserverForName:UIApplicationDidBecomeActiveNotification
-     object:nil
-     queue:[NSOperationQueue mainQueue]
-     usingBlock:^(NSNotification *note) {
-         notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
-     }];
-    
-    TNSInspectorFrontendConnectedHandler connectionHandler =
-    ^TNSInspectorProtocolHandler(
-                                 TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error) {
-        if (error) {
-            if (listenSource) {
-                clear();
-            }
-            
-            NSLog(@"NativeScript debugger encountered %@.", error);
-            return nil;
-        }
-        
-        if (inspector) {
-            return nil;
-        }
-        
-        NSLog(@"NativeScript debugger attached.");
-        
-        inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
-        
-        NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
-        
-        if (isWaitingForDebugger) {
-            isWaitingForDebugger = NO;
-            
+        addObserverForName:UIApplicationDidBecomeActiveNotification
+                    object:nil
+                     queue:[NSOperationQueue mainQueue]
+                usingBlock:^(NSNotification* note) {
+                  notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
+                }];
+
+    TNSInspectorFrontendConnectedHandler connectionHandler = ^TNSInspectorProtocolHandler(
+        TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error) {
+      if (error) {
+          if (listenSource) {
+              clear();
+          }
+
+          NSLog(@"NativeScript debugger encountered %@.", error);
+          return nil;
+      }
+
+      if (inspector) {
+          return nil;
+      }
+
+      NSLog(@"NativeScript debugger attached.");
+
+      inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
+
+      NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
+
+      if (isWaitingForDebugger) {
+          isWaitingForDebugger = NO;
+
+          CFRunLoopRef runloop = CFRunLoopGetMain();
+          CFRunLoopPerformBlock(
+              runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
+                // If we pause right away the debugger messages that are send
+                // are not handled because the frontend is not yet initialized
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+
+                [inspector pause];
+              });
+          CFRunLoopWakeUp(runloop);
+      }
+
+      NSArray* inspectorRunloopModes =
+          @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
+      return ^(NSString* message, NSError* error) {
+        if (message) {
             CFRunLoopRef runloop = CFRunLoopGetMain();
             CFRunLoopPerformBlock(
-                                  runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
-                                      // If we pause right away the debugger messages that are send
-                                      // are not handled because the frontend is not yet initialized
-                                      CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
-                                      
-                                      [inspector pause];
-                                  });
+                runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
+                  [inspector dispatchMessage:message];
+                });
             CFRunLoopWakeUp(runloop);
-        }
-        
-        NSArray *inspectorRunloopModes =
-        @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
-        return ^(NSString *message, NSError *error) {
-            if (message) {
-                CFRunLoopRef runloop = CFRunLoopGetMain();
-                CFRunLoopPerformBlock(
-                                      runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
-                                          [inspector dispatchMessage:message];
-                                      });
-                CFRunLoopWakeUp(runloop);
+        } else {
+            clearInspector();
+
+            if (error) {
+                NSLog(@"NativeScript debugger received %@. Disconnecting.",
+                      error);
             } else {
-                clearInspector();
-                
-                if (error) {
-                    NSLog(@"NativeScript debugger received %@. Disconnecting.",
-                          error);
-                } else {
-                    NSLog(@"NativeScript debugger detached.");
-                }
+                NSLog(@"NativeScript debugger detached.");
             }
-        };
-    };
-    
-    TNSInspectorIoErrorHandler ioErrorHandler =
-    ^(NSObject* dummy, NSError *error) {
-        clearInspector();
-        if (error) {
-            NSLog(@"NativeScript debugger encountered %@.", error);
         }
+      };
     };
-    
-    
+
+    TNSInspectorIoErrorHandler ioErrorHandler = ^(NSObject* dummy, NSError* error) {
+      clearInspector();
+      if (error) {
+          NSLog(@"NativeScript debugger encountered %@.", error);
+      }
+    };
+
     int waitForDebuggerSubscription;
     notify_register_dispatch(
-                             NOTIFICATION("WaitForDebugger"), &waitForDebuggerSubscription,
-                             dispatch_get_main_queue(), ^(int token) {
-                                 isWaitingForDebugger = YES;
-                                 NSLog(@"NativeScript waiting for debugger.");
-                                 
-                                 CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
-                                     do {
-                                         CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
-                                     } while (isWaitingForDebugger);
-                                 });
-                                 CFRunLoopWakeUp(CFRunLoopGetMain());
-                             });
-    
+        NOTIFICATION("WaitForDebugger"), &waitForDebuggerSubscription,
+        dispatch_get_main_queue(), ^(int token) {
+          isWaitingForDebugger = YES;
+          NSLog(@"NativeScript waiting for debugger.");
+
+          CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
+            do {
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+            } while (isWaitingForDebugger);
+          });
+          CFRunLoopWakeUp(CFRunLoopGetMain());
+        });
+
     int attachRequestSubscription;
     notify_register_dispatch(
-                             NOTIFICATION("AttachRequest"), &attachRequestSubscription,
-                             dispatch_get_main_queue(), ^(int token) {
-                                 if (listenSource) {
-                                     clear();
-                                 }
-                                 
-                                 listenSource = TNSCreateInspectorServer(connectionHandler, ioErrorHandler);
-                                 notify_post(NOTIFICATION("ReadyForAttach"));
-                             });
-    
+        NOTIFICATION("AttachRequest"), &attachRequestSubscription,
+        dispatch_get_main_queue(), ^(int token) {
+          if (listenSource) {
+              clear();
+          }
+
+          listenSource = TNSCreateInspectorServer(connectionHandler, ioErrorHandler);
+          notify_post(NOTIFICATION("ReadyForAttach"));
+        });
+
     int attachAvailabilityQuerySubscription;
     notify_register_dispatch(NOTIFICATION("AttachAvailabilityQuery"),
                              &attachAvailabilityQuerySubscription,
                              dispatch_get_main_queue(), ^(int token) {
-                                 if (inspector) {
-                                     notify_post(NOTIFICATION("AlreadyConnected"));
-                                 } else if (listenSource) {
-                                     notify_post(NOTIFICATION("ReadyForAttach"));
-                                 } else {
-                                     notify_post(NOTIFICATION("AttachAvailable"));
-                                 }
+                               if (inspector) {
+                                   notify_post(NOTIFICATION("AlreadyConnected"));
+                               } else if (listenSource) {
+                                   notify_post(NOTIFICATION("ReadyForAttach"));
+                               } else {
+                                   notify_post(NOTIFICATION("AttachAvailable"));
+                               }
                              });
-    
+
     notify_post(NOTIFICATION("AppLaunching"));
-    
+
     for (int i = 1; i < argc; i++) {
         BOOL startListening = NO;
         BOOL shouldWaitForDebugger = NO;
-        
+
         if (strcmp(argv[i], "--nativescript-debug-brk") == 0) {
             shouldWaitForDebugger = YES;
         } else if (strcmp(argv[i], "--nativescript-debug-start") == 0) {
             startListening = YES;
         }
-        
+
         if (startListening || shouldWaitForDebugger) {
             notify_post(NOTIFICATION("AttachRequest"));
             if (shouldWaitForDebugger) {
                 notify_post(NOTIFICATION("WaitForDebugger"));
             }
-            
+
             break;
         }
     }
-    
+
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.5, false);
     notify_cancel(waitForDebuggerSubscription);
 }

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -312,17 +312,6 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
       if (isWaitingForDebugger) {
           isWaitingForDebugger = NO;
           [tempInspector pause];
-
-          //            CFRunLoopRef runloop = CFRunLoopGetMain();
-          //            CFRunLoopPerformBlock(
-          //                                  runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
-          //                                      // If we pause right away the debugger messages that are send
-          //                                      // are not handled because the frontend is not yet initialized
-          //                                      CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
-          //
-          //                                      [inspector pause];
-          //                                  });
-          //            CFRunLoopWakeUp(runloop);
       }
       NSArray* inspectorRunloopModes =
           @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
@@ -337,7 +326,9 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
                       tempInspector = inspector;
                   }
 
-                  [tempInspector dispatchMessage:message];
+                  if (tempInspector) {
+                      [tempInspector dispatchMessage:message];
+                  }
                 });
             CFRunLoopWakeUp(runloop);
         } else {

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -157,8 +157,8 @@ static dispatch_source_t TNSCreateInspectorServer(
           return;
       }
 
-      __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
-                                                  int error) {
+      __block dispatch_io_handler_t receiver = ^(bool done, dispatch_data_t data,
+                                                 int error) {
         if (!CheckError(error, dataSocketErrorHandler)) {
             return;
         }
@@ -188,7 +188,7 @@ static dispatch_source_t TNSCreateInspectorServer(
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
                                    @synchronized(inspectorLock()) {
                                        if (io) {
-                                           dispatch_io_read(io, 0, 4, queue, ioHandler);
+                                           dispatch_io_read(io, 0, 4, queue, receiver);
                                        }
                                    }
 #pragma clang diagnostic pop
@@ -199,7 +199,7 @@ static dispatch_source_t TNSCreateInspectorServer(
 
       @synchronized(inspectorLock()) {
           if (io) {
-              dispatch_io_read(io, 0, 4, queue, ioHandler);
+              dispatch_io_read(io, 0, 4, queue, receiver);
           }
       }
     });

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -5,18 +5,18 @@
 //  Copyright (c) 2015 г. Telerik. All rights reserved.
 //
 
-#import <UIKit/UIApplication.h>
-#import <JavaScriptCore/JavaScript.h>
 #import <JavaScriptCore/JSStringRefCF.h>
+#import <JavaScriptCore/JavaScript.h>
 #import <NativeScript.h>
+#import <UIKit/UIApplication.h>
 
-#include <netinet/in.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <errno.h>
+#include <netinet/in.h>
+#include <notify.h>
 #include <stdlib.h>
 #include <string.h>
-#include <notify.h>
+#include <sys/socket.h>
+#include <sys/types.h>
 
 static TNSRuntimeInspector *inspector = nil;
 static BOOL isWaitingForDebugger = NO;
@@ -45,8 +45,8 @@ typedef TNSInspectorProtocolHandler (^TNSInspectorFrontendConnectedHandler)(
 
 #define NOTIFICATION(name)                                                     \
   [[NSString stringWithFormat:@"%@:NativeScript.Debug.%s",                     \
-                              [[NSBundle mainBundle] bundleIdentifier],        \
-                              name] UTF8String]
+                              [[NSBundle mainBundle] bundleIdentifier], name]  \
+      UTF8String]
 
 static dispatch_source_t TNSCreateInspectorServer(
     TNSInspectorFrontendConnectedHandler connectedHandler) {
@@ -72,81 +72,87 @@ static dispatch_source_t TNSCreateInspectorServer(
       dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
 
   dispatch_source_set_event_handler(listenSource, ^{
-      dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
+    dispatch_fd_t newSocket = accept(listenSocket, NULL, NULL);
 
-      dispatch_io_t io = dispatch_io_create(
-          DISPATCH_IO_STREAM, newSocket, queue,
-          ^(int error) { CheckError(error, connectedHandler); });
+    dispatch_io_t io =
+        dispatch_io_create(DISPATCH_IO_STREAM, newSocket, queue, ^(int error) {
+          CheckError(error, connectedHandler);
+        });
 
-      TNSInspectorSendMessageBlock sender = ^(NSString *message) {
+    TNSInspectorSendMessageBlock sender = ^(NSString *message) {
 
-          NSUInteger length = [message
-              lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
+      NSUInteger length = [message
+          lengthOfBytesUsingEncoding:NSUTF16LittleEndianStringEncoding];
 
-          uint8_t* buffer = (uint8_t*)malloc(length + sizeof(uint32_t));
+      uint8_t *buffer = (uint8_t *)malloc(length + sizeof(uint32_t));
 
-          *(uint32_t *)buffer = htonl(length);
+      *(uint32_t *)buffer = htonl(length);
 
-          [message getBytes:&buffer[sizeof(uint32_t)]
-                   maxLength:length
-                  usedLength:NULL
-                    encoding:NSUTF16LittleEndianStringEncoding
-                     options:0
-                       range:NSMakeRange(0, message.length)
-              remainingRange:NULL];
+      [message getBytes:&buffer[sizeof(uint32_t)]
+               maxLength:length
+              usedLength:NULL
+                encoding:NSUTF16LittleEndianStringEncoding
+                 options:0
+                   range:NSMakeRange(0, message.length)
+          remainingRange:NULL];
 
-          dispatch_data_t data = dispatch_data_create(
-              buffer, length + sizeof(uint32_t), queue, ^{ free(buffer); });
-
-          dispatch_io_write(io, 0, data, queue,
-                            ^(bool done, dispatch_data_t data, int error) {
-              CheckError(error, connectedHandler);
+      dispatch_data_t data =
+          dispatch_data_create(buffer, length + sizeof(uint32_t), queue, ^{
+            free(buffer);
           });
-      };
 
-      __block TNSInspectorProtocolHandler handler =
-          connectedHandler(sender, nil);
-      if (!handler) {
-        close(newSocket);
+      dispatch_io_write(io, 0, data, queue,
+                        ^(bool done, dispatch_data_t data, int error) {
+                          CheckError(error, connectedHandler);
+                        });
+    };
+
+    __block TNSInspectorProtocolHandler handler = connectedHandler(sender, nil);
+    if (!handler) {
+      dispatch_io_close(io, DISPATCH_IO_STOP);
+      close(newSocket);
+      return;
+    }
+
+    __block dispatch_io_handler_t ioHandler = ^(bool done, dispatch_data_t data,
+                                                int error) {
+      if (!CheckError(error, handler)) {
         return;
       }
 
-      __block dispatch_io_handler_t ioHandler =
-          ^(bool done, dispatch_data_t data, int error) {
-          if (!CheckError(error, handler)) {
-            return;
-          }
+      const void *bytes = [(NSData *)data bytes];
+      if (!bytes) {
+        dispatch_io_close(io, DISPATCH_IO_STOP);
+        close(newSocket);
+        handler(nil, nil);
+        return;
+      }
 
-          const void *bytes = [(NSData *)data bytes];
-          if (!bytes) {
-            close(newSocket);
-            handler(nil, nil);
-            return;
-          }
+      uint32_t length = ntohl(*(uint32_t *)bytes);
+      dispatch_io_set_low_water(io, length);
+      dispatch_io_read(io, 0, length, queue,
+                       ^(bool done, dispatch_data_t data, int error) {
+                         if (!CheckError(error, handler)) {
+                           return;
+                         }
 
-          uint32_t length = ntohl(*(uint32_t *)bytes);
-          dispatch_io_set_low_water(io, length);
-          dispatch_io_read(io, 0, length, queue,
-                           ^(bool done, dispatch_data_t data, int error) {
-              if (!CheckError(error, handler)) {
-                return;
-              }
-
-              NSString *payload = [[NSString alloc]
-                  initWithData:(NSData *)data
-                      encoding:NSUTF16LittleEndianStringEncoding];
-              handler(payload, nil);
+                         NSString *payload = [[NSString alloc]
+                             initWithData:(NSData *)data
+                                 encoding:NSUTF16LittleEndianStringEncoding];
+                         handler(payload, nil);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-              dispatch_io_read(io, 0, 4, queue, ioHandler);
+                         dispatch_io_read(io, 0, 4, queue, ioHandler);
 #pragma clang diagnostic pop
-          });
-      };
+                       });
+    };
 
-      dispatch_io_read(io, 0, 4, queue, ioHandler);
+    dispatch_io_read(io, 0, 4, queue, ioHandler);
   });
-  dispatch_source_set_cancel_handler(listenSource, ^{ close(listenSocket); });
+  dispatch_source_set_cancel_handler(listenSource, ^{
+    close(listenSocket);
+  });
   dispatch_resume(listenSource);
 
   return listenSource;
@@ -158,20 +164,21 @@ static void TNSInspectorUncaughtExceptionHandler(NSException *exception) {
 
   JSValueRef errorArguments[] = {
       JSValueMakeString(inspector.runtime.globalContext, exceptionMessage)};
-  JSObjectRef error =
-      JSObjectMakeError(inspector.runtime.globalContext, 1, errorArguments, NULL);
+  JSObjectRef error = JSObjectMakeError(inspector.runtime.globalContext, 1,
+                                        errorArguments, NULL);
 
   [inspector reportFatalError:error];
 }
 
-static void TNSEnableRemoteInspector(int argc, char **argv, TNSRuntime *runtime) {
+static void TNSEnableRemoteInspector(int argc, char **argv,
+                                     TNSRuntime *runtime) {
   __block dispatch_source_t listenSource = nil;
 
   dispatch_block_t clear = ^{
-      dispatch_source_cancel(listenSource);
-      listenSource = nil;
-      inspector = nil;
-      NSSetUncaughtExceptionHandler(NULL);
+    dispatch_source_cancel(listenSource);
+    listenSource = nil;
+    inspector = nil;
+    NSSetUncaughtExceptionHandler(NULL);
   };
 
   [[NSNotificationCenter defaultCenter]
@@ -179,7 +186,7 @@ static void TNSEnableRemoteInspector(int argc, char **argv, TNSRuntime *runtime)
                   object:nil
                    queue:[NSOperationQueue mainQueue]
               usingBlock:^(NSNotification *note) {
-                  notify_post(NOTIFICATION("ApplicationWillResignActive"));
+                notify_post(NOTIFICATION("ApplicationWillResignActive"));
               }];
 
   [[NSNotificationCenter defaultCenter]
@@ -187,54 +194,55 @@ static void TNSEnableRemoteInspector(int argc, char **argv, TNSRuntime *runtime)
                   object:nil
                    queue:[NSOperationQueue mainQueue]
               usingBlock:^(NSNotification *note) {
-                  notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
+                notify_post(NOTIFICATION("ApplicationDidBecomeActive"));
               }];
 
   TNSInspectorFrontendConnectedHandler connectionHandler =
       ^TNSInspectorProtocolHandler(
           TNSInspectorSendMessageBlock sendMessageToFrontend, NSError *error) {
-      if (error) {
-        if (listenSource) {
-          clear();
+        if (error) {
+          if (listenSource) {
+            clear();
+          }
+
+          NSLog(@"NativeScript debugger encountered %@.", error);
+          return nil;
         }
 
-        NSLog(@"NativeScript debugger encountered %@.", error);
-        return nil;
-      }
+        if (inspector) {
+          return nil;
+        }
 
-      if (inspector) {
-        return nil;
-      }
+        NSLog(@"NativeScript debugger attached.");
 
-      NSLog(@"NativeScript debugger attached.");
+        inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
 
-      inspector = [runtime attachInspectorWithHandler:sendMessageToFrontend];
+        NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
 
-      NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
+        if (isWaitingForDebugger) {
+          isWaitingForDebugger = NO;
 
-      if (isWaitingForDebugger) {
-        isWaitingForDebugger = NO;
+          CFRunLoopRef runloop = CFRunLoopGetMain();
+          CFRunLoopPerformBlock(
+              runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
+                // If we pause right away the debugger messages that are send
+                // are not handled because the frontend is not yet initialized
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
 
-        CFRunLoopRef runloop = CFRunLoopGetMain();
-        CFRunLoopPerformBlock(runloop,
-                              (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
-            // If we pause right away the debugger messages that are send are
-            // not handled because the frontend is not yet initialized
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+                [inspector pause];
+              });
+          CFRunLoopWakeUp(runloop);
+        }
 
-            [inspector pause];
-        });
-        CFRunLoopWakeUp(runloop);
-      }
-
-      NSArray *inspectorRunloopModes =
-          @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
-      return ^(NSString *message, NSError *error) {
+        NSArray *inspectorRunloopModes =
+            @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];
+        return ^(NSString *message, NSError *error) {
           if (message) {
             CFRunLoopRef runloop = CFRunLoopGetMain();
-            CFRunLoopPerformBlock(runloop,
-                                  (__bridge CFTypeRef)(inspectorRunloopModes),
-                                  ^{ [inspector dispatchMessage:message]; });
+            CFRunLoopPerformBlock(
+                runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
+                  [inspector dispatchMessage:message];
+                });
             CFRunLoopWakeUp(runloop);
           } else {
             clear();
@@ -246,59 +254,59 @@ static void TNSEnableRemoteInspector(int argc, char **argv, TNSRuntime *runtime)
               NSLog(@"NativeScript debugger detached.");
             }
           }
+        };
       };
-  };
 
   int waitForDebuggerSubscription;
-  notify_register_dispatch(NOTIFICATION("WaitForDebugger"),
-                           &waitForDebuggerSubscription,
-                           dispatch_get_main_queue(), ^(int token) {
-      isWaitingForDebugger = YES;
-      NSLog(@"NativeScript waiting for debugger.");
+  notify_register_dispatch(
+      NOTIFICATION("WaitForDebugger"), &waitForDebuggerSubscription,
+      dispatch_get_main_queue(), ^(int token) {
+        isWaitingForDebugger = YES;
+        NSLog(@"NativeScript waiting for debugger.");
 
-      CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
+        CFRunLoopPerformBlock(CFRunLoopGetMain(), kCFRunLoopDefaultMode, ^{
           do {
-              CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
           } while (isWaitingForDebugger);
+        });
+        CFRunLoopWakeUp(CFRunLoopGetMain());
       });
-      CFRunLoopWakeUp(CFRunLoopGetMain());
-  });
 
   int attachRequestSubscription;
-  notify_register_dispatch(NOTIFICATION("AttachRequest"),
-                           &attachRequestSubscription,
-                           dispatch_get_main_queue(), ^(int token) {
-      if (listenSource) {
-        return;
-      }
+  notify_register_dispatch(
+      NOTIFICATION("AttachRequest"), &attachRequestSubscription,
+      dispatch_get_main_queue(), ^(int token) {
+        if (listenSource) {
+          return;
+        }
 
-      listenSource = TNSCreateInspectorServer(connectionHandler);
-      notify_post(NOTIFICATION("ReadyForAttach"));
+        listenSource = TNSCreateInspectorServer(connectionHandler);
+        notify_post(NOTIFICATION("ReadyForAttach"));
 
-      dispatch_time_t delay =
-          dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 30);
-      dispatch_after(delay, dispatch_get_main_queue(), ^{
+        dispatch_time_t delay =
+            dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 30);
+        dispatch_after(delay, dispatch_get_main_queue(), ^{
           if (!inspector && listenSource) {
             dispatch_source_cancel(listenSource);
             listenSource = nil;
           }
 
           isWaitingForDebugger = NO;
+        });
       });
-  });
 
   int attachAvailabilityQuerySubscription;
   notify_register_dispatch(NOTIFICATION("AttachAvailabilityQuery"),
                            &attachAvailabilityQuerySubscription,
                            dispatch_get_main_queue(), ^(int token) {
-      if (inspector) {
-        notify_post(NOTIFICATION("AlreadyConnected"));
-      } else if (listenSource) {
-        notify_post(NOTIFICATION("ReadyForAttach"));
-      } else {
-        notify_post(NOTIFICATION("AttachAvailable"));
-      }
-  });
+                             if (inspector) {
+                               notify_post(NOTIFICATION("AlreadyConnected"));
+                             } else if (listenSource) {
+                               notify_post(NOTIFICATION("ReadyForAttach"));
+                             } else {
+                               notify_post(NOTIFICATION("AttachAvailable"));
+                             }
+                           });
 
   notify_post(NOTIFICATION("AppLaunching"));
 


### PR DESCRIPTION
# Introduction
We identified a couple of issues with the way connections are handled between the Inspector and the backend. On one side, the sockets were not handled correctly using the Dispatch API resulting in faulty connections upon subsequent connection attempts. 
On the other side, there was an issue with the way Backend Dispatchers were handled via RefPtrs. For example, the DomainBackendDispatcher adopts a pointer to the dispatcher created by the DomainInspectorAgent, which also has a pointer to it. Adopting this pointer does not increase the refcount which in turn breaks the underlying object's (RefCountedBase) state.
The third amendment is in the way backend dispatchers are handled by the Agents in the `didCreateFrontendAndBackend` and `willDestroyFrontendAndBackend` calls. We now create a single instance of each dispatcher and leave it alive until the owning Agent is destroyed. This is the behaviour as seen in the vanilla WebKit [source](https://github.com/WebKit/webkit/blob/0a19ca4ea7d983b71f0caa78cbe13b76050c8022/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp#L168-L169).

Fixes #832 

* After the debugger frontend is detached certain RefPtr properties are cleaned up and recreated on a subsequent connection which is causing a crash due to improper reference management. Making the *m_backendDispatcher* property persist between different connections fixes the bug.

* Every time the debugger is detached the IO channel should be closed in order the next connection to be successful. Otherwise the connection attempt will fail with a bad descriptor error.

* https://github.com/NativeScript/ios-runtime/pull/835/commits/153d45f01a53f06195968de94dc7bd47ab0cddf2 addresses an issue with debugger delay killing the already existing listen connection at an inappropriate time. We do not need this delay to cancel the listen connection as we immediately close it after a successful frontend connection.