### PR TITLE
fix(debugging): Do not clear inspector if it doesn't match failed connection

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -266,12 +266,13 @@ static void TNSInspectorUncaughtExceptionHandler(NSException* exception) {
 static void TNSEnableRemoteInspector(int argc, char** argv,
                                      TNSRuntime* runtime) {
     __block dispatch_source_t listenSource = nil;
+    __block dispatch_io_t current_connection_inspector_io = nil;
 
     dispatch_block_t clearInspector = ^{
       // Keep a working copy for calling into the VM after releasing inspectorLock
       TNSRuntimeInspector* tempInspector = nil;
       @synchronized(inspectorLock()) {
-          if (inspector) {
+          if (inspector && current_connection_inspector_io == inspector_io) {
               tempInspector = inspector;
               inspector = nil;
               NSSetUncaughtExceptionHandler(NULL);
@@ -347,6 +348,7 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
 
           inspector = tempInspector;
           inspector_io = io;
+          current_connection_inspector_io = io;
           NSSetUncaughtExceptionHandler(&TNSInspectorUncaughtExceptionHandler);
       }
 


### PR DESCRIPTION
In the scenario when a new connection disconnects the previous one there's
a racing condition which sometimes leads to disconnecting both frontends.
To avoid clearing the new one when the older receives EABORT, we now
check whether the current global inspector_io matches the one of the
failed connection. This way even if the order of events is unfavoring we
won't disconnect the wrong frontend client.


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Connecting a second debugger tab sometimes fails and/or makes the frontend hang.

## What is the new behavior?
Connecting a second debugger tab always disconnect the first one and doesn't fail sporadically.

Additional fix for #927

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

