### PR TITLE
chore(build): Create CMake project generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,8 @@ For more details on how it works, read the [documentation](https://docs.nativesc
 ## Local Development
 Execute the following commands:
 ```shell
-mkdir "cmake-build" && cd "cmake-build"
-cmake .. -G "Xcode"
-open "NativeScript.xcodeproj"
+./cmake-gen.sh 
+open "cmake-build/NativeScript.xcodeproj"
 ```
 
 After you open the newly generated project in Xcode you can run the `TestRunner` target or the `Gameraww` example app.

--- a/cmake-gen.sh
+++ b/cmake-gen.sh
@@ -1,0 +1,7 @@
+set -ex
+mkdir -p cmake-build
+cd cmake-build
+cmake -DBUILD_SHARED_LIBS=1 -GXcode ..
+
+# Workaround for https://cmake.org/pipermail/cmake/2015-April/060484.html
+sed -i bak -e 's/Versions\/A\///g' NativeScript.xcodeproj/project.pbxproj


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The recommended way of generating the iOS Runtime's Xcode project was to build NativeScript as a static library.

## What is the new behavior?
Create a script to generate the project with dynamic libraries. It works around the bug that CMake has when generating references to frameworks (for details see [this email thread](https://cmake.org/pipermail/cmake/2015-April/060484.html)).

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

