### PR TITLE
Update postinstall to check OS version.

### DIFF
--- a/build/npm/inspector_package.json
+++ b/build/npm/inspector_package.json
@@ -23,7 +23,7 @@
     "**/*"
   ],
   "scripts": {
-    "postinstall": "unzip -o './NativeScript Inspector.zip' -d ."
+    "postinstall": "OSVERSION=\"$(sw_vers -productVersion | grep -o \"[0-9][0-9].[0-9][0-9]\")\"; OSVERSION=${OSVERSION//.}; UNZIP_FILE=\"NativeScript Inspector Sierra\"; if [ $OSVERSION -ge 1013 ]; then UNZIP_FILE=\"NativeScript Inspector HighSierra\"; fi; unzip -o \"$UNZIP_FILE\" -d .; rm *.zip"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
As per the latest discussions, we need to check the MACOSX version the Inspector is being installed on to unzip the corresponding binaries accordingly. This PR updates the postinstall script of the Inspector .tgz to generate a number representing the version of the OS (1012, 1013), checks if the version is 1013 or greater and chooses the HighSierra version of the Inspector. Otherwise the Sierra version is used.

Some questions:
* Do we want to restrict to Sierra and HighSierra only?
* Do we want to delete the .zip archives?
* How do we proceed in case the client updates the OS?