### PR TITLE
fix(inspector): stderr maxbuffer exceeded is thrown during unzip

### DIFF
--- a/build/npm/inspector_package.json
+++ b/build/npm/inspector_package.json
@@ -23,7 +23,7 @@
     "**/*"
   ],
   "scripts": {
-    "postinstall": "OSVERSION=\"$(sw_vers -productVersion | grep -o \"[0-9][0-9].[0-9][0-9]\")\"; OSVERSION=${OSVERSION//.}; UNZIP_FILE=\"NativeScript Inspector Sierra\"; if [ $OSVERSION -ge 1013 ]; then UNZIP_FILE=\"NativeScript Inspector HighSierra\"; fi; unzip -o \"$UNZIP_FILE\" -d .; rm *.zip"
+    "postinstall": "OSVERSION=\"$(sw_vers -productVersion | grep -o \"[0-9][0-9].[0-9][0-9]\")\"; OSVERSION=${OSVERSION//.}; UNZIP_FILE=\"NativeScript Inspector Sierra\"; if [ $OSVERSION -ge 1013 ]; then UNZIP_FILE=\"NativeScript Inspector HighSierra\"; fi; unzip -o -q \"$UNZIP_FILE\" -d .; rm *.zip"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
In some cases, when CLI tries to install the `tns-ios-inspector` an error is thrown - `stderr maxbuffer exceeded`. This is caused by the huge output of the unzip operation executed on post install of the inspector. In order to fix this, pass `-q` (quiet) to the unzip operation.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The easiest way to reproduce the issue is to follow the steps below:
1. `tns create myApp`
2. `cd myApp`
3. `npm i --save-dev --ignore-scripts tns-ios-inpsector@rc`
4. `rm -rf node_modules`
5. `tns platform add ios@rc`

The last operation will fail.

## What is the new behavior?
The unzip operation is much quieter and the buffer is not exceeded.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

