### PR TITLE
fix(bridge): Discover protocol members when extending native class

### DIFF
--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -69,7 +69,7 @@ void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyNam
 
         if (methodMetas.size() == 0 && protocols && !protocols->empty()) {
             for (auto aProtocol : *protocols) {
-                if ((methodMetas = aProtocol->members(propertyName.publicName(), memberType)).size() == 0) {
+                if ((methodMetas = aProtocol->members(propertyName.publicName(), memberType)).size() > 0) {
                     break;
                 }
             }

--- a/tests/TestFixtures/TNSTestNativeCallbacks.h
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.h
@@ -38,6 +38,8 @@
 
 + (void)protocolImplementationMethods:(id<TNSBaseProtocol1, NSObject>)object;
 
++ (void)categoryProtocolImplementationMethods:(id<TNSBaseCategoryProtocol1, NSObject>)object;
+
 + (void)protocolImplementationProtocolInheritance:(id<TNSBaseProtocol2, NSObject>)object;
 
 + (void)protocolImplementationOptionalMethods:(id<TNSBaseProtocol2, NSObject>)object;

--- a/tests/TestFixtures/TNSTestNativeCallbacks.m
+++ b/tests/TestFixtures/TNSTestNativeCallbacks.m
@@ -205,6 +205,12 @@
     [object baseProtocolMethod1];
 }
 
++ (void)categoryProtocolImplementationMethods:(id<TNSBaseCategoryProtocol1, NSObject>)object {
+    NSAssert([object conformsToProtocol:@protocol(TNSBaseCategoryProtocol1)], NSStringFromSelector(_cmd));
+    NSAssert([[object class] conformsToProtocol:@protocol(TNSBaseCategoryProtocol1)], NSStringFromSelector(_cmd));
+    [object baseCategoryProtocolMethod1];
+}
+
 + (void)protocolImplementationProtocolInheritance:(id<TNSBaseProtocol2, NSObject>)object {
     NSAssert([object conformsToProtocol:@protocol(TNSBaseProtocol1)], NSStringFromSelector(_cmd));
     NSAssert([[object class] conformsToProtocol:@protocol(TNSBaseProtocol1)], NSStringFromSelector(_cmd));

--- a/tests/TestRunner/app/Inheritance/ProtocolImplementationTests.js
+++ b/tests/TestRunner/app/Inheritance/ProtocolImplementationTests.js
@@ -131,4 +131,35 @@ describe(module.id, function () {
             protocols: [TNSBaseProtocol1]
         });
     });
+
+    it('Two protocols', function () {
+        var object = NSObject.extend({
+            baseProtocolMethod1: function () {
+                TNSLog('baseProtocolMethod1 called');
+            },
+            baseCategoryProtocolMethod1: function () {
+                TNSLog('baseCategoryProtocolMethod1 called');
+            }
+        }, {
+            protocols: [TNSBaseProtocol1, TNSBaseCategoryProtocol1]
+        }).alloc().init();
+
+        var actual;
+        var expected =
+            'baseProtocolMethod1 called' +
+            'baseCategoryProtocolMethod1 called';
+
+        object.baseProtocolMethod1();
+        object.baseCategoryProtocolMethod1();
+
+        actual = TNSGetOutput();
+        expect(actual).toBe(expected);
+        TNSClearOutput();
+
+        TNSTestNativeCallbacks.protocolImplementationMethods(object);
+        TNSTestNativeCallbacks.categoryProtocolImplementationMethods(object);
+
+        actual = TNSGetOutput();
+        expect(actual).toBe(expected);
+    });
 });


### PR DESCRIPTION
The condition for stopping the protocols loop was wrong. Add a unit test to
ensure that protocol methods from two protocols are callable from JS and native.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
