### PR TITLE
fix(console): Fix issue with missing console.time() messages.

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -115,12 +115,20 @@ void GlobalObjectConsoleClient::takeHeapSnapshot(JSC::ExecState*, const String& 
 }
 
 void GlobalObjectConsoleClient::time(JSC::ExecState*, const String& title) {
-    m_consoleAgent->startTiming(title);
+    std::unique_ptr<String> startMsg = m_consoleAgent->startTiming(title);
+    const String* url;
+    if (startMsg) {
+        ConsoleClient::printConsoleMessage(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Warning, *startMsg.get(), (const String&)url, -1, -1);
+    }
 }
 
 void GlobalObjectConsoleClient::timeEnd(JSC::ExecState* exec, const String& title) {
-    RefPtr<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, 1));
-    m_consoleAgent->stopTiming(title, WTFMove(callStack));
+    Ref<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, 1));
+    std::unique_ptr<String> stopMsg = m_consoleAgent->stopTiming(title, WTFMove(callStack));
+    const String* url;
+    if (stopMsg) {
+        ConsoleClient::printConsoleMessage(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, *stopMsg.get(), (const String&)url, -1, -1);
+    }
 }
 
 void GlobalObjectConsoleClient::timeStamp(JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&) {

--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -115,19 +115,17 @@ void GlobalObjectConsoleClient::takeHeapSnapshot(JSC::ExecState*, const String& 
 }
 
 void GlobalObjectConsoleClient::time(JSC::ExecState*, const String& title) {
-    std::unique_ptr<String> startMsg = m_consoleAgent->startTiming(title);
-    const String* url;
+    std::unique_ptr<Inspector::ConsoleMessage> startMsg = m_consoleAgent->startTiming(title);
     if (startMsg) {
-        ConsoleClient::printConsoleMessage(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Warning, *startMsg.get(), (const String&)url, -1, -1);
+        ConsoleClient::printConsoleMessage(startMsg->source(), startMsg->type(), startMsg->level(), startMsg->message(), startMsg->url(), startMsg->line(), startMsg->column());
     }
 }
 
 void GlobalObjectConsoleClient::timeEnd(JSC::ExecState* exec, const String& title) {
     Ref<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, 1));
-    std::unique_ptr<String> stopMsg = m_consoleAgent->stopTiming(title, WTFMove(callStack));
-    const String* url;
+    std::unique_ptr<Inspector::ConsoleMessage> stopMsg = m_consoleAgent->stopTiming(title, WTFMove(callStack));
     if (stopMsg) {
-        ConsoleClient::printConsoleMessage(MessageSource::ConsoleAPI, MessageType::Timing, MessageLevel::Debug, *stopMsg.get(), (const String&)url, -1, -1);
+        ConsoleClient::printConsoleMessage(stopMsg->source(), stopMsg->type(), stopMsg->level(), stopMsg->message(), stopMsg->url(), stopMsg->line(), stopMsg->column());
     }
 }
 


### PR DESCRIPTION
This PR addresses an issue with console.time() messages missing on iOS unless the Inspector console is used. The fix consists of extending the `InspectorConsoleAgent`'s API to return the generated console.time() message which is then consumed by the `GlobalObjectConsoleClient` which prints it in the Console.

Related: https://github.com/NativeScript/ios-runtime/issues/843