### PR TITLE
fix(console-dir): Fix missing console.dir output

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -207,6 +207,7 @@ set(NativeScript_PUBLIC_HEADERS
 set(JSFILES
     __extends.js
     inlineFunctions.js
+    smartStringify.js
 )
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/**" "${LIBFFI_INCLUDE_DIR}" "${WEBKIT_INCLUDE_DIRECTORIES}")

--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -134,6 +134,10 @@ public:
         return this->_typeScriptOriginalExtendsFunction.get();
     }
 
+    JSC::JSFunction* smartStringifyFunction() const {
+        return this->_smartStringifyFunction.get();
+    }
+
     GlobalObjectInspectorController& inspectorController() const {
         return *this->_inspectorController.get();
     }
@@ -246,6 +250,7 @@ private:
     JSC::WriteBarrier<Interop> _interop;
 
     JSC::WriteBarrier<JSC::JSFunction> _typeScriptOriginalExtendsFunction;
+    JSC::WriteBarrier<JSC::JSFunction> _smartStringifyFunction;
 
     JSC::WriteBarrier<JSC::Structure> _weakRefConstructorStructure;
     JSC::WriteBarrier<JSC::Structure> _weakRefPrototypeStructure;

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -41,6 +41,7 @@
 #include "__extends.h"
 #include "inlineFunctions.h"
 #include "inspector/GlobalObjectInspectorController.h"
+#include "smartStringify.h"
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/FunctionConstructor.h>
 #include <JavaScriptCore/FunctionPrototype.h>
@@ -191,6 +192,8 @@ void GlobalObject::finishCreation(VM& vm, WTF::String applicationPath) {
 
     this->putDirectNativeFunction(vm, this, Identifier::fromString(globalExec, "__time"), 0, &time, NoIntrinsic, DontEnum);
 
+    this->_smartStringifyFunction.set(vm, this, jsCast<JSFunction*>(evaluate(this->globalExec(), makeSource(WTF::String(smartStringify_js, smartStringify_js_len), SourceOrigin()), JSValue())));
+
 #ifdef DEBUG
     SourceCode sourceCode = makeSource(WTF::String(__extends_js, __extends_js_len), SourceOrigin(), WTF::ASCIILiteral("__extends.ts"));
 #else
@@ -240,6 +243,7 @@ void GlobalObject::visitChildren(JSCell* cell, SlotVisitor& visitor) {
     visitor.append(globalObject->_interop);
     visitor.append(globalObject->_typeFactory);
     visitor.append(globalObject->_typeScriptOriginalExtendsFunction);
+    visitor.append(globalObject->_smartStringifyFunction);
     visitor.append(globalObject->_ffiCallPrototype);
     visitor.append(globalObject->_objCMethodCallStructure);
     visitor.append(globalObject->_objCConstructorCallStructure);

--- a/src/NativeScript/inlineFunctions.js
+++ b/src/NativeScript/inlineFunctions.js
@@ -86,6 +86,7 @@ Object.assign(global, {
             exposedMethod.params[parameterIndex] = type || interop.types.void;
         };
     },
+    
 });
 
 Object.defineProperty(global, "__tsEnum", {

--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.h
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.h
@@ -3,6 +3,7 @@
 #define GlobalObjectConsoleClient_hpp
 
 #include "InspectorLogAgent.h"
+#include <GlobalObject.h>
 #include <JavaScriptCore/InspectorConsoleAgent.h>
 #include <JavaScriptCore/runtime/ConsoleClient.h>
 #include <stdio.h>

--- a/src/NativeScript/smartStringify.js
+++ b/src/NativeScript/smartStringify.js
@@ -1,0 +1,16 @@
+(function (object) {
+    seen = [];
+    var replacer = function (key, value) {
+        if (value != null && typeof value == "object") {
+            if (seen.indexOf(value) >= 0) {
+                if (key) {
+                    return "[Circular]";
+                }
+                return;
+            }
+            seen.push(value);
+        }
+        return value;
+    };
+    return JSON.stringify(object, replacer, 2);
+});


### PR DESCRIPTION
This PR addresses issues with calling `console.dir` on objects in an iOS app. There are two aspects here:
- improve CLI filtering to pass multiline `console.log/console.dir` messages - https://github.com/NativeScript/nativescript-cli/pull/3389
- align `console.dir` behavior with android runtime's by introducing the `smartStringifyFunction` to handle circular references adequately.

Related issue: https://github.com/NativeScript/ios-runtime/issues/875

P.S.
There are functional tests covering this functionality.