### PR TITLE
feat: Create NativeScriptEmbedder protocol

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -105,6 +105,7 @@ set(HEADER_FILES
     Workers/JSWorkerInstance.h
     Workers/JSWorkerPrototype.h
     Workers/WorkerMessagingProxy.h
+    module.modulemap
 )
 
 set(SOURCE_FILES
@@ -212,6 +213,7 @@ set(NativeScript_PUBLIC_HEADERS
     TNSRuntime+Diagnostics.h
     TNSRuntime+Inspector.h
     TNSRuntime.h
+    module.modulemap
 )
 
 set(JSFILES

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -55,6 +55,7 @@ set(HEADER_FILES
     Metadata/Metadata.h
     NativeScript-Prefix.h
     NativeScript.h
+    NativeScriptEmbedder.h
     ObjC/AllocatedPlaceholder.h
     ObjC/Block/ObjCBlockCall.h
     ObjC/Block/ObjCBlockCallback.h
@@ -206,6 +207,7 @@ set(SOURCE_FILES
 
 set(NativeScript_PUBLIC_HEADERS
     NativeScript.h
+    NativeScriptEmbedder.h
     TNSRuntimeInstrumentation.h
     TNSRuntime+Diagnostics.h
     TNSRuntime+Inspector.h

--- a/src/NativeScript/NativeScript.h
+++ b/src/NativeScript/NativeScript.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 г. Telerik. All rights reserved.
 //
 
+#import "NativeScriptEmbedder.h"
 #import "TNSRuntime+Diagnostics.h"
 #import "TNSRuntime+Inspector.h"
 #import "TNSRuntime.h"

--- a/src/NativeScript/NativeScriptEmbedder.h
+++ b/src/NativeScript/NativeScriptEmbedder.h
@@ -6,10 +6,11 @@
 //
 #include <UIKit/UIKit.h>
 
-//When embedding NativeScript application embedder needs to conform to this protocol
-//in order to have control over the NativeScript UIViewController
-//otherwise NativeScript application is presented over the topmost UIViewController.
-//https://github.com/NativeScript/NativeScript/pull/5967
+// When embedding NativeScript application embedder needs to conform to this protocol
+// in order to have control over the NativeScript UIViewController
+// otherwise NativeScript application is presented over the topmost UIViewController.
+// Implemented in tns-core-modules by the following PR:
+// https://github.com/NativeScript/NativeScript/pull/5967
 @protocol NativeScriptEmbedder
 - (id)presentNativeScriptApp:(UIViewController*)vc;
 @end

--- a/src/NativeScript/NativeScriptEmbedder.h
+++ b/src/NativeScript/NativeScriptEmbedder.h
@@ -1,0 +1,15 @@
+//
+//  NativeScriptEmbedder.h
+//  NativeScript
+//
+//  Created by Teodor Dermendzhiev on 6/19/18.
+//
+#include <UIKit/UIKit.h>
+
+//When embedding NativeScript application embedder needs to conform to this protocol
+//in order to have control over the NativeScript UIViewController
+//otherwise NativeScript application is presented over the topmost UIViewController.
+//https://github.com/NativeScript/NativeScript/pull/5967
+@protocol NativeScriptEmbedder
+- (id)presentNativeScriptApp:(UIViewController*)vc;
+@end

--- a/src/NativeScript/module.modulemap
+++ b/src/NativeScript/module.modulemap
@@ -1,0 +1,4 @@
+module NativeScript {
+    header "NativeScriptEmbedder.h"
+    export *
+}


### PR DESCRIPTION
When embedding a NativeScript application, the native class, calling the NS runtime, should conform to NativeScriptEmbedder protocol in order get a reference to the NativeScript application viewcontroller. Related to https://github.com/NativeScript/NativeScript/pull/5967

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Embedded app is always presented on top of the application's rootViewController.

## What is the new behavior?
Embedded app's rootViewController is passed to the native class which implements the NativeScriptEmbedder protocol.


