### PR TITLE
Bump inspector package version

### DIFF
--- a/build/npm/inspector_package.json
+++ b/build/npm/inspector_package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-ios-inspector",
   "description": "Telerik NativeScript Inspector for iOS Runtime",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
Due to problems in build scripts we erroneously published v3.4.1 in npm. Bump the version to 3.4.2