### PR TITLE
fix(Inspector): CLI's --debug-brk option no longer works

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -334,7 +334,16 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
 
       if (isWaitingForDebugger) {
           isWaitingForDebugger = NO;
-          [tempInspector pause];
+          CFRunLoopRef runloop = CFRunLoopGetMain();
+          CFRunLoopPerformBlock(
+              runloop, (__bridge CFTypeRef)(NSRunLoopCommonModes), ^{
+                // If we pause right away the debugger messages that are send
+                // are not handled because the frontend is not yet initialized
+                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1, false);
+
+                [inspector pause];
+              });
+          CFRunLoopWakeUp(runloop);
       }
       NSArray* inspectorRunloopModes =
           @[ NSRunLoopCommonModes, TNSInspectorRunLoopMode ];


### PR DESCRIPTION
It seems that we've regressed the functioning of `--debug-brk` by invoking `[inspector pause]` directly in the connection handling method. Revert to the old behaviour of executing 1 sec. of the main loop before calling it.

We'll further debug and try to understand whether this is the most appropriate fix for the issue, but for the 3.4.1 hotfix will keep the old behaviour.