### PR TITLE
chore: Clone WebKit shallowly by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "src/webkit"]
 	path = src/webkit
 	url = git@github.com:NativeScript/webkit.git
+	shallow = true
 [submodule "src/libffi"]
 	path = src/libffi
 	url = git@github.com:NativeScript/libffi.git


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
When the project is cloned anew it clones the whole WebKit submodule which is huge

## What is the new behavior?
When the project is cloned anew it clones the WebKit submodule shallowly