### PR TITLE
fix: Add missing calls to addMessageToConsole in console client's tim…

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -183,10 +183,13 @@ void GlobalObjectConsoleClient::takeHeapSnapshot(JSC::ExecState*, const String& 
     m_consoleAgent->takeHeapSnapshot(title);
 }
 
-void GlobalObjectConsoleClient::time(JSC::ExecState*, const String& title) {
+void GlobalObjectConsoleClient::time(JSC::ExecState* exec, const String& title) {
     std::unique_ptr<Inspector::ConsoleMessage> startMsg = m_consoleAgent->startTiming(title);
     if (startMsg) {
         ConsoleClient::printConsoleMessage(startMsg->source(), startMsg->type(), startMsg->level(), startMsg->message(), startMsg->url(), startMsg->line(), startMsg->column());
+
+        m_logAgent->addMessageToConsole(std::make_unique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, startMsg->type(), startMsg->level(), startMsg->message(), WTF::emptyString(), 0, 0, exec));
+        m_consoleAgent->addMessageToConsole(std::make_unique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, startMsg->type(), startMsg->level(), startMsg->message(), WTF::emptyString(), 0, 0, exec));
     }
 }
 
@@ -195,6 +198,8 @@ void GlobalObjectConsoleClient::timeEnd(JSC::ExecState* exec, const String& titl
     std::unique_ptr<Inspector::ConsoleMessage> stopMsg = m_consoleAgent->stopTiming(title, WTFMove(callStack));
     if (stopMsg) {
         ConsoleClient::printConsoleMessage(stopMsg->source(), stopMsg->type(), stopMsg->level(), stopMsg->message(), stopMsg->url(), stopMsg->line(), stopMsg->column());
+        m_logAgent->addMessageToConsole(std::make_unique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, stopMsg->type(), stopMsg->level(), stopMsg->message(), WTF::emptyString(), 0, 0, exec));
+        m_consoleAgent->addMessageToConsole(std::make_unique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, stopMsg->type(), stopMsg->level(), stopMsg->message(), WTF::emptyString(), 0, 0, exec));
     }
 }
 


### PR DESCRIPTION
…e() and timeEnd()

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
console.time() and console.timeEnd() are not working with Chrome DevTools debugger.

## What is the new behavior?
Both methods print proper values in DevTools console.

Fixes #888 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

