### PR TITLE
fix(template): Remove VALID_ARCHS from project.pbxproj

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -272,7 +272,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "armv7 arm64";
 			};
 			name = Debug;
 		};
@@ -307,7 +306,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "armv7 arm64";
 			};
 			name = Release;
 		};
@@ -326,7 +324,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = __PROJECT_NAME__;
-				VALID_ARCHS = "armv7 arm64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -342,7 +339,6 @@
 				INFOPLIST_FILE = "$(SRCROOT)/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = __PROJECT_NAME__;
-				VALID_ARCHS = "armv7 arm64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
The `armv7 arm64` setting is invalid when building for simulator.
The reason for not detecting it until now is that it has been
overridden with a command line argument passed to `xcodebuild`
by {N} CLI.

Doing so however prevents users from specifying their own value
for ARCHS and VALID_ARCHS settings.

See https://github.com/NativeScript/nativescript-cli/issues/4197

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
`VALID_ARCHS` is set in the project template's `project.pbxproj`

## What is the new behavior?
`VALID_ARCHS` is deleted from the project template's `project.pbxproj`.
