### PR TITLE
fix(build): Get Inspector UI from High Sierra build

### DIFF
--- a/build/scripts/package-tns-ios-inspector.sh
+++ b/build/scripts/package-tns-ios-inspector.sh
@@ -9,9 +9,9 @@ checkpoint "tns-ios-inspector started"
 PACKAGE_DIR="$DIST_DIR/inspector-package"
 
 mkdir -p "$PACKAGE_DIR"
-cp -r "$WORKSPACE/src/debugging/WebInspectorUI" "$PACKAGE_DIR/WebInspectorUI"
 cp -R -a "$BINARIES_DIR/NativeScript Inspector Sierra.zip" "$PACKAGE_DIR"
 cp -R -a "$BINARIES_DIR/NativeScript Inspector HighSierra.zip" "$PACKAGE_DIR"
+tar -zxf "$BINARIES_DIR/WebInspectorUI.tgz" -C "$PACKAGE_DIR"
 cp -r "$WORKSPACE/build/npm/inspector_package.json" "$PACKAGE_DIR/package.json"
 
 python "$WORKSPACE/build/scripts/update-version.py" "$PACKAGE_DIR/package.json"


### PR DESCRIPTION
Till now the Inspector UI package was taken from the workspace of the
combining build. In order to remove the need to clone webkit in it we're
moving it's preparation in the build that produces the High Sierra application
package.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Inspector package build needs to clone submodules

## What is the new behavior?
Inspector package build no longer needs to clone submodules


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

