### PR TITLE
fix(inspector): Fix API compatibility issue with Inspector

### DIFF
--- a/src/debugging/Inspector/Inspector/Inspector/main.m
+++ b/src/debugging/Inspector/Inspector/Inspector/main.m
@@ -21,10 +21,19 @@ int main(int argc, const char* argv[]) {
         [runningApplications[0] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
     } else {
         NSDictionary* configuration = @{
-            NSWorkspaceLaunchConfigurationArguments : @[ main_file_path, project_name, socket_path ],
-            NSWorkspaceLaunchConfigurationEnvironment : @{ @"DYLD_FRAMEWORK_PATH" : [[NSBundle mainBundle] privateFrameworksPath] }
+            NSWorkspaceLaunchConfigurationArguments : @[ main_file_path, project_name, socket_path ]
         };
-
+        
+        // Check: Starting with High Sierra some internal APIs
+        // used by WebKit are not present. We resort to compat libraries
+        // instead of using our own until we upgrade to the latest WebKit version.
+        NSProcessInfo *pInfo = [NSProcessInfo processInfo];
+        NSOperatingSystemVersion version = {.majorVersion = 10, .minorVersion = 13};
+        
+        if (![pInfo isOperatingSystemAtLeastVersion:version]){
+            [configuration setValue:@{ @"DYLD_FRAMEWORK_PATH" : [[NSBundle mainBundle] privateFrameworksPath]}  forKey:NSWorkspaceLaunchConfigurationEnvironment];
+        }
+        
         [[NSWorkspace sharedWorkspace] launchApplicationAtURL:applicationBundle.bundleURL options:0 configuration:configuration error:nil];
     }
 


### PR DESCRIPTION
There are internal APIs used by our WebKit build that are not present on High Sierra. We need to use the builtin WebCore frameworks to avoid crashing instead of our own. This fix checks if we are on High Sierra and resorts to the builtin frameworks if yes. We need this up until we upgrade to the latest WebKit version which does not use the internal APIs.