### PR TITLE
fix(debug): Close dispatch_io when disconnecting inspector

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -35,6 +35,7 @@ id inspectorLock() {
     return lock;
 }
 static TNSRuntimeInspector* inspector = nil;
+static dispatch_io_t inspector_io = nil;
 static BOOL isWaitingForDebugger = NO;
 static int currentInspectorPort = 0;
 
@@ -43,7 +44,7 @@ typedef void (^TNSInspectorProtocolHandler)(NSString* message, NSError* error);
 typedef void (^TNSInspectorSendMessageBlock)(NSString* message);
 
 typedef TNSInspectorProtocolHandler (^TNSInspectorFrontendConnectedHandler)(
-    TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error);
+    TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error, dispatch_io_t io);
 
 typedef void (^TNSInspectorIoErrorHandler)(
     NSObject* dummy /*make compatible with CheckError macro*/, NSError* error);
@@ -82,6 +83,10 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
         sizeof(addr), AF_INET, htons(18183), { INADDR_ANY }, { 0 }
     };
 
+    // Adapter block for CheckError macro
+    TNSInspectorProtocolHandler (^connectedErrorHandler)(TNSInspectorSendMessageBlock, NSError*) = ^(TNSInspectorSendMessageBlock sendMessage, NSError* error) {
+      return connectedHandler(sendMessage, error, nil);
+    };
     if (bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)) != 0) {
 
         // Try getting a random port if the default one is unavailable
@@ -89,19 +94,19 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
 
         if (!CheckError(
                 bind(listenSocket, (const struct sockaddr*)&addr, sizeof(addr)),
-                connectedHandler)) {
+                connectedErrorHandler)) {
 
             return nil;
         }
     }
 
-    if (!CheckError(listen(listenSocket, 0), connectedHandler)) {
+    if (!CheckError(listen(listenSocket, 0), connectedErrorHandler)) {
         return nil;
     }
 
     // read actually allocated listening port
     socklen_t len = sizeof(addr);
-    if (!CheckError(getsockname(listenSocket, (struct sockaddr*)&addr, &len), connectedHandler)) {
+    if (!CheckError(getsockname(listenSocket, (struct sockaddr*)&addr, &len), connectedErrorHandler)) {
         return nil;
     }
 
@@ -177,7 +182,7 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
         }
       };
 
-      protocolHandler = connectedHandler(sender, nil);
+      protocolHandler = connectedHandler(sender, nil, io);
       if (!protocolHandler) {
           dataSocketErrorHandler(nil, nil);
           return;
@@ -270,6 +275,11 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
               tempInspector = inspector;
               inspector = nil;
               NSSetUncaughtExceptionHandler(NULL);
+
+              if (inspector_io) {
+                  dispatch_io_close(inspector_io, DISPATCH_IO_STOP);
+                  inspector_io = 0;
+              }
           }
       }
       // Release and dealloc old inspector; must be outside of the inspectorLock
@@ -304,7 +314,7 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
                 }];
 
     TNSInspectorFrontendConnectedHandler connectionHandler = ^TNSInspectorProtocolHandler(
-        TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error) {
+        TNSInspectorSendMessageBlock sendMessageToFrontend, NSError* error, dispatch_io_t io) {
       if (error) {
           if (listenSource) {
               clear();
@@ -336,6 +346,7 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
           NSLog(@"NativeScript debugger attached.");
 
           inspector = tempInspector;
+          inspector_io = io;
           NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
       }
 


### PR DESCRIPTION
When a second inspector client connects we want to dispose of
the previous one. Before this fix however, we only destroyed the
handler function without disconnecting the frontend socket.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a new frontend connects, the socket of the previous one is left open.
## What is the new behavior?
<!-- Describe the changes. -->
When a new frontend connects, the socket of the previous one is closed.

Fixes #927

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

