### PR TITLE
fix(bridge): Catch ObjC Exceptions and throw them to JS

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -118,7 +118,7 @@ set(SOURCE_FILES
     Calling/FFICallPrototype.cpp
     Calling/CFunctionWrapper.mm
     Calling/FFIFunctionCallback.cpp
-    Calling/FunctionWrapper.cpp
+    Calling/FunctionWrapper.mm
     GlobalObject.mm
     GlobalObject.moduleLoader.mm
     inspector/CachedResource.mm

--- a/tests/TestRunner/app/Infrastructure/simulator.js
+++ b/tests/TestRunner/app/Infrastructure/simulator.js
@@ -1,0 +1,9 @@
+function isSimulator() {
+    if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 9, minorVersion: 0, patchVersion: 0})) {
+        return NSProcessInfo.processInfo.environment.objectForKey("SIMULATOR_DEVICE_NAME") !== null;
+    } else {
+        return UIDevice.currentDevice.name.toLowerCase().indexOf("simulator") > -1;
+    }
+}
+
+global.isSimulator = isSimulator();

--- a/tests/TestRunner/app/index.js
+++ b/tests/TestRunner/app/index.js
@@ -2,6 +2,7 @@
 console.log('Application Start!');
 
 import "./Infrastructure/timers";
+import "./Infrastructure/simulator";
 
 global.UNUSED = function (param) {
 };


### PR DESCRIPTION
* Wrap `ffi_call`s with @try-block
* Throw ObjC exception to JavaScript
(attaching the original native one as `nativeException` property)
* Update libffi with the latest master in an effort to get the
fix from https://github.com/libffi/libffi/issues/418

refs #1029

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Objective-C exceptions in calls made from JS crash the application.

## What is the new behavior?
Objective-C exceptions are intercepted by iOS Runtime and are thrown to JS, where they can be caught. If no catch handler is found they will be treated as unhandled JavaScript exceptions.

