### PR TITLE
fix(marshalling): Protect against missing topCallFrame

### DIFF
--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -41,7 +41,7 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    JSC::JSValue pointerInstanceForPointer(JSC::VM&, void*);
+    JSC::JSValue pointerInstanceForPointer(JSC::ExecState*, void*);
 
     JSC::Structure* referenceInstanceStructure() const {
         return this->_referenceInstanceStructure.get();

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -150,7 +150,7 @@ static EncodedJSValue JSC_HOST_CALL interopFuncAlloc(ExecState* execState) {
     void* value = calloc(size, 1);
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState->vm(), value);
+    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState, value);
     if (PointerInstance* pointer = jsDynamicCast<PointerInstance*>(execState->vm(), result)) {
         pointer->setAdopted(true);
     }
@@ -209,7 +209,7 @@ static EncodedJSValue JSC_HOST_CALL interopFuncHandleof(ExecState* execState) {
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    JSValue pointer = globalObject->interop()->pointerInstanceForPointer(execState->vm(), handle);
+    JSValue pointer = globalObject->interop()->pointerInstanceForPointer(execState, handle);
     return JSValue::encode(pointer);
 }
 
@@ -336,7 +336,7 @@ void Interop::finishCreation(VM& vm, GlobalObject* globalObject) {
     objCBlockTypePrototype->putDirect(vm, vm.propertyNames->constructor, objCBlockTypeConstructor, DontEnum);
 }
 
-JSValue Interop::pointerInstanceForPointer(VM& vm, void* value) {
+JSValue Interop::pointerInstanceForPointer(ExecState* execState, void* value) {
     if (!value) {
         return jsNull();
     }
@@ -345,7 +345,7 @@ JSValue Interop::pointerInstanceForPointer(VM& vm, void* value) {
         return pointerInstance;
     }
 
-    PointerInstance* pointerInstance = PointerInstance::create(vm, this->_pointerInstanceStructure.get(), value);
+    PointerInstance* pointerInstance = PointerInstance::create(execState, this->_pointerInstanceStructure.get(), value);
     this->_pointerToInstance.set(value, pointerInstance);
     return pointerInstance;
 }

--- a/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
+++ b/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
@@ -127,7 +127,7 @@ static JSValue cStringType_read(ExecState* execState, const void* buffer, JSCell
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     JSCell* type = globalObject->typeFactory()->int8Type();
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), const_cast<char*>(string)));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<char*>(string)));
     return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), type, pointer);
 }
 static void cStringType_write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {

--- a/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
@@ -36,7 +36,7 @@ static EncodedJSValue JSC_HOST_CALL constructPointerInstance(ExecState* execStat
         value = reinterpret_cast<void*>(execState->argument(0).toUInt32(execState));
     }
 
-    JSValue result = jsCast<GlobalObject*>(execState->lexicalGlobalObject())->interop()->pointerInstanceForPointer(execState->vm(), value);
+    JSValue result = jsCast<GlobalObject*>(execState->lexicalGlobalObject())->interop()->pointerInstanceForPointer(execState, value);
     return JSValue::encode(result);
 }
 
@@ -58,7 +58,7 @@ JSValue PointerConstructor::read(ExecState* execState, const void* buffer, JSCel
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    return globalObject->interop()->pointerInstanceForPointer(execState->vm(), const_cast<void*>(data));
+    return globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data));
 }
 
 void PointerConstructor::write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {

--- a/src/NativeScript/Marshalling/Pointer/PointerInstance.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerInstance.cpp
@@ -39,9 +39,9 @@ EncodedJSValue JSC_HOST_CALL readFromPointer(ExecState* execState) {
 
 const ClassInfo PointerInstance::s_info = { "Pointer", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(PointerInstance) };
 
-void PointerInstance::finishCreation(VM& vm, void* value) {
-    Base::finishCreation(vm);
-    this->preventExtensions(this, vm.topCallFrame);
+void PointerInstance::finishCreation(ExecState* execState, void* value) {
+    Base::finishCreation(execState->vm());
+    this->preventExtensions(this, execState);
     this->_data = value;
 }
 

--- a/src/NativeScript/Marshalling/Pointer/PointerInstance.h
+++ b/src/NativeScript/Marshalling/Pointer/PointerInstance.h
@@ -22,9 +22,10 @@ public:
 
     DECLARE_INFO;
 
-    static PointerInstance* create(JSC::VM& vm, JSC::Structure* structure, void* value = nullptr) {
+    static PointerInstance* create(JSC::ExecState* execState, JSC::Structure* structure, void* value = nullptr) {
+        JSC::VM& vm = execState->vm();
         PointerInstance* object = new (NotNull, JSC::allocateCell<PointerInstance>(vm.heap)) PointerInstance(vm, structure);
-        object->finishCreation(vm, value);
+        object->finishCreation(execState, value);
         return object;
     }
 
@@ -55,7 +56,7 @@ private:
         static_cast<PointerInstance*>(cell)->~PointerInstance();
     }
 
-    void finishCreation(JSC::VM&, void*);
+    void finishCreation(JSC::ExecState*, void*);
 
     void* _data;
 

--- a/src/NativeScript/Marshalling/Pointer/PointerPrototype.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerPrototype.cpp
@@ -21,7 +21,7 @@ static EncodedJSValue JSC_HOST_CALL pointerProtoFuncAdd(ExecState* execState) {
     void* newValue = reinterpret_cast<void*>(reinterpret_cast<char*>(value) + offset);
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState->vm(), newValue);
+    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState, newValue);
     return JSValue::encode(result);
 }
 
@@ -31,7 +31,7 @@ static EncodedJSValue JSC_HOST_CALL pointerProtoFuncSubtract(ExecState* execStat
     void* newValue = reinterpret_cast<void*>(reinterpret_cast<char*>(value) - offset);
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState->vm(), newValue);
+    JSValue result = globalObject->interop()->pointerInstanceForPointer(execState, newValue);
     return JSValue::encode(result);
 }
 

--- a/src/NativeScript/Marshalling/Record/RecordConstructor.cpp
+++ b/src/NativeScript/Marshalling/Record/RecordConstructor.cpp
@@ -93,7 +93,7 @@ JSValue RecordConstructor::read(ExecState* execState, const void* buffer, JSCell
 
     void* data = malloc(size);
     memcpy(data, buffer, size);
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), data));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, data));
     pointer->setAdopted(true);
     RecordInstance* record = RecordInstance::create(execState->vm(), globalObject, constructor->instancesStructure(), size, pointer);
     return record;
@@ -189,7 +189,7 @@ EncodedJSValue JSC_HOST_CALL RecordConstructor::constructRecordInstance(ExecStat
     const ffi_type* ffiType = constructor->_ffiTypeMethodTable.ffiType;
 
     void* data = calloc(ffiType->size, 1);
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), data));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, data));
     pointer->setAdopted(true);
 
     RecordInstance* instance = RecordInstance::create(execState->vm(), globalObject, constructor->instancesStructure(), ffiType->size, pointer);

--- a/src/NativeScript/Marshalling/Record/RecordInstance.cpp
+++ b/src/NativeScript/Marshalling/Record/RecordInstance.cpp
@@ -14,12 +14,12 @@ using namespace JSC;
 
 const ClassInfo RecordInstance::s_info = { "record", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(RecordInstance) };
 
-void RecordInstance::finishCreation(VM& vm, JSGlobalObject* globalObject, size_t size, PointerInstance* pointer) {
-    Base::finishCreation(vm);
-    this->preventExtensions(this, vm.topCallFrame);
+void RecordInstance::finishCreation(ExecState* execState, JSGlobalObject* globalObject, size_t size, PointerInstance* pointer) {
+    Base::finishCreation(execState->vm());
+    this->preventExtensions(this, execState);
 
     this->_size = size;
-    this->_pointer.set(vm, this, pointer);
+    this->_pointer.set(execState->vm(), this, pointer);
 }
 
 void RecordInstance::visitChildren(JSCell* cell, SlotVisitor& visitor) {

--- a/src/NativeScript/Marshalling/Record/RecordInstance.h
+++ b/src/NativeScript/Marshalling/Record/RecordInstance.h
@@ -19,7 +19,7 @@ public:
 
     static RecordInstance* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, size_t size, PointerInstance* pointer) {
         RecordInstance* cell = new (NotNull, JSC::allocateCell<RecordInstance>(vm.heap)) RecordInstance(vm, structure);
-        cell->finishCreation(vm, globalObject, size, pointer);
+        cell->finishCreation(globalObject->globalExec(), globalObject, size, pointer);
         return cell;
     }
 
@@ -50,7 +50,7 @@ private:
         static_cast<RecordInstance*>(cell)->~RecordInstance();
     }
 
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, size_t size, PointerInstance* pointer);
+    void finishCreation(JSC::ExecState*, JSC::JSGlobalObject*, size_t size, PointerInstance* pointer);
 
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
 

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
@@ -31,7 +31,7 @@ JSValue ExtVectorTypeInstance::read(ExecState* execState, const void* buffer, JS
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     ExtVectorTypeInstance* referenceType = jsCast<ExtVectorTypeInstance*>(self);
 
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), const_cast<void*>(data)));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
     return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->extVectorInstanceStructure(), referenceType->innerType(), pointer);
 }
 

--- a/src/NativeScript/Marshalling/Reference/IndexedRefInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefInstance.cpp
@@ -31,7 +31,7 @@ void IndexedRefInstance::createBackingStorage(VM& vm, GlobalObject* globalObject
     this->setType(vm, innerType);
 
     void* data = calloc(this->_ffiTypeMethodTable.ffiType->size, 1);
-    this->_pointer.set(vm, this, jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(vm, data)));
+    this->_pointer.set(vm, this, jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, data)));
     this->_pointer->setAdopted(true);
 
     PropertySlot propertySlot(this, PropertySlot::InternalMethodType::GetOwnProperty);

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
@@ -30,7 +30,7 @@ JSValue IndexedRefTypeInstance::read(ExecState* execState, const void* buffer, J
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     IndexedRefTypeInstance* referenceType = jsCast<IndexedRefTypeInstance*>(self);
 
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), const_cast<void*>(data)));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
     return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->indexedRefInstanceStructure(), referenceType->innerType(), pointer);
 }
 

--- a/src/NativeScript/Marshalling/Reference/ReferenceConstructor.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceConstructor.cpp
@@ -63,7 +63,7 @@ static EncodedJSValue JSC_HOST_CALL constructReference(ExecState* execState) {
             handle = calloc(ffiTypeMethodTable->ffiType->size, 1);
         }
 
-        PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(vm, handle));
+        PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, handle));
         pointer->setAdopted(adopted);
         result = ReferenceInstance::create(vm, globalObject, globalObject->interop()->referenceInstanceStructure(), maybeType.asCell(), pointer);
     } else if (execState->argumentCount() == 2) {

--- a/src/NativeScript/Marshalling/Reference/ReferenceInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceInstance.cpp
@@ -31,7 +31,7 @@ void ReferenceInstance::createBackingStorage(VM& vm, GlobalObject* globalObject,
     this->setType(vm, innerType);
 
     void* data = calloc(this->_ffiTypeMethodTable.ffiType->size, 1);
-    this->_pointer.set(vm, this, jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(vm, data)));
+    this->_pointer.set(vm, this, jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, data)));
     this->_pointer->setAdopted(true);
 
     PropertySlot propertySlot(this, PropertySlot::InternalMethodType::GetOwnProperty);

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
@@ -25,7 +25,7 @@ JSValue ReferenceTypeInstance::read(ExecState* execState, const void* buffer, JS
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     ReferenceTypeInstance* referenceType = jsCast<ReferenceTypeInstance*>(self);
 
-    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState->vm(), const_cast<void*>(data)));
+    PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
     return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), referenceType->innerType(), pointer);
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

It's possible to receive a null topCallFrame when embedding {N} runtime
in a native app. Refactor so that we take the `ExecState` as an argument
instead of relying on `vm.topCallFrame`

Fixes https://github.com/NativeScript/NativeScript/issues/6019

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

