### PR TITLE
fix(live-edit): Correctly find source of CommonJS modules in setScriptSource

### DIFF
--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -15,6 +15,9 @@
 #include <objc/runtime.h>
 #include <wtf/Deque.h>
 
+#define COMMONJS_FUNCTION_PROLOGUE "{function anonymous(require, module, exports, __dirname, __filename) {"
+#define COMMONJS_FUNCTION_EPILOGUE "\n}}"
+
 namespace NativeScript {
 class ObjCConstructorBase;
 class ObjCProtocolWrapper;

--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -383,9 +383,9 @@ JSInternalPromise* GlobalObject::moduleLoaderInstantiate(JSGlobalObject* globalO
         ASSERT(!error.isValid());
 
         WTF::StringBuilder moduleFunctionSource;
-        moduleFunctionSource.append("{function anonymous(require, module, exports, __dirname, __filename) {");
+        moduleFunctionSource.append(COMMONJS_FUNCTION_PROLOGUE);
         moduleFunctionSource.append(source);
-        moduleFunctionSource.append("\n}}");
+        moduleFunctionSource.append(COMMONJS_FUNCTION_EPILOGUE);
 
         JSObject* exception = nullptr;
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Continues the work from #959 which was not working with source code of CommonJS modules

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

