### PR TITLE
Fix issues with using private Apple APIs

### DIFF
--- a/tests/TestRunner/app/FunctionsTests.js
+++ b/tests/TestRunner/app/FunctionsTests.js
@@ -18,4 +18,44 @@ describe(module.id, function () {
         expect(CFBagGetCountOfValue(bag, a)).toBe(1);
         expect(CFBagContainsValue(bag, a)).toBe(true);
     });
+         
+    it("String.prototype.normalize", function(){
+       //Since we overwrite the original normalize implementation, we test it against the behavior described on https://developer.mozilla.org
+       //Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+       // Initial string
+       
+       // U+1E9B: LATIN SMALL LETTER LONG S WITH DOT ABOVE
+       // U+0323: COMBINING DOT BELOW
+       var str = '\u1E9B\u0323';
+       
+       
+       // Canonically-composed form (NFC)
+       
+       // U+1E9B: LATIN SMALL LETTER LONG S WITH DOT ABOVE
+       // U+0323: COMBINING DOT BELOW
+       expect(str.normalize('NFC')).toBe('\u1E9B\u0323');
+       expect(str.normalize()).toBe('\u1E9B\u0323');
+       
+       
+       // Canonically-decomposed form (NFD)
+       
+       // U+017F: LATIN SMALL LETTER LONG S
+       // U+0323: COMBINING DOT BELOW
+       // U+0307: COMBINING DOT ABOVE
+       expect(str.normalize('NFD')).toBe('\u017F\u0323\u0307'); //
+       
+       
+       // Compatibly-composed (NFKC)
+       
+       // U+1E69: LATIN SMALL LETTER S WITH DOT BELOW AND DOT ABOVE
+       expect(str.normalize('NFKC')).toBe('\u1E69'); // '\u1E69'
+       
+       
+       // Compatibly-decomposed (NFKD)
+       
+       // U+0073: LATIN SMALL LETTER S
+       // U+0323: COMBINING DOT BELOW
+       // U+0307: COMBINING DOT ABOVE
+       expect(str.normalize('NFKD')).toBe('\u0073\u0323\u0307');
+   });
 });


### PR DESCRIPTION
After upgrading WebKit to v11.0 we've encountered several issues with using private APIs forbidden for usage by apps on the AppStore. This PR addresses these issues in the following way:

- mock the unorm2_ APIs and replace them with our own `String.prototype.normalize` implementation using the official CFString APIs. This is done in `GlobalObject.mm` whereas the mocking is done in the WebKit's source code
- replace the usage of the private Crypto APIs with public APIs

A unit test is added that verifies the behavior of `String.prototype.normalize` against the https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize specification.

