### PR TITLE
fix(runtime): Throw an Objective C exception on fatal error

### DIFF
--- a/examples/Gameraww/app/MasterViewController.js
+++ b/examples/Gameraww/app/MasterViewController.js
@@ -21,6 +21,7 @@ var JSMasterViewController = UITableViewController.extend(
         this.loadData();
       },
       "aboutPressed:" : function(sender) {
+        throw new Error("crash!");
         var alertWindow = new UIAlertView({
           title : "About",
           message : "NativeScript Team",


### PR DESCRIPTION
Raise an Objective C exception with JS callstack information, instead of causing
an EXC_BAD_ACCESS signal when a fatal error is detected. This way of crashing
is more appropriate for handling by error reporting analytics libraries like Sentry

refs #963

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

