### PR TITLE
chore: add waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NativeScript for iOS Runtime
+[![Waffle.io - NativeScript Runtimes and CLI](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
 
 ```shell
 git clone --recursive git@github.com:NativeScript/ios-runtime.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# NativeScript for iOS Runtime
 [![Waffle.io - NativeScript Runtimes and CLI](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
+
+# NativeScript for iOS Runtime
 
 ```shell
 git clone --recursive git@github.com:NativeScript/ios-runtime.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Waffle.io - NativeScript Runtimes and CLI](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
-
 # NativeScript for iOS Runtime
+
+[![Waffle.io - NativeScript Runtimes and CLI](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
 
 ```shell
 git clone --recursive git@github.com:NativeScript/ios-runtime.git


### PR DESCRIPTION
Add waffle.io badge to waffle board in order to give more visibility to the current issues status.