### PR TITLE
fix: Incorrect constant array type parsing

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -329,8 +329,8 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
         if (functionSymbol) {
             const FunctionMeta* functionMeta = static_cast<const FunctionMeta*>(symbolMeta);
             const Metadata::TypeEncoding* encodingPtr = functionMeta->encodings()->first();
-            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodingPtr);
-            const WTF::Vector<JSCell*> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodingPtr, (int)functionMeta->encodings()->count - 1);
+            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodingPtr, false);
+            const WTF::Vector<JSCell*> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodingPtr, (int)functionMeta->encodings()->count - 1, false);
 
             if (functionMeta->returnsUnmanaged()) {
                 JSC::Structure* unmanagedStructure = UnmanagedType::createStructure(vm, globalObject, jsNull());
@@ -346,7 +346,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
         void* varSymbol = SymbolLoader::instance().loadDataSymbol(varMeta->topLevelModule(), varMeta->name());
         if (varSymbol) {
             const Metadata::TypeEncoding* encoding = varMeta->encoding();
-            JSCell* symbolType = globalObject->typeFactory()->parseType(globalObject, encoding);
+            JSCell* symbolType = globalObject->typeFactory()->parseType(globalObject, encoding, false);
             symbolWrapper = getFFITypeMethodTable(vm, symbolType).read(execState, varSymbol, symbolType);
         }
         break;

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -128,8 +128,8 @@ std::string getCompilerEncoding(JSC::JSGlobalObject* globalObject, const Metadat
     const Metadata::TypeEncodingsList<Metadata::ArrayCount>* encodings = method->encodings();
     GlobalObject* nsGlobalObject = jsCast<GlobalObject*>(globalObject);
     const Metadata::TypeEncoding* currentEncoding = encodings->first();
-    JSCell* returnTypeCell = nsGlobalObject->typeFactory()->parseType(nsGlobalObject, currentEncoding);
-    const WTF::Vector<JSCell*> parameterTypesCells = nsGlobalObject->typeFactory()->parseTypes(nsGlobalObject, currentEncoding, encodings->count - 1);
+    JSCell* returnTypeCell = nsGlobalObject->typeFactory()->parseType(nsGlobalObject, currentEncoding, false);
+    const WTF::Vector<JSCell*> parameterTypesCells = nsGlobalObject->typeFactory()->parseTypes(nsGlobalObject, currentEncoding, encodings->count - 1, false);
 
     std::stringstream compilerEncoding;
 

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
@@ -91,14 +91,10 @@ void ExtVectorTypeInstance::finishCreation(JSC::VM& vm, JSCell* innerType) {
 
     ffi_type* type = new ffi_type({ .size = arraySize * innerFFIType->size, .alignment = innerFFIType->alignment, .type = FFI_TYPE_EXT_VECTOR });
 
-    ffi_type* ffiTypeEl = new ffi_type({ .size = sizeof(float),
-                                         .alignment = sizeof(float),
-                                         .type = FFI_TYPE_FLOAT });
-
     type->elements = new ffi_type*[arraySize + 1];
 
     for (size_t i = 0; i < arraySize; i++) {
-        type->elements[i] = ffiTypeEl;
+        type->elements[i] = innerFFIType;
     }
 
     type->elements[arraySize] = nullptr;

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
@@ -91,8 +91,8 @@ void ExtVectorTypeInstance::finishCreation(JSC::VM& vm, JSCell* innerType) {
 
     ffi_type* type = new ffi_type({ .size = arraySize * innerFFIType->size, .alignment = innerFFIType->alignment, .type = FFI_TYPE_EXT_VECTOR });
 
-    ffi_type* ffiTypeEl = new ffi_type({ .size = 4,
-                                         .alignment = 4,
+    ffi_type* ffiTypeEl = new ffi_type({ .size = sizeof(float),
+                                         .alignment = sizeof(float),
                                          .type = FFI_TYPE_FLOAT });
 
     type->elements = new ffi_type*[arraySize + 1];
@@ -106,8 +106,15 @@ void ExtVectorTypeInstance::finishCreation(JSC::VM& vm, JSCell* innerType) {
     this->_ffiTypeMethodTable.ffiType = type;
     this->_ffiTypeMethodTable.read = &read;
     this->_ffiTypeMethodTable.write = &write;
+    this->_ffiTypeMethodTable.encode = &encode;
+    this->_ffiTypeMethodTable.canConvert = &canConvert;
 
     this->_innerType.set(vm, this, innerType);
+}
+
+bool ExtVectorTypeInstance::canConvert(ExecState* execState, const JSValue& value, JSCell* buffer) {
+    JSC::VM& vm = execState->vm();
+    return value.isUndefinedOrNull() || value.inherits(vm, IndexedRefInstance::info()) || value.inherits(vm, PointerInstance::info());
 }
 
 void ExtVectorTypeInstance::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor) {

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.h
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.h
@@ -44,6 +44,7 @@ private:
     std::string _compilerEncoding;
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
     static const char* encode(VM&, JSC::JSCell*);
+    static bool canConvert(JSC::ExecState*, const JSC::JSValue&, JSC::JSCell*);
     size_t _size;
     ExtVectorTypeInstance(JSC::VM& vm, JSC::Structure* structure, size_t size)
         : Base(vm, structure)

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
@@ -17,7 +17,6 @@
 
 namespace NativeScript {
 using namespace JSC;
-typedef ReferenceTypeInstance Base;
 
 const ClassInfo IndexedRefTypeInstance::s_info = { "IndexedRefTypeInstance", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(IndexedRefTypeInstance) };
 
@@ -97,7 +96,15 @@ void IndexedRefTypeInstance::finishCreation(JSC::VM& vm, JSCell* innerType) {
     this->_ffiTypeMethodTable.read = &read;
     this->_ffiTypeMethodTable.write = &write;
 
+    this->_ffiTypeMethodTable.canConvert = &canConvert;
+    this->_ffiTypeMethodTable.encode = &encode;
+
     this->_innerType.set(vm, this, innerType);
+}
+
+bool IndexedRefTypeInstance::canConvert(ExecState* execState, const JSValue& value, JSCell* buffer) {
+    JSC::VM& vm = execState->vm();
+    return value.isUndefinedOrNull() || value.inherits(vm, IndexedRefInstance::info()) || value.inherits(vm, PointerInstance::info());
 }
 
 void IndexedRefTypeInstance::visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor) {

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.h
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.h
@@ -43,6 +43,7 @@ private:
     std::string _compilerEncoding;
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
     static const char* encode(VM&, JSC::JSCell*);
+    static bool canConvert(JSC::ExecState*, const JSC::JSValue&, JSC::JSCell*);
     ffi_type* _indexedRefType;
     size_t _size;
     IndexedRefTypeInstance(JSC::VM& vm, JSC::Structure* structure, size_t size)

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
@@ -24,8 +24,8 @@ void ObjCConstructorCall::finishCreation(VM& vm, GlobalObject* globalObject, Cla
 
     const Metadata::TypeEncoding* encodings = metadata->encodings()->first();
 
-    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings);
-    const WTF::Vector<JSCell*> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1);
+    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+    const WTF::Vector<JSCell*> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1, false);
 
     Base::initializeFFI(vm, { &preInvocation, &postInvocation }, returnType, parametersTypes, 2);
     this->_selector = metadata->selector();

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -132,8 +132,8 @@ static void addMethodToClass(ExecState* execState, Class klass, JSCell* method, 
 
     const TypeEncoding* encodings = meta->encodings()->first();
 
-    JSCell* returnTypeCell = globalObject->typeFactory()->parseType(globalObject, encodings);
-    const WTF::Vector<JSCell*> parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, encodings, meta->encodings()->count - 1);
+    JSCell* returnTypeCell = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+    const WTF::Vector<JSCell*> parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, encodings, meta->encodings()->count - 1, false);
 
     ObjCMethodCallback* callback = ObjCMethodCallback::create(execState->vm(), globalObject, globalObject->objCMethodCallbackStructure(), method, returnTypeCell, parameterTypesCells);
     gcProtect(callback);
@@ -352,8 +352,8 @@ void ObjCClassBuilder::addProperty(ExecState* execState, const Identifier& name,
             }
 
             const TypeEncoding* encodings = getter->encodings()->first();
-            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings);
-            const WTF::Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, getter->encodings()->count - 1);
+            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+            const WTF::Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, getter->encodings()->count - 1, false);
 
             ObjCMethodCallback* getterCallback = ObjCMethodCallback::create(vm, globalObject, globalObject->objCMethodCallbackStructure(), propertyDescriptor.getter().asCell(), returnType, parameterTypes);
             gcProtect(getterCallback);
@@ -370,8 +370,8 @@ void ObjCClassBuilder::addProperty(ExecState* execState, const Identifier& name,
             }
 
             const TypeEncoding* encodings = setter->encodings()->first();
-            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings);
-            const WTF::Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, setter->encodings()->count - 1);
+            JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+            const WTF::Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, setter->encodings()->count - 1, false);
 
             ObjCMethodCallback* setterCallback = ObjCMethodCallback::create(vm, globalObject, globalObject->objCMethodCallbackStructure(), propertyDescriptor.setter().asCell(), returnType, parameterTypes);
             gcProtect(setterCallback);

--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -29,8 +29,8 @@ void ObjCMethodCall::finishCreation(VM& vm, GlobalObject* globalObject, const Me
     Base::finishCreation(vm, metadata->jsName());
     const TypeEncoding* encodings = metadata->encodings()->first();
 
-    JSCell* returnTypeCell = globalObject->typeFactory()->parseType(globalObject, encodings);
-    const WTF::Vector<JSCell*> parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1);
+    JSCell* returnTypeCell = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+    const WTF::Vector<JSCell*> parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1, false);
 
     Base::initializeFFI(vm, { &preInvocation, &postInvocation }, returnTypeCell, parameterTypesCells, 2);
     this->_retainsReturnedCocoaObjects = metadata->ownsReturnedCocoaObject();

--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -23,8 +23,8 @@ ObjCMethodCallback* createProtectedMethodCallback(ExecState* execState, JSValue 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
 
     const Metadata::TypeEncoding* typeEncodings = meta->encodings()->first();
-    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, typeEncodings);
-    Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, typeEncodings, meta->encodings()->count - 1);
+    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, typeEncodings, false);
+    Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, typeEncodings, meta->encodings()->count - 1, false);
 
     ObjCMethodCallback* methodCallback = ObjCMethodCallback::create(execState->vm(), globalObject, globalObject->objCMethodCallbackStructure(), value.asCell(), returnType, parameterTypes, TriState(meta->hasErrorOutParameter()));
     gcProtect(methodCallback);

--- a/src/NativeScript/TypeFactory.h
+++ b/src/NativeScript/TypeFactory.h
@@ -48,9 +48,9 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    JSC::JSCell* parseType(GlobalObject*, const Metadata::TypeEncoding*&);
+    JSC::JSCell* parseType(GlobalObject*, const Metadata::TypeEncoding*&, bool isStructMember = false);
 
-    const WTF::Vector<JSC::JSCell*> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count);
+    const WTF::Vector<JSC::JSCell*> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember = false);
 
     ObjCConstructorNative* getObjCNativeConstructor(GlobalObject*, const WTF::String& klassName);
 

--- a/src/NativeScript/TypeFactory.h
+++ b/src/NativeScript/TypeFactory.h
@@ -48,9 +48,9 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    JSC::JSCell* parseType(GlobalObject*, const Metadata::TypeEncoding*&, bool isStructMember = false);
+    JSC::JSCell* parseType(GlobalObject*, const Metadata::TypeEncoding*&, bool isStructMember);
 
-    const WTF::Vector<JSC::JSCell*> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember = false);
+    const WTF::Vector<JSC::JSCell*> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember);
 
     ObjCConstructorNative* getObjCNativeConstructor(GlobalObject*, const WTF::String& klassName);
 

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -120,7 +120,7 @@ RecordConstructor* TypeFactory::getStructConstructor(GlobalObject* globalObject,
     ASSERT(structInfo && structInfo->type() == MetaType::Struct);
 
     const TypeEncoding* encodingsPtr = structInfo->fieldsEncodings()->first();
-    fieldsTypes = parseTypes(globalObject, encodingsPtr, structInfo->fieldsEncodings()->count);
+    fieldsTypes = parseTypes(globalObject, encodingsPtr, structInfo->fieldsEncodings()->count, true);
 
     for (Array<Metadata::String>::iterator it = structInfo->fieldNames().begin(); it != structInfo->fieldNames().end(); it++) {
         fieldsNames.append(WTF::ASCIILiteral((*it).valuePtr()));
@@ -162,7 +162,7 @@ RecordConstructor* TypeFactory::getAnonymousStructConstructor(GlobalObject* glob
     }
 
     const TypeEncoding* encodingsPtr = details.getFieldsEncodings();
-    fieldsTypes = parseTypes(globalObject, encodingsPtr, details.fieldsCount);
+    fieldsTypes = parseTypes(globalObject, encodingsPtr, details.fieldsCount, true);
 
     WTF::Vector<RecordField*> fields = createRecordFields(globalObject, fieldsTypes, fieldsNames, ffiType);
     recordPrototype->setFields(vm, globalObject, fields);
@@ -321,31 +321,12 @@ ObjCConstructorNative* TypeFactory::NSObjectConstructor(GlobalObject* globalObje
 }
 
 IndexedRefTypeInstance* TypeFactory::getIndexedRefType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize) {
-    WeakImpl* innerWeak = WeakSet::allocate(JSValue(innerType));
-    if (this->_cacheReferenceType.contains(innerWeak)) {
-        WeakImpl* value = this->_cacheReferenceType.get(innerWeak);
-        if (value->state() == WeakImpl::State::Live) {
-            return static_cast<IndexedRefTypeInstance*>(value->jsValue().asCell());
-        } else {
-            this->_cacheReferenceType.remove(innerWeak);
-        }
-    }
 
     IndexedRefTypeInstance* result = IndexedRefTypeInstance::create(globalObject->vm(), this->_indexedRefTypeStructure.get(), innerType, typeSize);
     return result;
 }
 
 ExtVectorTypeInstance* TypeFactory::getExtVectorType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize) {
-    WeakImpl* innerWeak = WeakSet::allocate(JSValue(innerType));
-    if (this->_cacheReferenceType.contains(innerWeak)) {
-        WeakImpl* value = this->_cacheReferenceType.get(innerWeak);
-        if (value->state() == WeakImpl::State::Live) {
-            return static_cast<ExtVectorTypeInstance*>(value->jsValue().asCell());
-        } else {
-            this->_cacheReferenceType.remove(innerWeak);
-        }
-    }
-
     ExtVectorTypeInstance* result = ExtVectorTypeInstance::create(globalObject->vm(), this->_extVectorTypeStructure.get(), innerType, typeSize);
     return result;
 }
@@ -367,7 +348,7 @@ ReferenceTypeInstance* TypeFactory::getReferenceType(GlobalObject* globalObject,
     return result;
 }
 
-JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncoding) {
+JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncoding, bool isStructMember) {
     DeferGCForAWhile deferGC(globalObject->vm().heap);
 
     JSC::JSCell* result = nullptr;
@@ -479,20 +460,25 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
     case BinaryTypeEncodingType::ConstantArrayEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.constantArray.getInnerType();
         size_t arraySize = typeEncoding->details.constantArray.size;
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding);
-        result = this->getIndexedRefType(globalObject, innerType, arraySize);
+        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, true);
+        if (isStructMember) {
+            result = this->getIndexedRefType(globalObject, innerType, arraySize);
+        } else {
+            result = this->getReferenceType(globalObject, innerType);
+        }
+
         break;
     }
     case BinaryTypeEncodingType::ExtVectorEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.extVector.getInnerType();
         size_t arraySize = typeEncoding->details.extVector.size;
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding);
+        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, true);
         result = this->getExtVectorType(globalObject, innerType, arraySize);
         break;
     }
     case BinaryTypeEncodingType::IncompleteArrayEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.incompleteArray.getInnerType();
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding);
+        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, true);
         result = this->getReferenceType(globalObject, innerType);
         break;
     }
@@ -515,12 +501,12 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
     return result;
 }
 
-const WTF::Vector<JSC::JSCell*> TypeFactory::parseTypes(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncodings, int count) {
+const WTF::Vector<JSC::JSCell*> TypeFactory::parseTypes(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember) {
     DeferGCForAWhile deferGC(globalObject->vm().heap);
 
     WTF::Vector<JSCell*> types;
     for (int i = 0; i < count; i++) {
-        types.append(parseType(globalObject, typeEncodings));
+        types.append(parseType(globalObject, typeEncodings, isStructMember));
     }
     return types;
 }


### PR DESCRIPTION
When arrays are passed as parameters in functions or returned by them, they are passed by reference so they should be parsed as ReferenceTypeInstance. When they are elements of other arrays/vectors or struct fields they are passed by value. In such cases they should be parsed as IndexedRefTypeInstance.