### PR TITLE
fix(debugging): Don't close inspector socket after 30 sec. timeout

### DIFF
--- a/src/debugging/Inspector/Inspector/NativeScript Inspector/Communication.m
+++ b/src/debugging/Inspector/Inspector/NativeScript Inspector/Communication.m
@@ -108,7 +108,7 @@
             communicationSocket = socket(PF_INET, SOCK_STREAM, 0);
 
             struct sockaddr_in addr = {
-                sizeof(addr), AF_INET, htons(18181), { INADDR_ANY }, { 0 }
+                sizeof(addr), AF_INET, htons(18182), { INADDR_ANY }, { 0 }
             };
 
             connected = setupConnection((const struct sockaddr*)&addr, sizeof(addr));

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -79,7 +79,7 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
     setsockopt(listenSocket, SOL_SOCKET, SO_REUSEADDR, &so_reuseaddr,
                sizeof(so_reuseaddr));
     struct sockaddr_in addr = {
-        sizeof(addr), AF_INET, htons(18181), { INADDR_ANY }, { 0 }
+        sizeof(addr), AF_INET, htons(18182), { INADDR_ANY }, { 0 }
     };
 
     if (bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)) != 0) {

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -19,8 +19,12 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-// Synchronization object for serializing access to inspector variable and data
-// socket
+// {N} CLI is relying on this message in order to receive the inspector port number. Please do not change it!
+// Parsing regex is 'NativeScript debugger has opened inspector socket on port (\d+) for (.*)\.'
+// It's defined in 'ios-log-parser-service.ts'
+#define LOG_DEBUGGER_PORT NSLog(@"NativeScript debugger has opened inspector socket on port %d for %@.", currentInspectorPort, [[NSBundle mainBundle] bundleIdentifier])
+
+// Synchronization object for serializing access to inspector variable and data socket
 
 id inspectorLock() {
     static dispatch_once_t once;
@@ -32,7 +36,7 @@ id inspectorLock() {
 }
 static TNSRuntimeInspector* inspector = nil;
 static BOOL isWaitingForDebugger = NO;
-static int32_t cleanupRequestsCount = 0;
+static int currentInspectorPort = 0;
 
 typedef void (^TNSInspectorProtocolHandler)(NSString* message, NSError* error);
 
@@ -77,15 +81,31 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
     struct sockaddr_in addr = {
         sizeof(addr), AF_INET, htons(18181), { INADDR_ANY }, { 0 }
     };
-    if (!CheckError(
-            bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)),
-            connectedHandler)) {
-        return nil;
+
+    if (bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)) != 0) {
+
+        // Try getting a random port if the default one is unavailable
+        addr.sin_port = htons(0);
+
+        if (!CheckError(
+                bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)),
+                connectedHandler)) {
+
+            return nil;
+        }
     }
 
     if (!CheckError(listen(listenSocket, 0), connectedHandler)) {
         return nil;
     }
+
+    // read actually allocated listening port
+    socklen_t len = sizeof(addr);
+    if (!CheckError(getsockname(listenSocket, (struct sockaddr*)&addr, &len), connectedHandler)) {
+        return nil;
+    }
+
+    currentInspectorPort = ntohs(addr.sin_port);
 
     __block dispatch_source_t listenSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listenSocket, 0, queue);
 
@@ -242,8 +262,6 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
                                      TNSRuntime* runtime) {
     __block dispatch_source_t listenSource = nil;
 
-    __block dispatch_block_t scheduleInspectorServerCleanup = nil;
-
     dispatch_block_t clearInspector = ^{
       // Keep a working copy for calling into the VM after releasing inspectorLock
       TNSRuntimeInspector* tempInspector = nil;
@@ -252,7 +270,6 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
               tempInspector = inspector;
               inspector = nil;
               NSSetUncaughtExceptionHandler(NULL);
-              scheduleInspectorServerCleanup();
           }
       }
       // Release and dealloc old inspector; must be outside of the inspectorLock
@@ -268,23 +285,6 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
       }
 
       clearInspector();
-    };
-
-    scheduleInspectorServerCleanup = ^{
-      dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 30);
-      OSAtomicIncrement32Barrier(&cleanupRequestsCount);
-      dispatch_after(delay, dispatch_get_main_queue(), ^{
-        if (OSAtomicDecrement32Barrier(&cleanupRequestsCount) == 0) {
-            bool stopListening = false;
-            @synchronized(inspectorLock()) {
-                stopListening = inspector == nil;
-            }
-
-            if (stopListening) {
-                clear();
-            }
-        }
-      });
     };
 
     [[NSNotificationCenter defaultCenter]
@@ -368,16 +368,14 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
             CFRunLoopRef runloop = CFRunLoopGetMain();
             CFRunLoopPerformBlock(
                 runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
-                  // Keep a working copy for calling into the VM after releasing
-                  // inspectorLock
+                  // Keep a working copy for calling into the VM after releasing inspectorLock
                   TNSRuntimeInspector* tempInspector = nil;
                   @synchronized(inspectorLock()) {
                       tempInspector = inspector;
                   }
 
                   if (tempInspector) {
-                      //                      NSLog(@"NativeScript Debugger
-                      //                      receiving: %@", message);
+                      // NSLog(@"NativeScript Debugger receiving: %@", message);
                       [tempInspector dispatchMessage:message];
                   }
                 });
@@ -412,8 +410,7 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
           dispatch_after(delay, dispatch_get_main_queue(), ^{
             if (isWaitingForDebugger) {
                 isWaitingForDebugger = NO;
-                NSLog(@"NativeScript waiting for debugger timeout elapsed. "
-                      @"Continuing execution.");
+                NSLog(@"NativeScript waiting for debugger timeout elapsed. Continuing execution.");
             }
           });
 
@@ -434,15 +431,12 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
           // Remove any existing frontend connections
           clearInspector();
 
-          // Keep current listening source if existing, schedule cleanup before
-          // check will guard it from previous timer (if such has been started)
-          scheduleInspectorServerCleanup();
-
           if (!listenSource) {
               listenSource = TNSCreateInspectorServer(
                   connectionHandler, ioErrorHandler, clearInspector);
           }
 
+          LOG_DEBUGGER_PORT;
           notify_post(NOTIFICATION("ReadyForAttach"));
         });
 
@@ -451,8 +445,10 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
                              &attachAvailabilityQuerySubscription,
                              dispatch_get_main_queue(), ^(int token) {
                                if (inspector) {
+                                   LOG_DEBUGGER_PORT;
                                    notify_post(NOTIFICATION("AlreadyConnected"));
                                } else if (listenSource) {
+                                   LOG_DEBUGGER_PORT;
                                    notify_post(NOTIFICATION("ReadyForAttach"));
                                } else {
                                    notify_post(NOTIFICATION("AttachAvailable"));

--- a/src/debugging/debugger-proxy.js
+++ b/src/debugging/debugger-proxy.js
@@ -5,10 +5,10 @@ var stream = require("stream");
 
 util.inherits(PacketStream, stream.Transform);
 function PacketStream(opts) {
-	stream.Transform.call(this, opts);
+    stream.Transform.call(this, opts);
 }
 
-PacketStream.prototype._transform = function (packet, encoding, done) {
+PacketStream.prototype._transform = function(packet, encoding, done) {
     while (packet.length > 0) {
         if (!this.buffer) {
             // read length
@@ -32,41 +32,41 @@ PacketStream.prototype._transform = function (packet, encoding, done) {
 };
 
 var server = ws.createServer({
-	port: 8080
+    port: 8080
 });
 server.on("connection", function(webSocket) {
-	console.info("Frontend client connected.");
-	
-	var deviceSocket = net.connect(18181);
-	var packets = new PacketStream();
-	deviceSocket.pipe(packets);
-	
-	packets.on("data", function (buffer) {
-		//console.log("DEVICE " + buffer.toString("utf8"));
-		webSocket.send(buffer.toString("utf16le"), function (error) {
-			if (error) {
-				console.log("ERROR " + error);
-				process.exit(0);
-			}
-		});
-	});
-	
-	webSocket.on("message", function (message, flags) {
-		//console.log("FRONTEND " + message);
-		var length = Buffer.byteLength(message, "utf16le");
-		var payload = new Buffer(length + 4);
-		payload.writeInt32BE(length, 0);
-		payload.write(message, 4, length, "utf16le");
-		deviceSocket.write(payload);
-	});
-	
-	deviceSocket.on("end", function() {
-		console.info("Backend socket closed!");
-		process.exit(0);
-	});
+    console.info("Frontend client connected.");
 
-	webSocket.on("close", function() {
-		console.info('Frontend socket closed!');
-		process.exit(0);
-	});
+    var deviceSocket = net.connect(18182);
+    var packets = new PacketStream();
+    deviceSocket.pipe(packets);
+
+    packets.on("data", function(buffer) {
+        //console.log("DEVICE " + buffer.toString("utf8"));
+        webSocket.send(buffer.toString("utf16le"), function(error) {
+            if (error) {
+                console.log("ERROR " + error);
+                process.exit(0);
+            }
+        });
+    });
+
+    webSocket.on("message", function(message, flags) {
+        //console.log("FRONTEND " + message);
+        var length = Buffer.byteLength(message, "utf16le");
+        var payload = new Buffer(length + 4);
+        payload.writeInt32BE(length, 0);
+        payload.write(message, 4, length, "utf16le");
+        deviceSocket.write(payload);
+    });
+
+    deviceSocket.on("end", function() {
+        console.info("Backend socket closed!");
+        process.exit(0);
+    });
+
+    webSocket.on("close", function() {
+        console.info('Frontend socket closed!');
+        process.exit(0);
+    });
 });


### PR DESCRIPTION
### This PR has to be merged along with https://github.com/NativeScript/nativescript-cli/pull/3540. Wait for it to be approved.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The inspector listening socket is being closed 30 sec. after the last
activity on it (opening, disconnection, etc). It had to be closed in order 
to have the hardcoded port number 18181 available for other apps after
 finishing (or never starting) a debugging session. Without this timeout 
the first app that opened the port would take it for as long as it's running 
and would prevent any subsequent debugging attempts of another app on
the same iOS device; or even any {N} app on any iOS Simulator on the
same Mac machine.

## What is the new behavior?
<!-- Describe the changes. -->
From now on, the default port becomes 18182 and if it is unavailable, 
a random free port will be used. Its number will be output in the 
application log. When starting a debug session, {N} CLI will monitor 
the logs in order to receive the allocated port number for the current
session.

This will allow to connect the frontend at any moment after starting a 
debug session, instead of failing after the 30 seconds have elapsed.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

