### PR TITLE
fix: update TestRunner app ExportOptions.plist

### DIFF
--- a/cmake/ExportOptions.plist
+++ b/cmake/ExportOptions.plist
@@ -2,7 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>method</key>
-    <string>development</string>
+	<key>method</key>
+	<string>development</string>
+	<key>teamID</key>
+	<string>W7TGC3P93K</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>iPhone Developer</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>org.nativescript.TestRunner</key>
+		<string>NativeScriptDevProfile</string>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently TestRunner application can not be exported after archiving on Xcode9 because of missing provisioning profile. This leads to failures in CI when try to build ios-runtime on machines with Xcode9
```
 Step failed: <IDEDistributionSigningAssetsStep: 0x7fa60b183b30>: Error Domain=IDEDistributionSigningAssetStepErrorDomain Code=0 "Locating signing assets failed." UserInfo={NSLocalizedDescription=Locating signing assets failed., IDEDistributionSigningAssetStepUnderlyingErrors=(
13:54:25     "Error Domain=IDEProvisioningErrorDomain Code=9 \"\"TestRunner.app\" requires a provisioning profile.\" UserInfo={NSLocalizedDescription=\"TestRunner.app\" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the \"provisioningProfiles\" dictionary in your Export Options property list.}"
13:54:25 )}
13:54:25 error: exportArchive: "TestRunner.app" requires a provisioning profile.
13:54:25 
13:54:25 Error Domain=IDEProvisioningErrorDomain Code=9 ""TestRunner.app" requires a provisioning profile." UserInfo={NSLocalizedDescription="TestRunner.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
13:54:25 
13:54:25 ** EXPORT FAILED **
```
## What is the new behavior?
<!-- Describe the changes. -->
To be able to export TestRunner app on Xcode9 ExportOptions.plist should be updated with adding `provisioningProfiles`, `signingCertificate`, `signingStyle`, `teamID`.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

