### PR TITLE
fix(JSC): Make __nsException property's key a Symbol

### DIFF
--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -7,13 +7,14 @@
 //
 
 #include <JavaScriptCore/APICast.h>
+#include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/FunctionConstructor.h>
 #include <JavaScriptCore/InitializeThreading.h>
 #include <JavaScriptCore/JSGlobalObjectInspectorController.h>
 #include <JavaScriptCore/JSInternalPromise.h>
-#include <JavaScriptCore/JSNativeStdFunction.h>
 #include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/JSNativeStdFunction.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <iostream>
 
@@ -21,13 +22,13 @@
 #import <UIKit/UIApplication.h>
 #endif
 
-#import "TNSRuntime.h"
-#import "TNSRuntime+Private.h"
 #include "JSErrors.h"
+#include "ManualInstrumentation.h"
 #include "Metadata/Metadata.h"
 #include "ObjCTypes.h"
+#import "TNSRuntime+Private.h"
+#import "TNSRuntime.h"
 #include "Workers/JSWorkerGlobalObject.h"
-#include "ManualInstrumentation.h"
 
 using namespace JSC;
 using namespace NativeScript;
@@ -150,7 +151,6 @@ static NSPointerArray* _runtimes;
     return [self executeModule:entryPointModuleIdentifier referredBy:@""];
 }
 
-
 - (void)executeModule:(NSString*)entryPointModuleIdentifier referredBy:(NSString*)referrer {
     JSLockHolder lock(*self->_vm);
     JSInternalPromise* promise = loadAndEvaluateModule(self->_globalObject->globalExec(), entryPointModuleIdentifier, referrer);
@@ -166,7 +166,7 @@ static NSPointerArray* _runtimes;
     if (error) {
         Exception* exception = jsDynamicCast<Exception*>(error);
         if (!exception) {
-            exception = jsDynamicCast<Exception*>(error.getObject()->getDirect(*self->_vm.get(), Identifier::fromString(self->_vm.get(), Exception::NS_EXCEPTION_IDENTIFIER_STRING)));
+            exception = jsDynamicCast<Exception*>(error.getObject()->getDirect(*self->_vm.get(), self->_vm.get()->propertyNames->builtinNames().nsExceptionIdentifierPrivateName()));
             if (!exception) {
                 exception = Exception::create(*self->_vm.get(), error, Exception::DoNotCaptureStack);
             }


### PR DESCRIPTION
The app crashed whenever the debugger inspector tried to inspect the value of this property,
because `Exception` class' `Structure` has a `null` `globalObject` assigned. In order to prevent
inspection of the `__nsException` property we make its key a `Symbol`, because according to
[`Object.getOwnPropertyNames` documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames):

> The **Object.getOwnPropertyNames()** method returns an array of all properties (including
> non-enumerable properties **except for those which use Symbol**) found directly upon a given object.

The issue has been introduced with https://github.com/NativeScript/ios-runtime/pull/815