### PR TITLE
fix(debugger): console.dir not displayed correctly in Safari inspector

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -122,8 +122,9 @@ void GlobalObjectConsoleClient::messageWithTypeAndLevel(MessageType type, Messag
             ConsoleClient::printConsoleMessageWithArguments(MessageSource::ConsoleAPI, type, level, exec, arguments.copyRef());
         }
     }
+
     std::unique_ptr<Inspector::ConsoleMessage> consoleMessage = std::make_unique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, message, WTF::emptyString(), 0, 0, exec);
-    this->addMessageToAgentsConsole(WTFMove(consoleMessage));
+    this->addMessageToAgentsConsole(WTFMove(consoleMessage), WTFMove(arguments), exec);
 }
 
 void GlobalObjectConsoleClient::count(JSC::ExecState* exec, Ref<Inspector::ScriptArguments>&& arguments) {
@@ -196,7 +197,7 @@ WTF::String GlobalObjectConsoleClient::getDirMessage(JSC::ExecState* exec, JSC::
     return output.toString();
 }
 
-WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType type, JSC::ExecState* exec, RefPtr<Inspector::ScriptArguments>&& arguments) {
+WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType type, JSC::ExecState* exec, Ref<Inspector::ScriptArguments>&& arguments) {
 
     RefPtr<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, 1));
     const Inspector::ScriptCallFrame& lastCaller = callStack->size() > 0 ? callStack->at(0) : Inspector::ScriptCallFrame("", "", JSC::noSourceID, 0, 0);
@@ -209,6 +210,7 @@ WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType ty
     }
 
     if (type == JSC::MessageType::Dir) {
+        // don't enumerate args as console.dir supports only one argument
         JSC::JSValue argumentValue = arguments->argumentAt(0).jsValue();
         builder.append(this->getDirMessage(exec, argumentValue));
     } else {
@@ -228,10 +230,17 @@ WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType ty
 }
 
 void GlobalObjectConsoleClient::addMessageToAgentsConsole(std::unique_ptr<Inspector::ConsoleMessage>&& message) {
-
     m_logAgent->addMessageToConsole(std::make_unique<Inspector::ConsoleMessage>(*message.get()));
 
     m_consoleAgent->addMessageToConsole(WTFMove(message));
 }
 
+void GlobalObjectConsoleClient::addMessageToAgentsConsole(std::unique_ptr<Inspector::ConsoleMessage>&& message, Ref<Inspector::ScriptArguments>&& arguments, JSC::ExecState* exec) {
+
+    auto consoleMessage = std::make_unique<Inspector::ConsoleMessage>(message->source(), message->type(), message->level(),
+                                                                      message->message(), WTFMove(arguments), exec);
+
+    m_logAgent->addMessageToConsole(WTFMove(message));
+    m_consoleAgent->addMessageToConsole(WTFMove(consoleMessage));
+}
 } // namespace NativeScript

--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.h
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.h
@@ -33,8 +33,9 @@ private:
     void warnUnimplemented(const String& method);
     void internalAddMessage(MessageType, MessageLevel, JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&);
     WTF::String getDirMessage(JSC::ExecState*, JSC::JSValue);
-    WTF::String createMessageFromArguments(MessageType, JSC::ExecState*, RefPtr<Inspector::ScriptArguments>&&);
+    WTF::String createMessageFromArguments(MessageType, JSC::ExecState*, Ref<Inspector::ScriptArguments>&&);
     void addMessageToAgentsConsole(std::unique_ptr<Inspector::ConsoleMessage>&&);
+    void addMessageToAgentsConsole(std::unique_ptr<Inspector::ConsoleMessage>&& message, Ref<Inspector::ScriptArguments>&& arguments, JSC::ExecState* exec);
 
     Inspector::InspectorConsoleAgent* m_consoleAgent;
     Inspector::InspectorLogAgent* m_logAgent;


### PR DESCRIPTION
consoleAgent prints them correctly only when they're constructed
using the overload accepting `ScriptArguments`.

Regression has been introduced with #912

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When `console.dir({a:1})` is executed by the application or in the console window of Safari Inspector the output contains only `undefined`.
## What is the new behavior?
<!-- Describe the changes. -->
`console.dir` correctly displays the object in the console window.

Fixes #930 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

