### PR TITLE
feat: Introduce a setting for discarding uncaught JS exceptions

### DIFF
--- a/src/NativeScript/JSErrors.h
+++ b/src/NativeScript/JSErrors.h
@@ -13,14 +13,10 @@
 #include <JavaScriptCore/Exception.h>
 
 namespace NativeScript {
-void reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*, bool callJsUncaughtErrorCallback = true);
 
-inline void reportErrorIfAny(JSC::ExecState* execState, JSC::CatchScope& scope) {
-    if (JSC::Exception* exception = scope.exception()) {
-        scope.clearException();
-        reportFatalErrorBeforeShutdown(execState, exception);
-    }
-}
+void reportErrorIfAny(JSC::ExecState* execState, JSC::CatchScope& scope);
+void reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*, bool callJsUncaughtErrorCallback = true, bool dontCrash = false);
+
 } // namespace NativeScript
 
 #endif /* defined(__NativeScript__JSErrors__) */

--- a/src/NativeScript/TNSRuntime.h
+++ b/src/NativeScript/TNSRuntime.h
@@ -36,6 +36,8 @@ FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handle
 - (void)executeModule:(NSString*)entryPointModuleIdentifier referredBy:(NSString*)referer;
 
 - (JSValueRef)convertObject:(id)object;
+
+- (id)appPackageJson;
 @end
 
 @interface TNSWorkerRuntime : TNSRuntime

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -44,7 +44,15 @@ JSInternalPromise* loadAndEvaluateModule(ExecState* exec, const String& moduleNa
     return globalObject->moduleLoader()->loadAndEvaluateModule(exec, moduleNameJsValue, referrerJsValue, initiator);
 }
 
+@interface TNSRuntime ()
+
+@property(nonatomic, retain) id appPackageJsonData;
+
+@end
+
 @implementation TNSRuntime
+
+@synthesize appPackageJsonData;
 
 static WTF::Lock _runtimesLock;
 static NSPointerArray* _runtimes;
@@ -178,6 +186,22 @@ static NSPointerArray* _runtimes;
 - (JSValueRef)convertObject:(id)object {
     JSLockHolder lock(*self->_vm);
     return toRef(self->_globalObject->globalExec(), toValue(self->_globalObject->globalExec(), object));
+}
+
+- (id)appPackageJson {
+
+    if (self->appPackageJsonData != nil) {
+        return self->appPackageJsonData;
+    }
+
+    NSString* packageJsonPath = [self->_applicationPath stringByAppendingPathComponent:@"app/package.json"];
+    NSData* data = [NSData dataWithContentsOfFile:packageJsonPath];
+    if (data) {
+        NSError* error = nil;
+        self->appPackageJsonData = [[NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error] retain];
+    }
+
+    return self->appPackageJsonData;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
The app crashes whenever an unhandled JS error is detected.

## What is the new behavior?
There's a new setting in `package.json` which determines whether to discard the exception after it's logged or to crash the application.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


For more information see #965 and https://github.com/NativeScript/android-runtime/issues/1119

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

