### PR TITLE
Remove OS check for Font API usage in updated Inspector

### DIFF
--- a/src/debugging/Inspector/Inspector/Inspector/main.m
+++ b/src/debugging/Inspector/Inspector/Inspector/main.m
@@ -33,19 +33,11 @@ int main(int argc, const char *argv[]) {
     [configuration setValue:@[ main_file_path, project_name, socket_path ]
                      forKey:NSWorkspaceLaunchConfigurationArguments];
 
-    // Check: Starting with High Sierra some internal APIs
-    // used by WebKit are not present. We resort to compat libraries
-    // instead of using our own until we upgrade to the latest WebKit version.
-    NSProcessInfo *pInfo = [NSProcessInfo processInfo];
-    NSOperatingSystemVersion version = {.majorVersion = 10, .minorVersion = 13};
-
-    if (![pInfo isOperatingSystemAtLeastVersion:version]) {
-      [configuration setValue:@{
+    [configuration setValue:@{
         @"DYLD_FRAMEWORK_PATH" : [[NSBundle mainBundle] privateFrameworksPath]
       }
                        forKey:NSWorkspaceLaunchConfigurationEnvironment];
-    }
-
+      
     [[NSWorkspace sharedWorkspace]
         launchApplicationAtURL:applicationBundle.bundleURL
                        options:0


### PR DESCRIPTION
As discussed, in the updated version of WebKit we do not need to check the OS version when running the Inspector and pick against which WebKit libraries to link. We always use our own libraries as they are compatible with both Sierra and High Sierra. We just need to build them with different deployment targets.