### PR TITLE
fix(objc-call): Don't crash when calling an optional protocol method

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -25,13 +25,15 @@ enum MetaFlags {
     FunctionReturnsUnmanaged = 3,
     FunctionIsVariadic = 5,
     FunctionOwnsReturnedCocoaObject = 4,
+    MemberIsOptional = 0, // Mustn't equal any Method or Property flag since it can be applicable to both
     MethodIsInitializer = 1,
     MethodIsVariadic = 2,
     MethodIsNullTerminatedVariadic = 3,
     MethodOwnsReturnedCocoaObject = 4,
     MethodHasErrorOutParameter = 5,
     PropertyHasGetter = 2,
-    PropertyHasSetter = 3
+    PropertyHasSetter = 3,
+
 };
 
 /// This enum describes the possible ObjectiveC entity types.
@@ -581,6 +583,9 @@ public:
 };
 
 struct MemberMeta : Meta {
+    bool isOptional() const {
+        return this->flag(MetaFlags::MemberIsOptional);
+    }
 };
 
 struct MethodMeta : MemberMeta {

--- a/src/NativeScript/ObjC/ObjCMethodCall.h
+++ b/src/NativeScript/ObjC/ObjCMethodCall.h
@@ -66,6 +66,8 @@ private:
 
     bool _hasErrorOutParameter;
 
+    bool _isOptional;
+
     bool _isInitializer;
 
     SEL _selector;


### PR DESCRIPTION
refs #978

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
