### PR TITLE
fix(cmake): Embed NativeScript.framework in sample and test applications

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -1,5 +1,7 @@
+project(NativeScriptFramework)
+
 set(HEADER_FILES
-    Calling/FFICache.h	
+    Calling/FFICache.h
     Calling/FFICall.h
     Calling/FFICallback.h
     Calling/FFICallbackInlines.h


### PR DESCRIPTION
This is necessary in order to be able to run them successfully on device

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Xcode targets for sample and TestRunner apps cannot be deployed on device when NativeScript is built as a dynamic framework.
## What is the new behavior?
The framework is embedded in the built app bundles and they can now run on devices.
