### PR TITLE
chore: Move clang modules and auto link frameworks flags to build.xcc…

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -316,8 +316,6 @@
 			baseConfigurationReference = CDD59A261BB43B5D00EC2671 /* build-debug.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_MODULES_AUTOLINK = NO;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch";
@@ -338,8 +336,6 @@
 			baseConfigurationReference = CDD59A271BB43B5D00EC2671 /* build-release.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_MODULES_AUTOLINK = NO;
 				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "__PROJECT_NAME__/__PROJECT_NAME__-Prefix.pch";

--- a/build/project-template/__PROJECT_NAME__/build.xcconfig
+++ b/build/project-template/__PROJECT_NAME__/build.xcconfig
@@ -1,1 +1,3 @@
 #include "../internal/nativescript-build.xcconfig"
+CLANG_ENABLE_MODULES = NO;
+CLANG_MODULES_AUTOLINK = NO;


### PR DESCRIPTION
…onfig

Having CLANG_ENABLE_MODULES and CLANG_MODULES_AUTOLINK in project.pbxproj makes these settings persist even when they should be overridden by a NativeScript app's custom .xcconfig file.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
All flags set in the .pbxproject could not be overriden by an .xcconfig file of a NativeScript application.

## What is the new behavior?
CLANG_ENABLE_MODULES and CLANG_MODULES_AUTOLINK flags are moved in build.xcconfig and therefore made overridable.


