### PR TITLE
fix(inspector): Fix issue with configuration dictionary.

### DIFF
--- a/src/debugging/Inspector/Inspector/Inspector/main.m
+++ b/src/debugging/Inspector/Inspector/Inspector/main.m
@@ -20,9 +20,8 @@ int main(int argc, const char* argv[]) {
         [[NSDistributedNotificationCenter defaultCenter] postNotificationName:@"org.NativeScriptInspector.ApplicationShouldHandleReopen" object:nil userInfo:innerArguments];
         [runningApplications[0] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
     } else {
-        NSDictionary* configuration = @{
-            NSWorkspaceLaunchConfigurationArguments : @[ main_file_path, project_name, socket_path ]
-        };
+        NSDictionary* configuration = [[NSMutableDictionary alloc] init];
+        [configuration setValue:@[ main_file_path, project_name, socket_path ] forKey:NSWorkspaceLaunchConfigurationArguments];
         
         // Check: Starting with High Sierra some internal APIs
         // used by WebKit are not present. We resort to compat libraries


### PR DESCRIPTION
The

```
 NSDictionary* configuration = @{
-            NSWorkspaceLaunchConfigurationArguments : @[ main_file_path, project_name, socket_path ]
-        };
```
literal creates a single-entry dictionary which throws an exception at a later point when `setValue` is called with additional key-value pairs.