### PR TITLE
fix: Format console message before sending it to the console client

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.h
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.h
@@ -30,10 +30,10 @@ protected:
     virtual void timeStamp(JSC::ExecState*, Ref<Inspector::ScriptArguments>&&) override;
 
 private:
-    void printConsoleMessageWithArguments(MessageSource, MessageType, MessageLevel, JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&);
     void warnUnimplemented(const String& method);
     void internalAddMessage(MessageType, MessageLevel, JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&);
     WTF::String getDirMessage(JSC::ExecState*, JSC::JSValue);
+    WTF::String createMessageFromArguments(MessageType, JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&);
 
     Inspector::InspectorConsoleAgent* m_consoleAgent;
     Inspector::InspectorLogAgent* m_logAgent;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
In Chrome DevTools console console.dir() prints only [object Object].

## What is the new behavior?
console.dir() prints objects properly formatted.

Fixes #906 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

