### PR TITLE
feat(bridge): Provide automatic garbage collection triggering

### DIFF
--- a/src/NativeScript/Calling/CFunctionWrapper.h
+++ b/src/NativeScript/Calling/CFunctionWrapper.h
@@ -47,8 +47,8 @@ class CFunctionWrapper : public FunctionWrapper {
 public:
     typedef FunctionWrapper Base;
 
-    static CFunctionWrapper* create(JSC::VM& vm, JSC::Structure* structure, void* functionPointer, const WTF::String& name, JSC::JSCell* returnType, const WTF::Vector<JSC::JSCell*>& parameterTypes, bool retainsReturnedCocoaObjects) {
-        CFunctionWrapper* function = new (NotNull, JSC::allocateCell<CFunctionWrapper>(vm.heap)) CFunctionWrapper(vm, structure);
+    static JSC::Strong<CFunctionWrapper> create(JSC::VM& vm, JSC::Structure* structure, void* functionPointer, const WTF::String& name, JSC::JSCell* returnType, const WTF::Vector<JSC::Strong<JSC::JSCell>>& parameterTypes, bool retainsReturnedCocoaObjects) {
+        JSC::Strong<CFunctionWrapper> function(vm, new (NotNull, JSC::allocateCell<CFunctionWrapper>(vm.heap)) CFunctionWrapper(vm, structure));
         function->finishCreation(vm, functionPointer, name, returnType, parameterTypes, retainsReturnedCocoaObjects);
         return function;
     }
@@ -68,7 +68,7 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, void* functionPointer, const WTF::String& name, JSC::JSCell* returnType, const WTF::Vector<JSC::JSCell*>& parameterTypes, bool retainsReturnedCocoaObjects);
+    void finishCreation(JSC::VM&, void* functionPointer, const WTF::String& name, JSC::JSCell* returnType, const WTF::Vector<JSC::Strong<JSC::JSCell>>& parameterTypes, bool retainsReturnedCocoaObjects);
 
     static void destroy(JSC::JSCell* cell) {
         static_cast<CFunctionWrapper*>(cell)->~CFunctionWrapper();

--- a/src/NativeScript/Calling/CFunctionWrapper.mm
+++ b/src/NativeScript/Calling/CFunctionWrapper.mm
@@ -13,7 +13,7 @@ using namespace JSC;
 
 const ClassInfo CFunctionWrapper::s_info = { "CFunctionWrapper", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(CFunctionWrapper) };
 
-void CFunctionWrapper::finishCreation(VM& vm, void* functionPointer, const WTF::String& name, JSCell* returnType, const WTF::Vector<JSCell*>& parameterTypes, bool retainsReturnedCocoaObjects) {
+void CFunctionWrapper::finishCreation(VM& vm, void* functionPointer, const WTF::String& name, JSCell* returnType, const WTF::Vector<Strong<JSCell>>& parameterTypes, bool retainsReturnedCocoaObjects) {
     Base::finishCreation(vm, name);
     auto call = std::make_unique<CFunctionCall>(this, functionPointer, retainsReturnedCocoaObjects);
     call->initializeFFI(vm, { &preInvocation, &postInvocation }, returnType, parameterTypes);

--- a/src/NativeScript/Calling/FFICall.cpp
+++ b/src/NativeScript/Calling/FFICall.cpp
@@ -10,7 +10,6 @@
 #include "FFICache.h"
 #include "FunctionWrapper.h"
 #include <JavaScriptCore/JSPromiseDeferred.h>
-#include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/interpreter/FrameTracers.h>
 #include <JavaScriptCore/interpreter/Interpreter.h>
 #include <dispatch/dispatch.h>
@@ -23,7 +22,7 @@ void deleteCif(ffi_cif* cif) {
     delete cif;
 }
 
-void FFICall::initializeFFI(VM& vm, const InvocationHooks& hooks, JSCell* returnType, const Vector<JSCell*>& parameterTypes, size_t initialArgumentIndex) {
+void FFICall::initializeFFI(VM& vm, const InvocationHooks& hooks, JSCell* returnType, const Vector<Strong<JSCell>>& parameterTypes, size_t initialArgumentIndex) {
     this->_invocationHooks = hooks;
 
     this->_initialArgumentIndex = initialArgumentIndex;
@@ -43,7 +42,7 @@ void FFICall::initializeFFI(VM& vm, const InvocationHooks& hooks, JSCell* return
     }
 
     for (size_t i = 0; i < parametersCount; i++) {
-        JSCell* parameterTypeCell = parameterTypes[i];
+        JSCell* parameterTypeCell = parameterTypes[i].get();
         this->_parameterTypesCells.append(WriteBarrier<JSCell>(vm, owner, parameterTypeCell));
 
         const FFITypeMethodTable& ffiTypeMethodTable = getFFITypeMethodTable(vm, parameterTypeCell);

--- a/src/NativeScript/Calling/FFICall.h
+++ b/src/NativeScript/Calling/FFICall.h
@@ -160,7 +160,7 @@ public:
         }
     }
 
-    void initializeFFI(JSC::VM&, const InvocationHooks&, JSC::JSCell* returnType, const WTF::Vector<JSC::JSCell*>& parameterTypes, size_t initialArgumentIndex = 0);
+    void initializeFFI(JSC::VM&, const InvocationHooks&, JSC::JSCell* returnType, const WTF::Vector<Strong<JSC::JSCell>>& parameterTypes, size_t initialArgumentIndex = 0);
 
 protected:
     std::shared_ptr<ffi_cif> _cif;

--- a/src/NativeScript/Calling/FFICallPrototype.h
+++ b/src/NativeScript/Calling/FFICallPrototype.h
@@ -18,8 +18,8 @@ public:
 
     static const unsigned StructureFlags = Base::StructureFlags;
 
-    static FFICallPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        FFICallPrototype* prototype = new (NotNull, JSC::allocateCell<FFICallPrototype>(globalObject->vm().heap)) FFICallPrototype(globalObject->vm(), structure);
+    static JSC::Strong<FFICallPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<FFICallPrototype> prototype(vm, new (NotNull, JSC::allocateCell<FFICallPrototype>(globalObject->vm().heap)) FFICallPrototype(globalObject->vm(), structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/Calling/FFICallback.h
+++ b/src/NativeScript/Calling/FFICallback.h
@@ -50,7 +50,7 @@ protected:
         static_cast<FFICallback*>(cell)->~FFICallback();
     }
 
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSCell* function, JSC::JSCell* returnType, const WTF::Vector<JSC::JSCell*>& parameterTypes, size_t initialArgumentIndex = 0);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSCell* function, JSC::JSCell* returnType, const WTF::Vector<JSC::Strong<JSC::JSCell>>& parameterTypes, size_t initialArgumentIndex = 0);
 
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
 

--- a/src/NativeScript/Calling/FFICallbackInlines.h
+++ b/src/NativeScript/Calling/FFICallbackInlines.h
@@ -70,7 +70,7 @@ inline void FFICallback<DerivedCallback>::callFunction(const JSC::JSValue& thisV
 }
 
 template <class DerivedCallback>
-inline void FFICallback<DerivedCallback>::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSCell* function, JSC::JSCell* returnType, const WTF::Vector<JSC::JSCell*>& parameterTypes, size_t initialArgumentIndex) {
+inline void FFICallback<DerivedCallback>::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSCell* function, JSC::JSCell* returnType, const WTF::Vector<JSC::Strong<JSC::JSCell>>& parameterTypes, size_t initialArgumentIndex) {
     Base::finishCreation(vm);
 
     this->_globalExecState = globalObject->globalExec();
@@ -90,7 +90,7 @@ inline void FFICallback<DerivedCallback>::finishCreation(JSC::VM& vm, JSC::JSGlo
     }
 
     for (size_t i = 0; i < parametersCount; ++i) {
-        JSCell* parameterTypeCell = parameterTypes[i];
+        JSCell* parameterTypeCell = parameterTypes[i].get();
         this->_parameterTypesCells.append(JSC::WriteBarrier<JSCell>(vm, this, parameterTypeCell));
 
         const FFITypeMethodTable& ffiTypeMethodTable = getFFITypeMethodTable(vm, parameterTypeCell);

--- a/src/NativeScript/Calling/FFIFunctionCallback.cpp
+++ b/src/NativeScript/Calling/FFIFunctionCallback.cpp
@@ -32,6 +32,6 @@ void FFIFunctionCallback::ffiClosureCallback(void* retValue, void** argValues, v
 }
 
 void FFIFunctionCallback::finishCreation(VM& vm, JSGlobalObject* globalObject, JSCell* function, FunctionReferenceTypeInstance* functionReferenceType) {
-    Base::finishCreation(vm, globalObject, function, functionReferenceType->returnType(), functionReferenceType->parameterTypes());
+    Base::finishCreation(vm, globalObject, function, functionReferenceType->returnType(), functionReferenceType->parameterTypes(vm));
 }
 } // namespace NativeScript

--- a/src/NativeScript/Calling/FFIFunctionCallback.h
+++ b/src/NativeScript/Calling/FFIFunctionCallback.h
@@ -18,8 +18,8 @@ class FFIFunctionCallback : public FFICallback<FFIFunctionCallback> {
 public:
     typedef FFICallback Base;
 
-    static FFIFunctionCallback* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, FunctionReferenceTypeInstance* functionReferenceType) {
-        FFIFunctionCallback* cell = new (NotNull, JSC::allocateCell<FFIFunctionCallback>(vm.heap)) FFIFunctionCallback(vm, structure);
+    static JSC::Strong<FFIFunctionCallback> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, FunctionReferenceTypeInstance* functionReferenceType) {
+        JSC::Strong<FFIFunctionCallback> cell(vm, new (NotNull, JSC::allocateCell<FFIFunctionCallback>(vm.heap)) FFIFunctionCallback(vm, structure));
         cell->finishCreation(vm, globalObject, function, functionReferenceType);
         return cell;
     }

--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -32,8 +32,8 @@ public:
 
     static const unsigned StructureFlags;
 
-    static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, WTF::String applicationPath) {
-        GlobalObject* object = new (NotNull, JSC::allocateCell<GlobalObject>(vm.heap)) GlobalObject(vm, structure);
+    static JSC::Strong<GlobalObject> create(JSC::VM& vm, JSC::Structure* structure, WTF::String applicationPath) {
+        JSC::Strong<GlobalObject> object(vm, new (NotNull, JSC::allocateCell<GlobalObject>(vm.heap)) GlobalObject(vm, structure));
         object->finishCreation(vm, applicationPath);
         return object;
     }
@@ -98,9 +98,9 @@ public:
         return this->_interop.get();
     }
 
-    ObjCConstructorBase* constructorFor(Class klass, Class fallback = Nil);
+    JSC::Strong<ObjCConstructorBase> constructorFor(Class klass, Class fallback = Nil);
 
-    ObjCProtocolWrapper* protocolWrapperFor(Protocol* aProtocol);
+    JSC::Strong<ObjCProtocolWrapper> protocolWrapperFor(Protocol* aProtocol);
 
     JSC::Structure* weakRefConstructorStructure() const {
         return this->_weakRefConstructorStructure.get();

--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -29,8 +29,8 @@ class Interop : public JSC::JSObject {
 public:
     typedef JSC::JSObject Base;
 
-    static Interop* create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure) {
-        Interop* object = new (NotNull, JSC::allocateCell<Interop>(vm.heap)) Interop(vm, structure);
+    static JSC::Strong<Interop> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<Interop> object(vm, new (NotNull, JSC::allocateCell<Interop>(vm.heap)) Interop(vm, structure));
         object->finishCreation(vm, globalObject);
         return object;
     }

--- a/src/NativeScript/Marshalling/FFISimpleType.h
+++ b/src/NativeScript/Marshalling/FFISimpleType.h
@@ -16,8 +16,8 @@ class FFISimpleType : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static FFISimpleType* create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& name, const FFITypeMethodTable& methodTable) {
-        FFISimpleType* cell = new (NotNull, JSC::allocateCell<FFISimpleType>(vm.heap)) FFISimpleType(vm, structure);
+    static JSC::Strong<FFISimpleType> create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& name, const FFITypeMethodTable& methodTable) {
+        JSC::Strong<FFISimpleType> cell(vm, new (NotNull, JSC::allocateCell<FFISimpleType>(vm.heap)) FFISimpleType(vm, structure));
         cell->finishCreation(vm, name, methodTable);
         return cell;
     }

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.cpp
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.cpp
@@ -33,8 +33,8 @@ EncodedJSValue JSC_HOST_CALL FunctionReferenceConstructor::constructFunctionRefe
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     JSCell* func = execState->uncheckedArgument(0).asCell();
-    FunctionReferenceInstance* functionReference = FunctionReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->functionReferenceInstanceStructure(), func);
-    return JSValue::encode(functionReference);
+    auto functionReference = FunctionReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->functionReferenceInstanceStructure(), func);
+    return JSValue::encode(functionReference.get());
 }
 
 } // namespace NativeScript

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.h
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.h
@@ -14,8 +14,8 @@ class FunctionReferenceConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static FunctionReferenceConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue prototype) {
-        FunctionReferenceConstructor* cell = new (NotNull, JSC::allocateCell<FunctionReferenceConstructor>(vm.heap)) FunctionReferenceConstructor(vm, structure);
+    static JSC::Strong<FunctionReferenceConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue prototype) {
+        JSC::Strong<FunctionReferenceConstructor> cell(vm, new (NotNull, JSC::allocateCell<FunctionReferenceConstructor>(vm.heap)) FunctionReferenceConstructor(vm, structure));
         cell->finishCreation(vm, prototype);
         return cell;
     }

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceInstance.h
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceInstance.h
@@ -11,6 +11,7 @@
 
 #include "FFIFunctionCallback.h"
 #include "JavaScriptCore/IsoSubspace.h"
+#include <JavaScriptCore/JSObject.h>
 
 namespace NativeScript {
 
@@ -18,8 +19,8 @@ class FunctionReferenceInstance : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static FunctionReferenceInstance* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function) {
-        FunctionReferenceInstance* cell = new (NotNull, JSC::allocateCell<FunctionReferenceInstance>(vm.heap)) FunctionReferenceInstance(vm, structure);
+    static JSC::Strong<FunctionReferenceInstance> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function) {
+        JSC::Strong<FunctionReferenceInstance> cell(vm, new (NotNull, JSC::allocateCell<FunctionReferenceInstance>(vm.heap)) FunctionReferenceInstance(vm, structure));
         cell->finishCreation(vm, globalObject, function);
         return cell;
     }

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeConstructor.cpp
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeConstructor.cpp
@@ -37,16 +37,16 @@ EncodedJSValue JSC_HOST_CALL FunctionReferenceTypeConstructor::constructFunction
         return throwVMError(execState, scope, createError(execState, "Not a valid type object is passed as return type of function reference."_s));
     }
 
-    WTF::Vector<JSCell*> parametersTypes;
+    WTF::Vector<Strong<JSCell>> parametersTypes;
     for (size_t i = 1; i < execState->argumentCount(); i++) {
         JSValue currentParameter = execState->uncheckedArgument(i);
         if (!tryGetFFITypeMethodTable(vm, currentParameter, &methodTable)) {
             return throwVMError(execState, scope, createError(execState, "Not a valid type object is passed as parameter of function reference."_s));
         }
-        parametersTypes.append(currentParameter.asCell());
+        parametersTypes.append(Strong<JSCell>(vm, currentParameter.asCell()));
     }
 
-    return JSValue::encode(globalObject->typeFactory()->getFunctionReferenceTypeInstance(globalObject, returnType.asCell(), parametersTypes));
+    return JSValue::encode(globalObject->typeFactory()->getFunctionReferenceTypeInstance(globalObject, returnType.asCell(), parametersTypes).get());
 }
 
 } // namespace NativeScript

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeConstructor.h
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeConstructor.h
@@ -15,8 +15,8 @@ class FunctionReferenceTypeConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static FunctionReferenceTypeConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSObject* functionReferenceTypePrototype) {
-        FunctionReferenceTypeConstructor* constructor = new (NotNull, JSC::allocateCell<FunctionReferenceTypeConstructor>(vm.heap)) FunctionReferenceTypeConstructor(vm, structure);
+    static JSC::Strong<FunctionReferenceTypeConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSObject* functionReferenceTypePrototype) {
+        JSC::Strong<FunctionReferenceTypeConstructor> constructor(vm, new (NotNull, JSC::allocateCell<FunctionReferenceTypeConstructor>(vm.heap)) FunctionReferenceTypeConstructor(vm, structure));
         constructor->finishCreation(vm, functionReferenceTypePrototype);
         return constructor;
     }

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeInstance.h
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeInstance.h
@@ -16,8 +16,8 @@ class FunctionReferenceTypeInstance : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static FunctionReferenceTypeInstance* create(JSC::VM& vm, JSC::Structure* structure, JSCell* returnType, const WTF::Vector<JSCell*>& parameterTypes) {
-        FunctionReferenceTypeInstance* cell = new (NotNull, JSC::allocateCell<FunctionReferenceTypeInstance>(vm.heap)) FunctionReferenceTypeInstance(vm, structure);
+    static JSC::Strong<FunctionReferenceTypeInstance> create(JSC::VM& vm, JSC::Structure* structure, JSCell* returnType, const WTF::Vector<JSC::Strong<JSCell>>& parameterTypes) {
+        JSC::Strong<FunctionReferenceTypeInstance> cell(vm, new (NotNull, JSC::allocateCell<FunctionReferenceTypeInstance>(vm.heap)) FunctionReferenceTypeInstance(vm, structure));
         cell->finishCreation(vm, returnType, parameterTypes);
         return cell;
     }
@@ -36,10 +36,10 @@ public:
         return this->_returnType.get();
     }
 
-    const WTF::Vector<JSC::JSCell*> parameterTypes() const {
-        WTF::Vector<JSC::JSCell*> result(this->_parameterTypes.size());
+    const WTF::Vector<JSC::Strong<JSC::JSCell>> parameterTypes(JSC::VM& vm) const {
+        WTF::Vector<JSC::Strong<JSC::JSCell>> result(this->_parameterTypes.size());
         for (size_t i = 0; i < this->_parameterTypes.size(); ++i) {
-            result[i] = this->_parameterTypes[i].get();
+            result[i] = JSC::Strong<JSC::JSCell>(vm, this->_parameterTypes[i].get());
         }
         return result;
     }
@@ -53,7 +53,7 @@ private:
         static_cast<FunctionReferenceTypeInstance*>(cell)->~FunctionReferenceTypeInstance();
     }
 
-    void finishCreation(JSC::VM&, JSCell* returnType, const WTF::Vector<JSCell*>& parameterTypes);
+    void finishCreation(JSC::VM&, JSCell* returnType, const WTF::Vector<JSC::Strong<JSCell>>& parameterTypes);
 
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
 

--- a/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
+++ b/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
@@ -128,7 +128,7 @@ static JSValue cStringType_read(ExecState* execState, const void* buffer, JSCell
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     JSCell* type = globalObject->typeFactory()->int8Type();
     PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<char*>(string)));
-    return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), type, pointer);
+    return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), type, pointer).get();
 }
 static void cStringType_write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {
     if (value.isUndefinedOrNull()) {

--- a/src/NativeScript/Marshalling/Pointer/PointerConstructor.h
+++ b/src/NativeScript/Marshalling/Pointer/PointerConstructor.h
@@ -22,8 +22,8 @@ public:
 
     static JSC::EncodedJSValue JSC_HOST_CALL constructPointerInstance(JSC::ExecState* execState);
 
-    static PointerConstructor* create(JSC::VM& vm, JSC::Structure* structure, PointerPrototype* pointerPrototype) {
-        PointerConstructor* constructor = new (NotNull, JSC::allocateCell<PointerConstructor>(vm.heap)) PointerConstructor(vm, structure);
+    static JSC::Strong<PointerConstructor> create(JSC::VM& vm, JSC::Structure* structure, PointerPrototype* pointerPrototype) {
+        JSC::Strong<PointerConstructor> constructor(vm, new (NotNull, JSC::allocateCell<PointerConstructor>(vm.heap)) PointerConstructor(vm, structure));
         constructor->finishCreation(vm, pointerPrototype);
         return constructor;
     }

--- a/src/NativeScript/Marshalling/Pointer/PointerInstance.h
+++ b/src/NativeScript/Marshalling/Pointer/PointerInstance.h
@@ -22,9 +22,9 @@ public:
 
     DECLARE_INFO;
 
-    static PointerInstance* create(JSC::ExecState* execState, JSC::Structure* structure, void* value = nullptr) {
+    static JSC::Strong<PointerInstance> create(JSC::ExecState* execState, JSC::Structure* structure, void* value = nullptr) {
         JSC::VM& vm = execState->vm();
-        PointerInstance* object = new (NotNull, JSC::allocateCell<PointerInstance>(vm.heap)) PointerInstance(vm, structure);
+        JSC::Strong<PointerInstance> object(vm, new (NotNull, JSC::allocateCell<PointerInstance>(vm.heap)) PointerInstance(vm, structure));
         object->finishCreation(execState, value);
         return object;
     }

--- a/src/NativeScript/Marshalling/Pointer/PointerPrototype.h
+++ b/src/NativeScript/Marshalling/Pointer/PointerPrototype.h
@@ -14,8 +14,8 @@ class PointerPrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static PointerPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        PointerPrototype* prototype = new (NotNull, JSC::allocateCell<PointerPrototype>(vm.heap)) PointerPrototype(vm, structure);
+    static JSC::Strong<PointerPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<PointerPrototype> prototype(vm, new (NotNull, JSC::allocateCell<PointerPrototype>(vm.heap)) PointerPrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/Marshalling/Record/RecordConstructor.h
+++ b/src/NativeScript/Marshalling/Record/RecordConstructor.h
@@ -20,8 +20,8 @@ class RecordConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static RecordConstructor* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, RecordPrototype* recordPrototype, const WTF::String& name, ffi_type* ffiType, RecordType recordType) {
-        RecordConstructor* cell = new (NotNull, JSC::allocateCell<RecordConstructor>(vm.heap)) RecordConstructor(vm, structure);
+    static JSC::Strong<RecordConstructor> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, RecordPrototype* recordPrototype, const WTF::String& name, ffi_type* ffiType, RecordType recordType) {
+        JSC::Strong<RecordConstructor> cell(vm, new (NotNull, JSC::allocateCell<RecordConstructor>(vm.heap)) RecordConstructor(vm, structure));
         cell->finishCreation(vm, globalObject, recordPrototype, name, ffiType, recordType);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Record/RecordField.h
+++ b/src/NativeScript/Marshalling/Record/RecordField.h
@@ -17,8 +17,8 @@ class RecordField : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static RecordField* create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& fieldName, JSCell* fieldType, ptrdiff_t offset) {
-        RecordField* cell = new (NotNull, JSC::allocateCell<RecordField>(vm.heap)) RecordField(vm, structure);
+    static JSC::Strong<RecordField> create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& fieldName, JSCell* fieldType, ptrdiff_t offset) {
+        JSC::Strong<RecordField> cell(vm, new (NotNull, JSC::allocateCell<RecordField>(vm.heap)) RecordField(vm, structure));
         cell->finishCreation(vm, fieldName, fieldType, offset);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Record/RecordInstance.h
+++ b/src/NativeScript/Marshalling/Record/RecordInstance.h
@@ -17,8 +17,8 @@ class RecordInstance : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static RecordInstance* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, size_t size, PointerInstance* pointer) {
-        RecordInstance* cell = new (NotNull, JSC::allocateCell<RecordInstance>(vm.heap)) RecordInstance(vm, structure);
+    static JSC::Strong<RecordInstance> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, size_t size, PointerInstance* pointer) {
+        JSC::Strong<RecordInstance> cell(vm, new (NotNull, JSC::allocateCell<RecordInstance>(vm.heap)) RecordInstance(vm, structure));
         cell->finishCreation(globalObject->globalExec(), globalObject, size, pointer);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Record/RecordPrototype.h
+++ b/src/NativeScript/Marshalling/Record/RecordPrototype.h
@@ -20,8 +20,8 @@ class RecordPrototype : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static RecordPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        RecordPrototype* cell = new (NotNull, JSC::allocateCell<RecordPrototype>(vm.heap)) RecordPrototype(vm, structure);
+    static JSC::Strong<RecordPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<RecordPrototype> cell(vm, new (NotNull, JSC::allocateCell<RecordPrototype>(vm.heap)) RecordPrototype(vm, structure));
         cell->finishCreation(vm, globalObject);
         return cell;
     }
@@ -32,15 +32,11 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    const WTF::Vector<RecordField*> fields() const {
-        WTF::Vector<RecordField*> result(this->_fields.size());
-        for (size_t i = 0; i < this->_fields.size(); ++i) {
-            result[i] = this->_fields[i].get();
-        }
-        return result;
+    const WTF::Vector<JSC::WriteBarrier<RecordField>> fields() const {
+        return this->_fields;
     }
 
-    void setFields(JSC::VM&, GlobalObject*, const WTF::Vector<RecordField*>&);
+    void setFields(JSC::VM&, GlobalObject*, const WTF::Vector<JSC::Strong<RecordField>>&);
 
 private:
     RecordPrototype(JSC::VM& vm, JSC::Structure* structure)

--- a/src/NativeScript/Marshalling/Record/RecordPrototypeFunctions.h
+++ b/src/NativeScript/Marshalling/Record/RecordPrototypeFunctions.h
@@ -18,8 +18,8 @@ class RecordProtoFieldGetter : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static RecordProtoFieldGetter* create(JSC::VM& vm, JSC::Structure* structure, RecordField* recordField) {
-        RecordProtoFieldGetter* cell = new (NotNull, JSC::allocateCell<RecordProtoFieldGetter>(vm.heap)) RecordProtoFieldGetter(vm, structure);
+    static JSC::Strong<RecordProtoFieldGetter> create(JSC::VM& vm, JSC::Structure* structure, RecordField* recordField) {
+        JSC::Strong<RecordProtoFieldGetter> cell(vm, new (NotNull, JSC::allocateCell<RecordProtoFieldGetter>(vm.heap)) RecordProtoFieldGetter(vm, structure));
         cell->finishCreation(vm, recordField);
         return cell;
     }
@@ -61,8 +61,8 @@ class RecordProtoFieldSetter : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static RecordProtoFieldSetter* create(JSC::VM& vm, JSC::Structure* structure, RecordField* recordField) {
-        RecordProtoFieldSetter* cell = new (NotNull, JSC::allocateCell<RecordProtoFieldSetter>(vm.heap)) RecordProtoFieldSetter(vm, structure);
+    static JSC::Strong<RecordProtoFieldSetter> create(JSC::VM& vm, JSC::Structure* structure, RecordField* recordField) {
+        JSC::Strong<RecordProtoFieldSetter> cell(vm, new (NotNull, JSC::allocateCell<RecordProtoFieldSetter>(vm.heap)) RecordProtoFieldSetter(vm, structure));
         cell->finishCreation(vm, recordField);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
@@ -37,7 +37,7 @@ JSValue ExtVectorTypeInstance::read(ExecState* execState, const void* buffer, JS
 
     PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
     pointer->setAdopted(true);
-    return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->extVectorInstanceStructure(), referenceType->innerType(), pointer);
+    return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->extVectorInstanceStructure(), referenceType->innerType(), pointer).get();
 }
 
 void ExtVectorTypeInstance::write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.h
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.h
@@ -14,8 +14,8 @@ class ExtVectorTypeInstance : public JSDestructibleObject {
 public:
     typedef JSDestructibleObject Base;
 
-    static ExtVectorTypeInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType, size_t size, bool isStructMember) {
-        ExtVectorTypeInstance* cell = new (NotNull, JSC::allocateCell<ExtVectorTypeInstance>(vm.heap)) ExtVectorTypeInstance(vm, structure, size);
+    static JSC::Strong<ExtVectorTypeInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType, size_t size, bool isStructMember) {
+        JSC::Strong<ExtVectorTypeInstance> cell(vm, new (NotNull, JSC::allocateCell<ExtVectorTypeInstance>(vm.heap)) ExtVectorTypeInstance(vm, structure, size));
         cell->finishCreation(vm, innerType, isStructMember);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Reference/IndexedRefInstance.h
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefInstance.h
@@ -20,14 +20,14 @@ public:
 
     DECLARE_INFO;
 
-    static IndexedRefInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue value = JSC::jsUndefined()) {
-        IndexedRefInstance* cell = new (NotNull, JSC::allocateCell<IndexedRefInstance>(vm.heap)) IndexedRefInstance(vm, structure);
+    static JSC::Strong<IndexedRefInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue value = JSC::jsUndefined()) {
+        JSC::Strong<IndexedRefInstance> cell(vm, new (NotNull, JSC::allocateCell<IndexedRefInstance>(vm.heap)) IndexedRefInstance(vm, structure));
         cell->finishCreation(vm, value);
         return cell;
     }
 
-    static IndexedRefInstance* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* innerType, PointerInstance* pointer) {
-        IndexedRefInstance* object = new (NotNull, JSC::allocateCell<IndexedRefInstance>(vm.heap)) IndexedRefInstance(vm, structure);
+    static JSC::Strong<IndexedRefInstance> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* innerType, PointerInstance* pointer) {
+        JSC::Strong<IndexedRefInstance> object(vm, new (NotNull, JSC::allocateCell<IndexedRefInstance>(vm.heap)) IndexedRefInstance(vm, structure));
         object->finishCreation(vm, globalObject, innerType, pointer);
         return object;
     }

--- a/src/NativeScript/Marshalling/Reference/IndexedRefPrototype.h
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefPrototype.h
@@ -13,8 +13,8 @@ class IndexedRefPrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static IndexedRefPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        IndexedRefPrototype* prototype = new (NotNull, JSC::allocateCell<IndexedRefPrototype>(vm.heap)) IndexedRefPrototype(vm, structure);
+    static JSC::Strong<IndexedRefPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<IndexedRefPrototype> prototype(vm, new (NotNull, JSC::allocateCell<IndexedRefPrototype>(vm.heap)) IndexedRefPrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
@@ -31,7 +31,7 @@ JSValue IndexedRefTypeInstance::read(ExecState* execState, const void* buffer, J
     IndexedRefTypeInstance* referenceType = jsCast<IndexedRefTypeInstance*>(self);
 
     PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
-    return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->indexedRefInstanceStructure(), referenceType->innerType(), pointer);
+    return IndexedRefInstance::create(execState->vm(), globalObject, globalObject->interop()->indexedRefInstanceStructure(), referenceType->innerType(), pointer).get();
 }
 
 void IndexedRefTypeInstance::write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.h
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.h
@@ -14,8 +14,8 @@ class IndexedRefTypeInstance : public JSDestructibleObject {
 public:
     typedef JSDestructibleObject Base;
 
-    static IndexedRefTypeInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType, size_t size) {
-        IndexedRefTypeInstance* cell = new (NotNull, JSC::allocateCell<IndexedRefTypeInstance>(vm.heap)) IndexedRefTypeInstance(vm, structure, size);
+    static JSC::Strong<IndexedRefTypeInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType, size_t size) {
+        JSC::Strong<IndexedRefTypeInstance> cell(vm, new (NotNull, JSC::allocateCell<IndexedRefTypeInstance>(vm.heap)) IndexedRefTypeInstance(vm, structure, size));
         cell->finishCreation(vm, innerType);
         return cell;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferenceConstructor.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceConstructor.cpp
@@ -27,7 +27,7 @@ void ReferenceConstructor::finishCreation(VM& vm, ReferencePrototype* referenceP
 
 EncodedJSValue JSC_HOST_CALL ReferenceConstructor::constructReference(ExecState* execState) {
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    ReferenceInstance* result;
+    Strong<ReferenceInstance> result;
 
     JSValue maybeType = execState->argument(0);
     JSC::VM& vm = execState->vm();
@@ -74,7 +74,7 @@ EncodedJSValue JSC_HOST_CALL ReferenceConstructor::constructReference(ExecState*
         result = ReferenceInstance::create(vm, globalObject->interop()->referenceInstanceStructure(), maybeType);
     }
 
-    return JSValue::encode(result);
+    return JSValue::encode(result.get());
 }
 
 } // namespace NativeScript

--- a/src/NativeScript/Marshalling/Reference/ReferenceConstructor.h
+++ b/src/NativeScript/Marshalling/Reference/ReferenceConstructor.h
@@ -16,8 +16,8 @@ class ReferenceConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static ReferenceConstructor* create(JSC::VM& vm, JSC::Structure* structure, ReferencePrototype* referencePrototype) {
-        ReferenceConstructor* constructor = new (NotNull, JSC::allocateCell<ReferenceConstructor>(vm.heap)) ReferenceConstructor(vm, structure);
+    static JSC::Strong<ReferenceConstructor> create(JSC::VM& vm, JSC::Structure* structure, ReferencePrototype* referencePrototype) {
+        JSC::Strong<ReferenceConstructor> constructor(vm, new (NotNull, JSC::allocateCell<ReferenceConstructor>(vm.heap)) ReferenceConstructor(vm, structure));
         constructor->finishCreation(vm, referencePrototype);
         return constructor;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferenceInstance.h
+++ b/src/NativeScript/Marshalling/Reference/ReferenceInstance.h
@@ -21,14 +21,14 @@ public:
 
     DECLARE_INFO;
 
-    static ReferenceInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue value = JSC::jsUndefined()) {
-        ReferenceInstance* cell = new (NotNull, JSC::allocateCell<ReferenceInstance>(vm.heap)) ReferenceInstance(vm, structure);
+    static JSC::Strong<ReferenceInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue value = JSC::jsUndefined()) {
+        JSC::Strong<ReferenceInstance> cell(vm, new (NotNull, JSC::allocateCell<ReferenceInstance>(vm.heap)) ReferenceInstance(vm, structure));
         cell->finishCreation(vm, value);
         return cell;
     }
 
-    static ReferenceInstance* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* innerType, PointerInstance* pointer) {
-        ReferenceInstance* object = new (NotNull, JSC::allocateCell<ReferenceInstance>(vm.heap)) ReferenceInstance(vm, structure);
+    static JSC::Strong<ReferenceInstance> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* innerType, PointerInstance* pointer) {
+        JSC::Strong<ReferenceInstance> object(vm, new (NotNull, JSC::allocateCell<ReferenceInstance>(vm.heap)) ReferenceInstance(vm, structure));
         object->finishCreation(vm, globalObject, innerType, pointer);
         return object;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferencePrototype.h
+++ b/src/NativeScript/Marshalling/Reference/ReferencePrototype.h
@@ -14,8 +14,8 @@ class ReferencePrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static ReferencePrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        ReferencePrototype* prototype = new (NotNull, JSC::allocateCell<ReferencePrototype>(vm.heap)) ReferencePrototype(vm, structure);
+    static JSC::Strong<ReferencePrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<ReferencePrototype> prototype(vm, new (NotNull, JSC::allocateCell<ReferencePrototype>(vm.heap)) ReferencePrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeConstructor.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeConstructor.cpp
@@ -39,7 +39,7 @@ EncodedJSValue JSC_HOST_CALL ReferenceTypeConstructor::constructReferenceType(Ex
         return throwVMError(execState, scope, createError(execState, "Not a valid type object is passed as parameter."_s));
     }
 
-    return JSValue::encode(globalObject->typeFactory()->getReferenceType(globalObject, type.asCell()));
+    return JSValue::encode(globalObject->typeFactory()->getReferenceType(globalObject, type.asCell()).get());
 }
 
 } // namespace NativeScript

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeConstructor.h
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeConstructor.h
@@ -15,8 +15,8 @@ class ReferenceTypeConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static ReferenceTypeConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSObject* referenceTypePrototype) {
-        ReferenceTypeConstructor* constructor = new (NotNull, JSC::allocateCell<ReferenceTypeConstructor>(vm.heap)) ReferenceTypeConstructor(vm, structure);
+    static JSC::Strong<ReferenceTypeConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSObject* referenceTypePrototype) {
+        JSC::Strong<ReferenceTypeConstructor> constructor(vm, new (NotNull, JSC::allocateCell<ReferenceTypeConstructor>(vm.heap)) ReferenceTypeConstructor(vm, structure));
         constructor->finishCreation(vm, referenceTypePrototype);
         return constructor;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
@@ -26,7 +26,7 @@ JSValue ReferenceTypeInstance::read(ExecState* execState, const void* buffer, JS
     ReferenceTypeInstance* referenceType = jsCast<ReferenceTypeInstance*>(self);
 
     PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, const_cast<void*>(data)));
-    return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), referenceType->innerType(), pointer);
+    return ReferenceInstance::create(execState->vm(), globalObject, globalObject->interop()->referenceInstanceStructure(), referenceType->innerType(), pointer).get();
 }
 
 void ReferenceTypeInstance::write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.h
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.h
@@ -10,6 +10,7 @@
 #define __NativeScript__ReferenceTypeInstance__
 
 #include "FFIType.h"
+#include <JavaScriptCore/JSObject.h>
 #include <string>
 
 namespace NativeScript {
@@ -17,8 +18,8 @@ class ReferenceTypeInstance : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static ReferenceTypeInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType) {
-        ReferenceTypeInstance* cell = new (NotNull, JSC::allocateCell<ReferenceTypeInstance>(vm.heap)) ReferenceTypeInstance(vm, structure);
+    static JSC::Strong<ReferenceTypeInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* innerType) {
+        JSC::Strong<ReferenceTypeInstance> cell(vm, new (NotNull, JSC::allocateCell<ReferenceTypeInstance>(vm.heap)) ReferenceTypeInstance(vm, structure));
         cell->finishCreation(vm, innerType);
         return cell;
     }

--- a/src/NativeScript/NativeScript-Prefix.h
+++ b/src/NativeScript/NativeScript-Prefix.h
@@ -14,6 +14,7 @@
 #include <JavaScriptCore/config.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/Error.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include "RecordType.h"
 #include "GlobalObject.h"
 #include "JSWarnings.h"

--- a/src/NativeScript/ObjC/AllocatedPlaceholder.h
+++ b/src/NativeScript/ObjC/AllocatedPlaceholder.h
@@ -14,8 +14,8 @@ class AllocatedPlaceholder : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static AllocatedPlaceholder* create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, id wrappedObject, JSC::Structure* instanceStructure) {
-        AllocatedPlaceholder* object = new (NotNull, JSC::allocateCell<AllocatedPlaceholder>(vm.heap)) AllocatedPlaceholder(vm, structure);
+    static JSC::Strong<AllocatedPlaceholder> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, id wrappedObject, JSC::Structure* instanceStructure) {
+        JSC::Strong<AllocatedPlaceholder> object(vm, new (NotNull, JSC::allocateCell<AllocatedPlaceholder>(vm.heap)) AllocatedPlaceholder(vm, structure));
         object->finishCreation(vm, globalObject, wrappedObject, instanceStructure);
         return object;
     }

--- a/src/NativeScript/ObjC/Block/ObjCBlockCall.h
+++ b/src/NativeScript/ObjC/Block/ObjCBlockCall.h
@@ -24,8 +24,8 @@ class ObjCBlockWrapper : public FunctionWrapper {
 public:
     typedef FunctionWrapper Base;
 
-    static ObjCBlockWrapper* create(JSC::VM& vm, JSC::Structure* structure, id block, ObjCBlockType* blockType) {
-        ObjCBlockWrapper* cell = new (NotNull, JSC::allocateCell<ObjCBlockWrapper>(vm.heap)) ObjCBlockWrapper(vm, structure);
+    static JSC::Strong<ObjCBlockWrapper> create(JSC::VM& vm, JSC::Structure* structure, id block, ObjCBlockType* blockType) {
+        JSC::Strong<ObjCBlockWrapper> cell(vm, new (NotNull, JSC::allocateCell<ObjCBlockWrapper>(vm.heap)) ObjCBlockWrapper(vm, structure));
         cell->finishCreation(vm, block, blockType);
         return cell;
     }

--- a/src/NativeScript/ObjC/Block/ObjCBlockCall.mm
+++ b/src/NativeScript/ObjC/Block/ObjCBlockCall.mm
@@ -24,7 +24,7 @@ const ClassInfo ObjCBlockWrapper::s_info = { "ObjCBlockWrapper", &Base::s_info, 
 void ObjCBlockWrapper::finishCreation(VM& vm, id block, ObjCBlockType* blockType) {
     Base::finishCreation(vm, WTF::emptyString());
 
-    const WTF::Vector<JSCell*> parameterTypes = blockType->parameterTypes();
+    auto parameterTypes = blockType->parameterTypes(vm);
     Base::initializeFunctionWrapper(vm, parameterTypes.size());
     std::unique_ptr<ObjCBlockCall> call(new ObjCBlockCall(this));
     call->initializeFFI(vm, { &preInvocation, nullptr }, blockType->returnType(), parameterTypes, 1);

--- a/src/NativeScript/ObjC/Block/ObjCBlockCallback.cpp
+++ b/src/NativeScript/ObjC/Block/ObjCBlockCallback.cpp
@@ -32,6 +32,6 @@ void ObjCBlockCallback::ffiClosureCallback(void* retValue, void** argValues, voi
 }
 
 void ObjCBlockCallback::finishCreation(VM& vm, JSGlobalObject* globalObject, JSCell* function, ObjCBlockType* blockType) {
-    Base::finishCreation(vm, globalObject, function, blockType->returnType(), blockType->parameterTypes(), 1);
+    Base::finishCreation(vm, globalObject, function, blockType->returnType(), blockType->parameterTypes(vm), 1);
 }
 } // namespace NativeScript

--- a/src/NativeScript/ObjC/Block/ObjCBlockCallback.h
+++ b/src/NativeScript/ObjC/Block/ObjCBlockCallback.h
@@ -18,8 +18,8 @@ class ObjCBlockCallback : public FFICallback<ObjCBlockCallback> {
 public:
     typedef FFICallback Base;
 
-    static ObjCBlockCallback* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, ObjCBlockType* blockType) {
-        ObjCBlockCallback* cell = new (NotNull, JSC::allocateCell<ObjCBlockCallback>(vm.heap)) ObjCBlockCallback(vm, structure);
+    static JSC::Strong<ObjCBlockCallback> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, ObjCBlockType* blockType) {
+        JSC::Strong<ObjCBlockCallback> cell(vm, new (NotNull, JSC::allocateCell<ObjCBlockCallback>(vm.heap)) ObjCBlockCallback(vm, structure));
         cell->finishCreation(vm, globalObject, function, blockType);
         return cell;
     }

--- a/src/NativeScript/ObjC/Block/ObjCBlockType.h
+++ b/src/NativeScript/ObjC/Block/ObjCBlockType.h
@@ -16,8 +16,8 @@ class ObjCBlockType : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static ObjCBlockType* create(JSC::VM& vm, JSC::Structure* structure, JSCell* returnType, const WTF::Vector<JSCell*>& parameterTypes) {
-        ObjCBlockType* cell = new (NotNull, JSC::allocateCell<ObjCBlockType>(vm.heap)) ObjCBlockType(vm, structure);
+    static JSC::Strong<ObjCBlockType> create(JSC::VM& vm, JSC::Structure* structure, JSCell* returnType, const WTF::Vector<JSC::Strong<JSCell>>& parameterTypes) {
+        JSC::Strong<ObjCBlockType> cell(vm, new (NotNull, JSC::allocateCell<ObjCBlockType>(vm.heap)) ObjCBlockType(vm, structure));
         cell->finishCreation(vm, returnType, parameterTypes);
         return cell;
     }
@@ -36,10 +36,10 @@ public:
         return this->_returnType.get();
     }
 
-    const WTF::Vector<JSC::JSCell*> parameterTypes() const {
-        WTF::Vector<JSC::JSCell*> result(this->_parameterTypes.size());
+    const WTF::Vector<JSC::Strong<JSC::JSCell>> parameterTypes(JSC::VM& vm) const {
+        WTF::Vector<JSC::Strong<JSC::JSCell>> result(this->_parameterTypes.size());
         for (size_t i = 0; i < this->_parameterTypes.size(); ++i) {
-            result[i] = this->_parameterTypes[i].get();
+            result[i] = JSC::Strong<JSC::JSCell>(vm, this->_parameterTypes[i].get());
         }
         return result;
     }
@@ -53,7 +53,7 @@ private:
         static_cast<ObjCBlockType*>(cell)->~ObjCBlockType();
     }
 
-    void finishCreation(JSC::VM&, JSCell* returnType, const WTF::Vector<JSCell*>& parameterTypes);
+    void finishCreation(JSC::VM&, JSCell* returnType, const WTF::Vector<JSC::Strong<JSCell>>& parameterTypes);
 
     static void visitChildren(JSC::JSCell*, JSC::SlotVisitor&);
 

--- a/src/NativeScript/ObjC/Block/ObjCBlockTypeConstructor.cpp
+++ b/src/NativeScript/ObjC/Block/ObjCBlockTypeConstructor.cpp
@@ -38,16 +38,16 @@ EncodedJSValue JSC_HOST_CALL ObjCBlockTypeConstructor::constructObjCBlockTypeCon
         return throwVMError(execState, scope, createError(execState, "Not a valid type object is passed as return type of block type."_s));
     }
 
-    WTF::Vector<JSCell*> parametersTypes;
+    WTF::Vector<Strong<JSCell>> parametersTypes;
     for (size_t i = 1; i < execState->argumentCount(); i++) {
         JSValue currentParameter = execState->uncheckedArgument(i);
         if (!tryGetFFITypeMethodTable(vm, currentParameter, &methodTable)) {
             return throwVMError(execState, scope, createError(execState, "Not a valid type object is passed as parameter of block type."_s));
         }
-        parametersTypes.append(currentParameter.asCell());
+        parametersTypes.append(Strong<JSCell>(vm, currentParameter.asCell()));
     }
 
-    return JSValue::encode(globalObject->typeFactory()->getObjCBlockType(globalObject, returnType.asCell(), parametersTypes));
+    return JSValue::encode(globalObject->typeFactory()->getObjCBlockType(globalObject, returnType.asCell(), parametersTypes).get());
 }
 
 } // namespace NativeScript

--- a/src/NativeScript/ObjC/Block/ObjCBlockTypeConstructor.h
+++ b/src/NativeScript/ObjC/Block/ObjCBlockTypeConstructor.h
@@ -15,8 +15,8 @@ class ObjCBlockTypeConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static ObjCBlockTypeConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSObject* objCBlockTypePrototype) {
-        ObjCBlockTypeConstructor* constructor = new (NotNull, JSC::allocateCell<ObjCBlockTypeConstructor>(vm.heap)) ObjCBlockTypeConstructor(vm, structure);
+    static JSC::Strong<ObjCBlockTypeConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSObject* objCBlockTypePrototype) {
+        JSC::Strong<ObjCBlockTypeConstructor> constructor(vm, new (NotNull, JSC::allocateCell<ObjCBlockTypeConstructor>(vm.heap)) ObjCBlockTypeConstructor(vm, structure));
         constructor->finishCreation(vm, objCBlockTypePrototype);
         return constructor;
     }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.h
@@ -22,8 +22,8 @@ class ObjCConstructorWrapper : public FunctionWrapper {
 public:
     typedef FunctionWrapper Base;
 
-    static ObjCConstructorWrapper* create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, Class klass, const Metadata::MethodMeta* metadata) {
-        ObjCConstructorWrapper* constructor = new (NotNull, JSC::allocateCell<ObjCConstructorWrapper>(vm.heap)) ObjCConstructorWrapper(vm, structure);
+    static JSC::Strong<ObjCConstructorWrapper> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, Class klass, const Metadata::MethodMeta* metadata) {
+        JSC::Strong<ObjCConstructorWrapper> constructor(vm, new (NotNull, JSC::allocateCell<ObjCConstructorWrapper>(vm.heap)) ObjCConstructorWrapper(vm, structure));
         constructor->finishCreation(vm, globalObject, klass, metadata);
         return constructor;
     }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorCall.mm
@@ -23,11 +23,11 @@ void ObjCConstructorWrapper::finishCreation(VM& vm, GlobalObject* globalObject, 
 
     const Metadata::TypeEncoding* encodings = metadata->encodings()->first();
 
-    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, encodings, false);
-    const WTF::Vector<JSCell*> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1, false);
+    Strong<JSCell> returnType = globalObject->typeFactory()->parseType(globalObject, encodings, false);
+    const WTF::Vector<Strong<JSCell>> parametersTypes = globalObject->typeFactory()->parseTypes(globalObject, encodings, metadata->encodings()->count - 1, false);
 
     std::unique_ptr<ObjCConstructorCall> call(new ObjCConstructorCall(this));
-    call->initializeFFI(vm, { &preInvocation, &postInvocation }, returnType, parametersTypes, 2);
+    call->initializeFFI(vm, { &preInvocation, &postInvocation }, returnType.get(), parametersTypes, 2);
     call->_klass = klass;
 
     Base::initializeFunctionWrapper(vm, parametersTypes.size());

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorDerived.h
@@ -17,8 +17,8 @@ class ObjCConstructorDerived : public ObjCConstructorBase {
 public:
     typedef ObjCConstructorBase Base;
 
-    static ObjCConstructorDerived* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
-        ObjCConstructorDerived* cell = new (NotNull, JSC::allocateCell<ObjCConstructorDerived>(vm.heap)) ObjCConstructorDerived(vm, structure);
+    static JSC::Strong<ObjCConstructorDerived> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
+        JSC::Strong<ObjCConstructorDerived> cell(vm, new (NotNull, JSC::allocateCell<ObjCConstructorDerived>(vm.heap)) ObjCConstructorDerived(vm, structure));
         cell->finishCreation(vm, globalObject, prototype, klass);
         return cell;
     }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.h
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.h
@@ -18,9 +18,9 @@ class ObjCConstructorNative : public ObjCConstructorBase {
 public:
     typedef ObjCConstructorBase Base;
 
-    static ObjCConstructorNative* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
+    static JSC::Strong<ObjCConstructorNative> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSObject* prototype, Class klass) {
         ASSERT(klass);
-        ObjCConstructorNative* cell = new (NotNull, JSC::allocateCell<ObjCConstructorNative>(vm.heap)) ObjCConstructorNative(vm, structure);
+        JSC::Strong<ObjCConstructorNative> cell(vm, new (NotNull, JSC::allocateCell<ObjCConstructorNative>(vm.heap)) ObjCConstructorNative(vm, structure));
         cell->finishCreation(vm, globalObject, prototype, klass);
         return cell;
     }

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.h
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.h
@@ -22,8 +22,8 @@ public:
 
     static const unsigned StructureFlags = Base::StructureFlags;
 
-    static ObjCFastEnumerationIterator* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, id object) {
-        ObjCFastEnumerationIterator* prototype = new (NotNull, JSC::allocateCell<ObjCFastEnumerationIterator>(vm.heap)) ObjCFastEnumerationIterator(vm, structure);
+    static JSC::Strong<ObjCFastEnumerationIterator> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, id object) {
+        JSC::Strong<ObjCFastEnumerationIterator> prototype(vm, new (NotNull, JSC::allocateCell<ObjCFastEnumerationIterator>(vm.heap)) ObjCFastEnumerationIterator(vm, structure));
         prototype->finishCreation(vm, globalObject, object);
         return prototype;
     }

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.h
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIteratorPrototype.h
@@ -18,8 +18,8 @@ public:
 
     static const unsigned StructureFlags = Base::StructureFlags;
 
-    static ObjCFastEnumerationIteratorPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        ObjCFastEnumerationIteratorPrototype* prototype = new (NotNull, JSC::allocateCell<ObjCFastEnumerationIteratorPrototype>(globalObject->vm().heap)) ObjCFastEnumerationIteratorPrototype(globalObject->vm(), structure);
+    static JSC::Strong<ObjCFastEnumerationIteratorPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<ObjCFastEnumerationIteratorPrototype> prototype(vm, new (NotNull, JSC::allocateCell<ObjCFastEnumerationIteratorPrototype>(globalObject->vm().heap)) ObjCFastEnumerationIteratorPrototype(globalObject->vm(), structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
+++ b/src/NativeScript/ObjC/NSErrorWrapperConstructor.h
@@ -17,8 +17,8 @@ class NSErrorWrapperConstructor : public JSC::InternalFunction {
 public:
     typedef JSC::InternalFunction Base;
 
-    static NSErrorWrapperConstructor* create(JSC::VM& vm, JSC::Structure* structure) {
-        NSErrorWrapperConstructor* cell = new (NotNull, JSC::allocateCell<NSErrorWrapperConstructor>(vm.heap)) NSErrorWrapperConstructor(vm, structure);
+    static JSC::Strong<NSErrorWrapperConstructor> create(JSC::VM& vm, JSC::Structure* structure) {
+        JSC::Strong<NSErrorWrapperConstructor> cell(vm, new (NotNull, JSC::allocateCell<NSErrorWrapperConstructor>(vm.heap)) NSErrorWrapperConstructor(vm, structure));
         cell->finishCreation(vm, structure->globalObject());
         return cell;
     }

--- a/src/NativeScript/ObjC/ObjCMethodCall.h
+++ b/src/NativeScript/ObjC/ObjCMethodCall.h
@@ -23,13 +23,13 @@ class ObjCMethodWrapper : public FunctionWrapper {
 public:
     typedef FunctionWrapper Base;
 
-    static ObjCMethodWrapper* create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, std::vector<const Metadata::MemberMeta*> metadata) {
-        ObjCMethodWrapper* cell = new (NotNull, JSC::allocateCell<ObjCMethodWrapper>(vm.heap)) ObjCMethodWrapper(vm, structure);
+    static JSC::Strong<ObjCMethodWrapper> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, std::vector<const Metadata::MemberMeta*> metadata) {
+        JSC::Strong<ObjCMethodWrapper> cell(vm, new (NotNull, JSC::allocateCell<ObjCMethodWrapper>(vm.heap)) ObjCMethodWrapper(vm, structure));
         cell->finishCreation(vm, globalObject, metadata);
         return cell;
     }
 
-    static ObjCMethodWrapper* create(JSC::ExecState* execState, std::vector<const Metadata::MemberMeta*> metadata) {
+    static Strong<ObjCMethodWrapper> create(JSC::ExecState* execState, std::vector<const Metadata::MemberMeta*> metadata) {
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
         return create(execState->vm(), globalObject, globalObject->objCMethodWrapperStructure(), metadata);
     }

--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -36,15 +36,15 @@ void ObjCMethodWrapper::finishCreation(VM& vm, GlobalObject* globalObject, std::
 
         const TypeEncoding* encodings = method->encodings()->first();
 
-        JSCell* returnTypeCell = globalObject->typeFactory()->parseType(globalObject, /*r*/ encodings, false);
-        const WTF::Vector<JSCell*> parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, /*r*/ encodings, method->encodings()->count - 1, false);
+        auto returnTypeCell = globalObject->typeFactory()->parseType(globalObject, /*r*/ encodings, false);
+        auto parameterTypesCells = globalObject->typeFactory()->parseTypes(globalObject, /*r*/ encodings, method->encodings()->count - 1, false);
 
         if (parameterTypesCells.size() > maxParamsCount) {
             maxParamsCount = parameterTypesCells.size();
         }
 
         std::unique_ptr<ObjCMethodCall> call(new ObjCMethodCall(this, method));
-        call->initializeFFI(vm, { &preInvocation, &postInvocation }, returnTypeCell, parameterTypesCells, 2);
+        call->initializeFFI(vm, { &preInvocation, &postInvocation }, returnTypeCell.get(), parameterTypesCells, 2);
         call->_retainsReturnedCocoaObjects = method->ownsReturnedCocoaObject();
         call->_isOptional = method->isOptional();
         call->_isInitializer = method->isInitializer();

--- a/src/NativeScript/ObjC/ObjCMethodCallback.h
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.h
@@ -25,8 +25,8 @@ class ObjCMethodCallback : public FFICallback<ObjCMethodCallback> {
 public:
     typedef FFICallback Base;
 
-    static ObjCMethodCallback* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, JSC::JSCell* returnType, WTF::Vector<JSC::JSCell*> parameterTypes, WTF::TriState hasErrorOutParameter = WTF::MixedTriState) {
-        ObjCMethodCallback* cell = new (NotNull, JSC::allocateCell<ObjCMethodCallback>(vm.heap)) ObjCMethodCallback(vm, structure);
+    static JSC::Strong<ObjCMethodCallback> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::JSCell* function, JSC::JSCell* returnType, WTF::Vector<Strong<JSC::JSCell>> parameterTypes, WTF::TriState hasErrorOutParameter = WTF::MixedTriState) {
+        JSC::Strong<ObjCMethodCallback> cell(vm, new (NotNull, JSC::allocateCell<ObjCMethodCallback>(vm.heap)) ObjCMethodCallback(vm, structure));
         cell->finishCreation(vm, globalObject, function, returnType, parameterTypes, hasErrorOutParameter);
         return cell;
     }
@@ -44,7 +44,7 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSCell* function, JSC::JSCell* returnType, WTF::Vector<JSC::JSCell*> parameterTypes, WTF::TriState hasErrorOutParameter);
+    void finishCreation(JSC::VM&, JSC::JSGlobalObject*, JSC::JSCell* function, JSC::JSCell* returnType, WTF::Vector<JSC::Strong<JSC::JSCell>> parameterTypes, WTF::TriState hasErrorOutParameter);
 
     bool _hasErrorOutParameter;
 };

--- a/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
+++ b/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
@@ -72,8 +72,8 @@ static JSValue objCProtocol_read(ExecState* execState, const void* buffer, JSCel
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    ObjCProtocolWrapper* protocolWrapper = globalObject->protocolWrapperFor(aProtocol);
-    return protocolWrapper;
+    auto protocolWrapper = globalObject->protocolWrapperFor(aProtocol);
+    return protocolWrapper.get();
 }
 static void objCProtocol_write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {
     VM& vm = execState->vm();
@@ -112,7 +112,7 @@ static JSValue objCClass_read(ExecState* execState, const void* buffer, JSCell* 
         return jsNull();
     }
 
-    return jsCast<GlobalObject*>(execState->lexicalGlobalObject())->constructorFor(klass);
+    return jsCast<GlobalObject*>(execState->lexicalGlobalObject())->constructorFor(klass).get();
 }
 static void objCClass_write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {
     JSC::VM& vm = execState->vm();

--- a/src/NativeScript/ObjC/ObjCProtocolWrapper.h
+++ b/src/NativeScript/ObjC/ObjCProtocolWrapper.h
@@ -24,8 +24,8 @@ public:
 
     DECLARE_INFO;
 
-    static ObjCProtocolWrapper* create(JSC::VM& vm, JSC::Structure* structure, ObjCPrototype* prototype, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol = nil) {
-        ObjCProtocolWrapper* cell = new (NotNull, JSC::allocateCell<ObjCProtocolWrapper>(vm.heap)) ObjCProtocolWrapper(vm, structure);
+    static JSC::Strong<ObjCProtocolWrapper> create(JSC::VM& vm, JSC::Structure* structure, ObjCPrototype* prototype, const Metadata::ProtocolMeta* metadata, Protocol* aProtocol = nil) {
+        JSC::Strong<ObjCProtocolWrapper> cell(vm, new (NotNull, JSC::allocateCell<ObjCProtocolWrapper>(vm.heap)) ObjCProtocolWrapper(vm, structure));
         cell->finishCreation(vm, prototype, metadata, aProtocol);
         return cell;
     }

--- a/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
+++ b/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
@@ -48,9 +48,9 @@ bool ObjCProtocolWrapper::getOwnPropertySlot(JSObject* object, ExecState* execSt
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
 
-        ObjCMethodWrapper* wrapper = ObjCMethodWrapper::create(execState->vm(), globalObject, globalObject->objCMethodWrapperStructure(), metas);
-        object->putDirect(execState->vm(), propertyName, wrapper);
-        propertySlot.setValue(object, static_cast<unsigned>(PropertyAttribute::None), wrapper);
+        auto wrapper = ObjCMethodWrapper::create(execState->vm(), globalObject, globalObject->objCMethodWrapperStructure(), metas);
+        object->putDirect(execState->vm(), propertyName, wrapper.get());
+        propertySlot.setValue(object, static_cast<unsigned>(PropertyAttribute::None), wrapper.get());
         return true;
     }
 

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -23,8 +23,8 @@ public:
 
     static const unsigned StructureFlags;
 
-    static ObjCPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::BaseClassMeta* metadata) {
-        ObjCPrototype* prototype = new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure);
+    static JSC::Strong<ObjCPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::BaseClassMeta* metadata) {
+        JSC::Strong<ObjCPrototype> prototype(vm, new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure));
         prototype->finishCreation(vm, globalObject, metadata);
         return prototype;
     }

--- a/src/NativeScript/ObjC/ObjCSuperObject.h
+++ b/src/NativeScript/ObjC/ObjCSuperObject.h
@@ -16,8 +16,8 @@ class ObjCSuperObject : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static ObjCSuperObject* create(JSC::VM& vm, JSC::Structure* structure, ObjCWrapperObject* wrapper, GlobalObject* globalObject) {
-        ObjCSuperObject* cell = new (NotNull, JSC::allocateCell<ObjCSuperObject>(vm.heap)) ObjCSuperObject(vm, structure);
+    static JSC::Strong<ObjCSuperObject> create(JSC::VM& vm, JSC::Structure* structure, ObjCWrapperObject* wrapper, GlobalObject* globalObject) {
+        JSC::Strong<ObjCSuperObject> cell(vm, new (NotNull, JSC::allocateCell<ObjCSuperObject>(vm.heap)) ObjCSuperObject(vm, structure));
         cell->finishCreation(vm, wrapper, globalObject);
         return cell;
     }

--- a/src/NativeScript/ObjC/ObjCTypes.mm
+++ b/src/NativeScript/ObjC/ObjCTypes.mm
@@ -139,7 +139,7 @@ JSValue toValue(ExecState* execState, id object, Class klass) {
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
 
     if (class_isMetaClass(object_getClass(object))) {
-        return globalObject->constructorFor(object_getClass(object), klass);
+        return globalObject->constructorFor(object_getClass(object), klass).get();
     }
 
     return toValue(execState, object, ^{
@@ -163,6 +163,6 @@ JSValue toValue(ExecState* execState, id object, Structure* (^structureResolver)
         return wrapper;
     }
 
-    return ObjCWrapperObject::create(execState->vm(), structureResolver(), object, globalObject);
+    return ObjCWrapperObject::create(execState->vm(), structureResolver(), object, globalObject).get();
 }
 }

--- a/src/NativeScript/ObjC/ObjCWrapperObject.h
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.h
@@ -17,8 +17,8 @@ class ObjCWrapperObject : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static ObjCWrapperObject* create(JSC::VM& vm, JSC::Structure* structure, id wrappedObject, GlobalObject* globalObject) {
-        ObjCWrapperObject* object = new (NotNull, JSC::allocateCell<ObjCWrapperObject>(vm.heap)) ObjCWrapperObject(vm, structure);
+    static JSC::Strong<ObjCWrapperObject> create(JSC::VM& vm, JSC::Structure* structure, id wrappedObject, GlobalObject* globalObject) {
+        JSC::Strong<ObjCWrapperObject> object(vm, new (NotNull, JSC::allocateCell<ObjCWrapperObject>(vm.heap)) ObjCWrapperObject(vm, structure));
         object->finishCreation(vm, wrappedObject, globalObject);
         return object;
     }

--- a/src/NativeScript/ObjC/TNSArrayAdapter.mm
+++ b/src/NativeScript/ObjC/TNSArrayAdapter.mm
@@ -10,7 +10,6 @@
 #include "Interop.h"
 #include "ObjCTypes.h"
 #include "TNSRuntime+Private.h"
-#include <JavaScriptCore/StrongInlines.h>
 
 using namespace NativeScript;
 using namespace JSC;

--- a/src/NativeScript/ObjC/TNSArrayAdapter.mm
+++ b/src/NativeScript/ObjC/TNSArrayAdapter.mm
@@ -55,6 +55,9 @@ using namespace JSC;
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState*)state objects:(id[])buffer count:(NSUInteger)len {
     RELEASE_ASSERT_WITH_MESSAGE([TNSRuntime runtimeForVM:self->_vm], "The runtime is deallocated.");
+
+    JSLockHolder lock(self->_execState);
+
     if (state->state == 0) { // uninitialized
         state->state = 1;
         state->mutationsPtr = reinterpret_cast<unsigned long*>(self);
@@ -67,7 +70,6 @@ using namespace JSC;
     NSUInteger count = 0;
     state->itemsPtr = buffer;
 
-    JSLockHolder lock(self->_execState);
     while (count < len && currentIndex < length) {
         *buffer++ = toObject(self->_execState, self->_object->get(self->_execState, currentIndex));
         currentIndex++;

--- a/src/NativeScript/ObjC/TNSDataAdapter.mm
+++ b/src/NativeScript/ObjC/TNSDataAdapter.mm
@@ -11,7 +11,6 @@
 #include "JSErrors.h"
 #include "TNSRuntime+Private.h"
 #include <JavaScriptCore/JSArrayBuffer.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 using namespace NativeScript;
 using namespace JSC;

--- a/src/NativeScript/ObjC/TNSDictionaryAdapter.mm
+++ b/src/NativeScript/ObjC/TNSDictionaryAdapter.mm
@@ -12,7 +12,6 @@
 #include "TNSRuntime+Private.h"
 #include <JavaScriptCore/JSMap.h>
 #include <JavaScriptCore/JSMapIterator.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 using namespace JSC;
 using namespace NativeScript;

--- a/src/NativeScript/ObjC/Unmanaged/UnmanagedInstance.h
+++ b/src/NativeScript/ObjC/Unmanaged/UnmanagedInstance.h
@@ -8,8 +8,8 @@ public:
 
     DECLARE_INFO;
 
-    static UnmanagedInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* returnType, void* value = nullptr) {
-        UnmanagedInstance* object = new (NotNull, JSC::allocateCell<UnmanagedInstance>(vm.heap)) UnmanagedInstance(vm, structure);
+    static JSC::Strong<UnmanagedInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSCell* returnType, void* value = nullptr) {
+        JSC::Strong<UnmanagedInstance> object(vm, new (NotNull, JSC::allocateCell<UnmanagedInstance>(vm.heap)) UnmanagedInstance(vm, structure));
         object->finishCreation(vm, returnType, value);
         return object;
     }

--- a/src/NativeScript/ObjC/Unmanaged/UnmanagedPrototype.h
+++ b/src/NativeScript/ObjC/Unmanaged/UnmanagedPrototype.h
@@ -6,8 +6,8 @@ class UnmanagedPrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static UnmanagedPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        UnmanagedPrototype* prototype = new (NotNull, JSC::allocateCell<UnmanagedPrototype>(vm.heap)) UnmanagedPrototype(vm, structure);
+    static JSC::Strong<UnmanagedPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<UnmanagedPrototype> prototype(vm, new (NotNull, JSC::allocateCell<UnmanagedPrototype>(vm.heap)) UnmanagedPrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/ObjC/Unmanaged/UnmanagedType.cpp
+++ b/src/NativeScript/ObjC/Unmanaged/UnmanagedType.cpp
@@ -27,7 +27,7 @@ JSValue UnmanagedType::read(ExecState* execState, const void* buffer, JSCell* se
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     UnmanagedType* unmanagedType = jsCast<UnmanagedType*>(self);
 
-    return UnmanagedInstance::create(execState->vm(), globalObject->unmanagedInstanceStructure(), unmanagedType->_returnType.get(), const_cast<void*>(data));
+    return UnmanagedInstance::create(execState->vm(), globalObject->unmanagedInstanceStructure(), unmanagedType->_returnType.get(), const_cast<void*>(data)).get();
 }
 
 void UnmanagedType::visitChildren(JSCell* cell, SlotVisitor& visitor) {

--- a/src/NativeScript/ObjC/Unmanaged/UnmanagedType.h
+++ b/src/NativeScript/ObjC/Unmanaged/UnmanagedType.h
@@ -11,8 +11,8 @@ class UnmanagedType : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static UnmanagedType* create(JSC::VM& vm, JSC::JSCell* returnType, JSC::Structure* structure) {
-        UnmanagedType* constructor = new (NotNull, JSC::allocateCell<UnmanagedType>(vm.heap)) UnmanagedType(vm, structure);
+    static JSC::Strong<UnmanagedType> create(JSC::VM& vm, JSC::JSCell* returnType, JSC::Structure* structure) {
+        JSC::Strong<UnmanagedType> constructor(vm, new (NotNull, JSC::allocateCell<UnmanagedType>(vm.heap)) UnmanagedType(vm, structure));
         constructor->finishCreation(vm, returnType);
         return constructor;
     }

--- a/src/NativeScript/Runtime/JSWeakRefConstructor.cpp
+++ b/src/NativeScript/Runtime/JSWeakRefConstructor.cpp
@@ -22,8 +22,8 @@ static EncodedJSValue JSC_HOST_CALL construct(ExecState* execState) {
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
-    JSWeakRefInstance* weakRef = JSWeakRefInstance::create(execState->vm(), globalObject->weakRefInstanceStructure(), argument.toObject(execState));
-    return JSValue::encode(weakRef);
+    auto weakRef = JSWeakRefInstance::create(execState->vm(), globalObject->weakRefInstanceStructure(), argument.toObject(execState));
+    return JSValue::encode(weakRef.get());
 }
 
 const ClassInfo JSWeakRefConstructor::s_info = { "WeakRef", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSWeakRefConstructor) };

--- a/src/NativeScript/Runtime/JSWeakRefConstructor.h
+++ b/src/NativeScript/Runtime/JSWeakRefConstructor.h
@@ -20,8 +20,8 @@ public:
 
     DECLARE_INFO;
 
-    static JSWeakRefConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSWeakRefPrototype* prototype) {
-        JSWeakRefConstructor* object = new (NotNull, JSC::allocateCell<JSWeakRefConstructor>(vm.heap)) JSWeakRefConstructor(vm, structure);
+    static JSC::Strong<JSWeakRefConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSWeakRefPrototype* prototype) {
+        JSC::Strong<JSWeakRefConstructor> object(vm, new (NotNull, JSC::allocateCell<JSWeakRefConstructor>(vm.heap)) JSWeakRefConstructor(vm, structure));
         object->finishCreation(vm, prototype);
         return object;
     }

--- a/src/NativeScript/Runtime/JSWeakRefInstance.h
+++ b/src/NativeScript/Runtime/JSWeakRefInstance.h
@@ -19,8 +19,8 @@ public:
 
     DECLARE_INFO;
 
-    static JSWeakRefInstance* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* weakObject) {
-        JSWeakRefInstance* object = new (NotNull, JSC::allocateCell<JSWeakRefInstance>(vm.heap)) JSWeakRefInstance(vm, structure);
+    static JSC::Strong<JSWeakRefInstance> create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* weakObject) {
+        JSC::Strong<JSWeakRefInstance> object(vm, new (NotNull, JSC::allocateCell<JSWeakRefInstance>(vm.heap)) JSWeakRefInstance(vm, structure));
         object->finishCreation(vm, weakObject);
         return object;
     }

--- a/src/NativeScript/Runtime/JSWeakRefPrototype.h
+++ b/src/NativeScript/Runtime/JSWeakRefPrototype.h
@@ -14,8 +14,8 @@ class JSWeakRefPrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static JSWeakRefPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        JSWeakRefPrototype* prototype = new (NotNull, JSC::allocateCell<JSWeakRefPrototype>(vm.heap)) JSWeakRefPrototype(vm, structure);
+    static JSC::Strong<JSWeakRefPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<JSWeakRefPrototype> prototype(vm, new (NotNull, JSC::allocateCell<JSWeakRefPrototype>(vm.heap)) JSWeakRefPrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/TNSRuntime.h
+++ b/src/NativeScript/TNSRuntime.h
@@ -39,7 +39,9 @@ FOUNDATION_EXTERN void TNSSetUncaughtErrorHandler(TNSUncaughtErrorHandler handle
 
 - (JSValueRef)convertObject:(id)object;
 
-- (id)appPackageJson;
+- (NSDictionary*)appPackageJson;
+
+- (void)tryCollectGarbage;
 @end
 
 @interface TNSWorkerRuntime : TNSRuntime

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -31,6 +31,8 @@
 #import "TNSRuntime.h"
 #include "Workers/JSWorkerGlobalObject.h"
 
+#include <mach/mach_host.h>
+
 using namespace JSC;
 using namespace NativeScript;
 
@@ -47,13 +49,33 @@ JSInternalPromise* loadAndEvaluateModule(ExecState* exec, const String& moduleNa
 
 @interface TNSRuntime ()
 
-@property(nonatomic, retain) id appPackageJsonData;
+@property(nonatomic, retain) NSDictionary* appPackageJsonData;
+
+@property double* gcThrottleTimeValue;
+
+@property double* memoryCheckIntervalValue;
+
+@property double* freeMemoryRatioValue;
+
+- (double)gcThrottleTime;
+
+- (double)memoryCheckInterval;
+
+- (double)freeMemoryRatio;
+
+- (double)readDoubleFromPackageJsonIos:(NSString*)key;
 
 @end
 
 @implementation TNSRuntime
 
 @synthesize appPackageJsonData;
+
+@synthesize gcThrottleTimeValue;
+
+@synthesize memoryCheckIntervalValue;
+
+@synthesize freeMemoryRatioValue;
 
 static WTF::Lock _runtimesLock;
 static NSPointerArray* _runtimes;
@@ -191,7 +213,7 @@ static NSPointerArray* _runtimes;
     return toRef(self->_globalObject->globalExec(), toValue(self->_globalObject->globalExec(), object));
 }
 
-- (id)appPackageJson {
+- (NSDictionary*)appPackageJson {
 
     if (self->appPackageJsonData != nil) {
         return self->appPackageJsonData;
@@ -205,6 +227,105 @@ static NSPointerArray* _runtimes;
     }
 
     return self->appPackageJsonData;
+}
+
+- (double)gcThrottleTime {
+
+    if (self->gcThrottleTimeValue != nullptr) {
+        return *self->gcThrottleTimeValue;
+    }
+
+    self->gcThrottleTimeValue = new double([self readDoubleFromPackageJsonIos:@"gcThrottleTime"]);
+
+    return *self->gcThrottleTimeValue;
+}
+
+- (double)memoryCheckInterval {
+
+    if (self->memoryCheckIntervalValue != nullptr) {
+        return *self->memoryCheckIntervalValue;
+    }
+
+    self->memoryCheckIntervalValue = new double([self readDoubleFromPackageJsonIos:@"memoryCheckInterval"]);
+
+    return *self->memoryCheckIntervalValue;
+}
+
+- (double)freeMemoryRatio {
+
+    if (self->freeMemoryRatioValue != nullptr) {
+        return *self->freeMemoryRatioValue;
+    }
+
+    self->freeMemoryRatioValue = new double([self readDoubleFromPackageJsonIos:@"freeMemoryRatio"]);
+
+    return *self->freeMemoryRatioValue;
+}
+
+- (double)readDoubleFromPackageJsonIos:(NSString*)key {
+    double res = 0;
+    if (auto packageJson = [self appPackageJson]) {
+        if (NSDictionary* ios = packageJson[@"ios"]) {
+            if (id value = ios[key]) {
+                if ([value respondsToSelector:@selector(doubleValue)]) {
+                    res = [value doubleValue];
+                } else {
+                    NSLog(@"\"%@\" setting from package.json cannot be converted to double: %@", key, value);
+                }
+            }
+        }
+    }
+
+    return res;
+}
+
+double getSystemFreeMemoryRatio() {
+    mach_port_t host_port = mach_host_self();
+    ;
+    mach_msg_type_number_t host_size = sizeof(vm_statistics_data_t) / sizeof(integer_t);
+    vm_statistics_data_t vm_stat;
+    if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size) != KERN_SUCCESS) {
+        NSLog(@"Failed to fetch vm statistics");
+        return 0;
+    }
+
+    double free = static_cast<double>(vm_stat.free_count + vm_stat.inactive_count);
+    double used = static_cast<double>(vm_stat.active_count + vm_stat.wire_count);
+    double total = free + used;
+
+    return free / total;
+}
+
+- (void)tryCollectGarbage {
+    using namespace std;
+    using namespace std::chrono;
+
+    static auto previousGcTime = steady_clock::now();
+
+    auto triggerGc = ^{
+      JSLockHolder locker(self->_vm.get());
+      self->_vm->heap.collectAsync(CollectionScope::Full);
+      previousGcTime = steady_clock::now();
+    };
+    auto elapsedMs = duration_cast<duration<double, milli>>(steady_clock::now() - previousGcTime).count();
+
+    if (auto gcThrottleTimeMs = [self gcThrottleTime]) {
+        if (elapsedMs > gcThrottleTimeMs) {
+            triggerGc();
+            return;
+        }
+    }
+
+    if (auto gcMemCheckIntervalMs = [self memoryCheckInterval]) {
+        if (elapsedMs > gcMemCheckIntervalMs) {
+            if (auto freeMemoryRatio = [self freeMemoryRatio]) {
+                if (getSystemFreeMemoryRatio() < freeMemoryRatio) {
+                    triggerGc();
+                    return;
+                }
+            }
+        }
+    }
 }
 
 - (void)dealloc {

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -14,7 +14,6 @@
 #include <JavaScriptCore/JSInternalPromise.h>
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/JSNativeStdFunction.h>
-#include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/inspector/JSGlobalObjectInspectorController.h>
 #include <iostream>
 
@@ -137,7 +136,7 @@ static NSPointerArray* _runtimes;
 #endif
 
         JSLockHolder lock(*self->_vm);
-        self->_globalObject = Strong<GlobalObject>(*self->_vm, [self createGlobalObjectInstance]);
+        self->_globalObject = [self createGlobalObjectInstance];
 
         {
             WTF::LockHolder lock(_runtimesLock);
@@ -148,7 +147,7 @@ static NSPointerArray* _runtimes;
     return self;
 }
 
-- (GlobalObject*)createGlobalObjectInstance {
+- (JSC::Strong<GlobalObject>)createGlobalObjectInstance {
     TNSPERF();
     return GlobalObject::create(*self->_vm, GlobalObject::createStructure(*self->_vm, jsNull()), self->_applicationPath);
 }
@@ -358,7 +357,7 @@ double getSystemFreeMemoryRatio() {
 
 @implementation TNSWorkerRuntime
 
-- (GlobalObject*)createGlobalObjectInstance {
+- (Strong<GlobalObject>)createGlobalObjectInstance {
     TNSPERF();
     return JSWorkerGlobalObject::create(*self->_vm, JSWorkerGlobalObject::createStructure(*self->_vm, jsNull()), self->_applicationPath);
 }

--- a/src/NativeScript/TypeFactory.h
+++ b/src/NativeScript/TypeFactory.h
@@ -36,8 +36,8 @@ class TypeFactory : public JSC::JSDestructibleObject {
 public:
     typedef JSC::JSDestructibleObject Base;
 
-    static TypeFactory* create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure) {
-        TypeFactory* object = new (NotNull, JSC::allocateCell<TypeFactory>(vm.heap)) TypeFactory(vm, structure);
+    static JSC::Strong<TypeFactory> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<TypeFactory> object(vm, new (NotNull, JSC::allocateCell<TypeFactory>(vm.heap)) TypeFactory(vm, structure));
         object->finishCreation(vm, globalObject);
         return object;
     }
@@ -48,25 +48,25 @@ public:
         return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
     }
 
-    JSC::JSCell* parseType(GlobalObject*, const Metadata::TypeEncoding*&, bool isStructMember);
+    Strong<JSC::JSCell> parseType(GlobalObject*, const Metadata::TypeEncoding*&, bool isStructMember);
 
-    const WTF::Vector<JSC::JSCell*> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember);
+    const WTF::Vector<JSC::Strong<JSC::JSCell>> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember);
 
-    ObjCConstructorNative* getObjCNativeConstructor(GlobalObject*, const WTF::String& klassName);
+    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructor(GlobalObject*, const WTF::String& klassName);
 
-    RecordConstructor* getStructConstructor(GlobalObject*, const WTF::String& structName);
+    JSC::Strong<RecordConstructor> getStructConstructor(GlobalObject*, const WTF::String& structName);
 
-    ObjCConstructorNative* NSObjectConstructor(GlobalObject*);
+    JSC::Strong<ObjCConstructorNative> NSObjectConstructor(GlobalObject*);
 
-    ReferenceTypeInstance* getReferenceType(GlobalObject* globalObject, JSC::JSCell* innerType);
+    JSC::Strong<ReferenceTypeInstance> getReferenceType(GlobalObject* globalObject, JSC::JSCell* innerType);
 
-    IndexedRefTypeInstance* getIndexedRefType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize);
+    JSC::Strong<IndexedRefTypeInstance> getIndexedRefType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize);
 
-    ExtVectorTypeInstance* getExtVectorType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize, bool isStructMember);
+    JSC::Strong<ExtVectorTypeInstance> getExtVectorType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize, bool isStructMember);
 
-    FunctionReferenceTypeInstance* getFunctionReferenceTypeInstance(GlobalObject* globalObject, JSC::JSCell* returnType, WTF::Vector<JSCell*> parametersTypes);
+    JSC::Strong<FunctionReferenceTypeInstance> getFunctionReferenceTypeInstance(GlobalObject* globalObject, JSC::JSCell* returnType, WTF::Vector<Strong<JSCell>> parametersTypes);
 
-    ObjCBlockType* getObjCBlockType(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<JSCell*> parametersTypes);
+    JSC::Strong<ObjCBlockType> getObjCBlockType(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<Strong<JSCell>> parametersTypes);
 
     PointerConstructor* pointerConstructor() const {
         return this->_pointerConstructor.get();
@@ -145,18 +145,18 @@ private:
 
     void finishCreation(JSC::VM&, GlobalObject*);
 
-    JSC::JSCell* parsePrimitiveType(JSC::JSGlobalObject* globalOBject, const Metadata::TypeEncoding*& typeEncoding);
+    Strong<JSC::JSCell> parsePrimitiveType(JSC::JSGlobalObject* globalOBject, const Metadata::TypeEncoding*& typeEncoding);
     size_t resolveConstArrayTypeSize(const Metadata::TypeEncoding* typeEncoding, const Metadata::TypeEncoding* innerTypeEncoding);
 
     static void visitChildren(JSC::JSCell* cell, JSC::SlotVisitor& visitor);
 
-    WTF::Vector<RecordField*> createRecordFields(GlobalObject*, const WTF::Vector<JSCell*>& fieldsTypes, const WTF::Vector<WTF::String>& fieldsNames, ffi_type* ffiType);
+    WTF::Vector<Strong<RecordField>> createRecordFields(GlobalObject*, const WTF::Vector<Strong<JSCell>>& fieldsTypes, const WTF::Vector<WTF::String>& fieldsNames, ffi_type* ffiType);
 
-    ObjCBlockType* parseBlockType(GlobalObject*, const Metadata::TypeEncodingsList<uint8_t>& typeEncodings);
+    Strong<ObjCBlockType> parseBlockType(GlobalObject*, const Metadata::TypeEncodingsList<uint8_t>& typeEncodings);
 
-    JSC::JSCell* parseFunctionReferenceType(GlobalObject* globalObject, const Metadata::TypeEncodingsList<uint8_t>& typeEncodings);
+    Strong<JSC::JSCell> parseFunctionReferenceType(GlobalObject* globalObject, const Metadata::TypeEncodingsList<uint8_t>& typeEncodings);
 
-    RecordConstructor* getAnonymousStructConstructor(GlobalObject*, const Metadata::TypeEncodingDetails::AnonymousRecordDetails& details);
+    JSC::Strong<RecordConstructor> getAnonymousStructConstructor(GlobalObject*, const Metadata::TypeEncodingDetails::AnonymousRecordDetails& details);
 
     JSC::WriteBarrier<FFISimpleType> _noopType;
     JSC::WriteBarrier<FFISimpleType> _voidType;

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -34,67 +34,67 @@ using namespace Metadata;
 
 const ClassInfo TypeFactory::s_info = { "TypeFactory", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(TypeFactory) };
 
-ObjCBlockType* TypeFactory::parseBlockType(GlobalObject* globalObject, const TypeEncodingsList<uint8_t>& typeEncodings) {
+Strong<ObjCBlockType> TypeFactory::parseBlockType(GlobalObject* globalObject, const TypeEncodingsList<uint8_t>& typeEncodings) {
     const TypeEncoding* typeEncodingPtr = typeEncodings.first();
-    JSCell* returnType = this->parseType(globalObject, typeEncodingPtr, false);
-    const WTF::Vector<JSCell*> parameters = this->parseTypes(globalObject, typeEncodingPtr, typeEncodings.count - 1, false);
-    return this->getObjCBlockType(globalObject, returnType, parameters);
+    Strong<JSCell> returnType = this->parseType(globalObject, typeEncodingPtr, false);
+    const WTF::Vector<Strong<JSCell>> parameters = this->parseTypes(globalObject, typeEncodingPtr, typeEncodings.count - 1, false);
+    return this->getObjCBlockType(globalObject, returnType.get(), parameters);
 }
 
-ObjCBlockType* TypeFactory::getObjCBlockType(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<JSCell*> parametersTypes) {
+Strong<ObjCBlockType> TypeFactory::getObjCBlockType(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<Strong<JSCell>> parametersTypes) {
     WTF::Vector<JSC::WeakImpl*> weakParametersTypes;
     weakParametersTypes.append(WeakSet::allocate(JSValue(returnType))); // add return value
     for (size_t i = 0; i < parametersTypes.size(); i++) {
-        weakParametersTypes.append(WeakSet::allocate(JSValue(parametersTypes[i])));
+        weakParametersTypes.append(WeakSet::allocate(JSValue(parametersTypes[i].get())));
     }
 
     if (this->_cacheObjCBlockType.contains(weakParametersTypes)) {
         WeakImpl* value = this->_cacheObjCBlockType.get(weakParametersTypes);
         if (value->state() == WeakImpl::State::Live) {
-            return static_cast<ObjCBlockType*>(value->jsValue().asCell());
+            return Strong<ObjCBlockType>(globalObject->vm(), static_cast<ObjCBlockType*>(value->jsValue().asCell()));
         } else {
             this->_cacheObjCBlockType.remove(weakParametersTypes);
         }
     }
 
-    ObjCBlockType* result = ObjCBlockType::create(globalObject->vm(), this->_objCBlockTypeStructure.get(), returnType, parametersTypes);
-    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result));
+    Strong<ObjCBlockType> result = ObjCBlockType::create(globalObject->vm(), this->_objCBlockTypeStructure.get(), returnType, parametersTypes);
+    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result.get()));
     this->_cacheObjCBlockType.add(weakParametersTypes, resultWeak);
     return result;
 }
 
-JSCell* TypeFactory::parseFunctionReferenceType(GlobalObject* globalObject, const TypeEncodingsList<uint8_t>& typeEncodings) {
+Strong<JSCell> TypeFactory::parseFunctionReferenceType(GlobalObject* globalObject, const TypeEncodingsList<uint8_t>& typeEncodings) {
     const TypeEncoding* typeEncodingPtr = typeEncodings.first();
-    JSCell* returnType = globalObject->typeFactory()->parseType(globalObject, typeEncodingPtr, false);
-    const WTF::Vector<JSCell*> parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, typeEncodingPtr, typeEncodings.count - 1, false);
-    return this->getFunctionReferenceTypeInstance(globalObject, returnType, parameterTypes);
+    Strong<JSCell> returnType = globalObject->typeFactory()->parseType(globalObject, typeEncodingPtr, false);
+    const auto parameterTypes = globalObject->typeFactory()->parseTypes(globalObject, typeEncodingPtr, typeEncodings.count - 1, false);
+    return this->getFunctionReferenceTypeInstance(globalObject, returnType.get(), parameterTypes);
 }
 
-FunctionReferenceTypeInstance* TypeFactory::getFunctionReferenceTypeInstance(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<JSCell*> parametersTypes) {
+Strong<FunctionReferenceTypeInstance> TypeFactory::getFunctionReferenceTypeInstance(GlobalObject* globalObject, JSCell* returnType, WTF::Vector<Strong<JSCell>> parametersTypes) {
     WTF::Vector<JSC::WeakImpl*> weakParametersTypes;
     weakParametersTypes.append(WeakSet::allocate(JSValue(returnType))); // add return value
     for (size_t i = 0; i < parametersTypes.size(); i++) {
-        weakParametersTypes.append(WeakSet::allocate(JSValue(parametersTypes[i])));
+        weakParametersTypes.append(WeakSet::allocate(JSValue(parametersTypes[i].get())));
     }
 
     if (this->_cacheFunctionReferenceType.contains(weakParametersTypes)) {
         WeakImpl* value = this->_cacheFunctionReferenceType.get(weakParametersTypes);
         if (value->state() == WeakImpl::State::Live) {
-            return jsDynamicCast<FunctionReferenceTypeInstance*>(globalObject->vm(), value->jsValue().asCell());
+            return Strong<FunctionReferenceTypeInstance>(globalObject->vm(), jsDynamicCast<FunctionReferenceTypeInstance*>(globalObject->vm(), value->jsValue().asCell()));
         } else {
             this->_cacheFunctionReferenceType.remove(weakParametersTypes);
         }
     }
 
-    FunctionReferenceTypeInstance* result = FunctionReferenceTypeInstance::create(globalObject->vm(), this->_functionReferenceTypeStructure.get(), returnType, parametersTypes);
-    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result));
+    Strong<FunctionReferenceTypeInstance> result(globalObject->vm(), FunctionReferenceTypeInstance::create(globalObject->vm(), this->_functionReferenceTypeStructure.get(), returnType, parametersTypes));
+    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result.get()));
     this->_cacheFunctionReferenceType.add(weakParametersTypes, resultWeak);
     return result;
 }
 
-RecordConstructor* TypeFactory::getStructConstructor(GlobalObject* globalObject, const WTF::String& structName) {
+Strong<RecordConstructor> TypeFactory::getStructConstructor(GlobalObject* globalObject, const WTF::String& structName) {
     if (RecordConstructor* constructor = this->_cacheStruct.get(structName)) {
-        return constructor;
+        return Strong<RecordConstructor>(globalObject->vm(), constructor);
     }
 
     ffi_type* ffiType = new ffi_type({ .size = 0,
@@ -104,16 +104,16 @@ RecordConstructor* TypeFactory::getStructConstructor(GlobalObject* globalObject,
     VM& vm = globalObject->vm();
 
     // Handle linked list structures
-    RecordPrototype* recordPrototype = RecordPrototype::create(vm, globalObject, _recordPrototypeStructure.get());
-    RecordConstructor* constructor = RecordConstructor::create(vm, globalObject, _recordConstructorStructure.get(), recordPrototype, structName, ffiType, RecordType::Struct);
-    recordPrototype->putDirect(vm, vm.propertyNames->constructor, constructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    auto recordPrototype = RecordPrototype::create(vm, globalObject, _recordPrototypeStructure.get());
+    auto constructor = RecordConstructor::create(vm, globalObject, _recordConstructorStructure.get(), recordPrototype.get(), structName, ffiType, RecordType::Struct);
+    recordPrototype->putDirect(vm, vm.propertyNames->constructor, constructor.get(), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    auto addResult = this->_cacheStruct.set(structName, constructor);
+    auto addResult = this->_cacheStruct.set(structName, constructor.get());
     if (!addResult.isNewEntry) {
         ASSERT_NOT_REACHED();
     }
 
-    WTF::Vector<JSCell*> fieldsTypes;
+    WTF::Vector<Strong<JSCell>> fieldsTypes;
     WTF::Vector<WTF::String> fieldsNames;
 
     const StructMeta* structInfo = static_cast<const StructMeta*>(MetaFile::instance()->globalTable()->findMeta(structName.impl()));
@@ -126,22 +126,22 @@ RecordConstructor* TypeFactory::getStructConstructor(GlobalObject* globalObject,
         fieldsNames.append((*it).valuePtr());
     }
 
-    WTF::Vector<RecordField*> fields = createRecordFields(globalObject, fieldsTypes, fieldsNames, ffiType);
+    WTF::Vector<Strong<RecordField>> fields = createRecordFields(globalObject, fieldsTypes, fieldsNames, ffiType);
     recordPrototype->setFields(vm, globalObject, fields);
 
     // This could already be initialized at this point.
     if (RecordConstructor* constructor = this->_cacheStruct.get(structName)) {
-        return constructor;
+        return Strong<RecordConstructor>(globalObject->vm(), constructor);
     }
 
-    addResult = this->_cacheStruct.set(structName, constructor);
+    addResult = this->_cacheStruct.set(structName, constructor.get());
     if (!addResult.isNewEntry) {
         ASSERT_NOT_REACHED();
     }
     return constructor;
 }
 
-RecordConstructor* TypeFactory::getAnonymousStructConstructor(GlobalObject* globalObject, const Metadata::TypeEncodingDetails::AnonymousRecordDetails& details) {
+Strong<RecordConstructor> TypeFactory::getAnonymousStructConstructor(GlobalObject* globalObject, const Metadata::TypeEncodingDetails::AnonymousRecordDetails& details) {
     ffi_type* ffiType = new ffi_type({ .size = 0,
                                        .alignment = 0,
                                        .type = FFI_TYPE_STRUCT });
@@ -149,11 +149,11 @@ RecordConstructor* TypeFactory::getAnonymousStructConstructor(GlobalObject* glob
     VM& vm = globalObject->vm();
 
     // Handle linked list structures
-    RecordPrototype* recordPrototype = RecordPrototype::create(vm, globalObject, _recordPrototypeStructure.get());
-    RecordConstructor* constructor = RecordConstructor::create(vm, globalObject, _recordConstructorStructure.get(), recordPrototype, "?", ffiType, RecordType::Struct);
-    recordPrototype->putDirect(vm, vm.propertyNames->constructor, constructor, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    auto recordPrototype = RecordPrototype::create(vm, globalObject, _recordPrototypeStructure.get());
+    auto constructor = RecordConstructor::create(vm, globalObject, _recordConstructorStructure.get(), recordPrototype.get(), "?", ffiType, RecordType::Struct);
+    recordPrototype->putDirect(vm, vm.propertyNames->constructor, constructor.get(), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    WTF::Vector<JSCell*> fieldsTypes;
+    WTF::Vector<Strong<JSCell>> fieldsTypes;
     WTF::Vector<WTF::String> fieldsNames;
 
     for (int i = 0; i < details.fieldsCount; ++i) {
@@ -164,13 +164,13 @@ RecordConstructor* TypeFactory::getAnonymousStructConstructor(GlobalObject* glob
     const TypeEncoding* encodingsPtr = details.getFieldsEncodings();
     fieldsTypes = parseTypes(globalObject, encodingsPtr, details.fieldsCount, true);
 
-    WTF::Vector<RecordField*> fields = createRecordFields(globalObject, fieldsTypes, fieldsNames, ffiType);
+    auto fields = createRecordFields(globalObject, fieldsTypes, fieldsNames, ffiType);
     recordPrototype->setFields(vm, globalObject, fields);
 
-    return constructor;
+    return Strong<RecordConstructor>(globalObject->vm(), constructor);
 }
 
-WTF::Vector<RecordField*> TypeFactory::createRecordFields(GlobalObject* globalObject, const WTF::Vector<JSCell*>& fieldsTypes, const WTF::Vector<WTF::String>& fieldsNames, ffi_type* ffiType) {
+WTF::Vector<Strong<RecordField>> TypeFactory::createRecordFields(GlobalObject* globalObject, const WTF::Vector<Strong<JSCell>>& fieldsTypes, const WTF::Vector<WTF::String>& fieldsNames, ffi_type* ffiType) {
     DeferGCForAWhile deferGC(globalObject->vm().heap);
 
     ASSERT(fieldsNames.size() == fieldsTypes.size());
@@ -181,9 +181,9 @@ WTF::Vector<RecordField*> TypeFactory::createRecordFields(GlobalObject* globalOb
 #if defined(__x86_64__)
     bool hasNestedStruct = false;
 #endif
-    WTF::Vector<RecordField*> fields;
+    WTF::Vector<Strong<RecordField>> fields;
     for (size_t i = 0; i < fieldsTypes.size(); i++) {
-        const ffi_type* fieldFFIType = getFFITypeMethodTable(vm, fieldsTypes[i]).ffiType;
+        const ffi_type* fieldFFIType = getFFITypeMethodTable(vm, fieldsTypes[i].get()).ffiType;
 #if defined(__x86_64__)
         hasNestedStruct = hasNestedStruct || (fieldFFIType->type == FFI_TYPE_STRUCT);
 #endif
@@ -199,7 +199,7 @@ WTF::Vector<RecordField*> TypeFactory::createRecordFields(GlobalObject* globalOb
         ffiType->size = offset + fieldFFIType->size;
         ffiType->alignment = std::max(ffiType->alignment, fieldFFIType->alignment);
 
-        RecordField* field = RecordField::create(vm, this->_recordFieldStructure.get(), fieldsNames[i], fieldsTypes[i], offset);
+        Strong<RecordField> field(vm, RecordField::create(vm, this->_recordFieldStructure.get(), fieldsNames[i], fieldsTypes[i].get(), offset));
         fields.append(field);
     }
 
@@ -239,10 +239,10 @@ WTF::Vector<RecordField*> TypeFactory::createRecordFields(GlobalObject* globalOb
     return fields;
 }
 
-ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globalObject, const WTF::String& klassName) {
+Strong<ObjCConstructorNative> TypeFactory::getObjCNativeConstructor(GlobalObject* globalObject, const WTF::String& klassName) {
     tns::instrumentation::Frame frame;
     if (ObjCConstructorNative* type = this->_cacheId.get(klassName)) {
-        return type;
+        return Strong<ObjCConstructorNative>(globalObject->vm(), type);
     }
 
     VM& vm = globalObject->vm();
@@ -262,8 +262,8 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
 #ifdef DEBUG
         NSLog(@"** Can not create constructor for \"%@\". Casting it to \"NSObject\". **", klassName.createCFString().autorelease());
 #endif
-        ObjCConstructorNative* nsobjectConstructor = this->NSObjectConstructor(globalObject);
-        this->_cacheId.set(klassName, nsobjectConstructor);
+        auto nsobjectConstructor = this->NSObjectConstructor(globalObject);
+        this->_cacheId.set(klassName, nsobjectConstructor.get());
         return nsobjectConstructor;
     }
 
@@ -272,7 +272,7 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
 
     const char* superKlassName = metadata->baseName();
     if (superKlassName) {
-        parentConstructor = getObjCNativeConstructor(globalObject, superKlassName);
+        parentConstructor = getObjCNativeConstructor(globalObject, superKlassName).get();
         parentPrototype = parentConstructor.get(globalObject->globalExec(), vm.propertyNames->prototype);
     } else {
         // NSObject and NSProxy don't have a base class and therefore inherit directly from GlobalObject.
@@ -285,17 +285,17 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
     /// the parent constructor has been created.
     /// TODO: Move this check in the if (superKlassName) case.
     if (ObjCConstructorNative* type = this->_cacheId.get(klassName)) {
-        return type;
+        return Strong<ObjCConstructorNative>(globalObject->vm(), type);
     }
 
     Structure* prototypeStructure = ObjCPrototype::createStructure(vm, globalObject, parentPrototype);
-    ObjCPrototype* prototype = ObjCPrototype::create(vm, globalObject, prototypeStructure, metadata);
+    auto prototype = ObjCPrototype::create(vm, globalObject, prototypeStructure, metadata);
 
     Structure* constructorStructure = ObjCConstructorNative::createStructure(vm, globalObject, parentConstructor);
-    ObjCConstructorNative* constructor = ObjCConstructorNative::create(vm, globalObject, constructorStructure, prototype, klass);
-    prototype->putDirectWithoutTransition(vm, vm.propertyNames->constructor, constructor, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    auto constructor = ObjCConstructorNative::create(vm, globalObject, constructorStructure, prototype.get(), klass);
+    prototype->putDirectWithoutTransition(vm, vm.propertyNames->constructor, constructor.get(), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 
-    auto addResult = this->_cacheId.set(klassName, constructor);
+    auto addResult = this->_cacheId.set(klassName, constructor.get());
     if (!addResult.isNewEntry) {
         ASSERT_NOT_REACHED();
     }
@@ -310,109 +310,107 @@ ObjCConstructorNative* TypeFactory::getObjCNativeConstructor(GlobalObject* globa
     return constructor;
 }
 
-ObjCConstructorNative* TypeFactory::NSObjectConstructor(GlobalObject* globalObject) {
+Strong<ObjCConstructorNative> TypeFactory::NSObjectConstructor(GlobalObject* globalObject) {
     if (LIKELY(this->_nsObjectConstructor)) {
-        return this->_nsObjectConstructor.get();
+        return Strong<ObjCConstructorNative>(globalObject->vm(), this->_nsObjectConstructor.get());
     }
 
-    ObjCConstructorNative* constructor = getObjCNativeConstructor(globalObject, "NSObject"_s);
-    this->_nsObjectConstructor.set(globalObject->vm(), this, constructor);
+    auto constructor = getObjCNativeConstructor(globalObject, "NSObject"_s);
+    this->_nsObjectConstructor.set(globalObject->vm(), this, constructor.get());
     return constructor;
 }
 
-IndexedRefTypeInstance* TypeFactory::getIndexedRefType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize) {
+Strong<IndexedRefTypeInstance> TypeFactory::getIndexedRefType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize) {
 
-    IndexedRefTypeInstance* result = IndexedRefTypeInstance::create(globalObject->vm(), this->_indexedRefTypeStructure.get(), innerType, typeSize);
-    return result;
+    return IndexedRefTypeInstance::create(globalObject->vm(), this->_indexedRefTypeStructure.get(), innerType, typeSize);
 }
 
-ExtVectorTypeInstance* TypeFactory::getExtVectorType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize, bool isStructMember) {
-    ExtVectorTypeInstance* result = ExtVectorTypeInstance::create(globalObject->vm(), this->_extVectorTypeStructure.get(), innerType, typeSize, isStructMember);
-    return result;
+Strong<ExtVectorTypeInstance> TypeFactory::getExtVectorType(GlobalObject* globalObject, JSCell* innerType, size_t typeSize, bool isStructMember) {
+    return ExtVectorTypeInstance::create(globalObject->vm(), this->_extVectorTypeStructure.get(), innerType, typeSize, isStructMember);
 }
 
-ReferenceTypeInstance* TypeFactory::getReferenceType(GlobalObject* globalObject, JSCell* innerType) {
+Strong<ReferenceTypeInstance> TypeFactory::getReferenceType(GlobalObject* globalObject, JSCell* innerType) {
     WeakImpl* innerWeak = WeakSet::allocate(JSValue(innerType));
     if (this->_cacheReferenceType.contains(innerWeak)) {
         WeakImpl* value = this->_cacheReferenceType.get(innerWeak);
         if (value->state() == WeakImpl::State::Live) {
-            return static_cast<ReferenceTypeInstance*>(value->jsValue().asCell());
+            return Strong<ReferenceTypeInstance>(globalObject->vm(), static_cast<ReferenceTypeInstance*>(value->jsValue().asCell()));
         } else {
             this->_cacheReferenceType.remove(innerWeak);
         }
     }
 
-    ReferenceTypeInstance* result = ReferenceTypeInstance::create(globalObject->vm(), this->_referenceTypeStructure.get(), innerType);
-    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result));
+    auto result = ReferenceTypeInstance::create(globalObject->vm(), this->_referenceTypeStructure.get(), innerType);
+    WeakImpl* resultWeak = WeakSet::allocate(JSValue(result.get()));
     this->_cacheReferenceType.add(innerWeak, resultWeak);
     return result;
 }
 
-JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncoding, bool isStructMember) {
+Strong<JSC::JSCell> TypeFactory::parseType(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncoding, bool isStructMember) {
     DeferGCForAWhile deferGC(globalObject->vm().heap);
 
-    JSC::JSCell* result = nullptr;
+    Strong<JSC::JSCell> result;
 
     switch (typeEncoding->type) {
     case BinaryTypeEncodingType::VoidEncoding:
-        result = this->_voidType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_voidType.get());
         break;
     case BinaryTypeEncodingType::BoolEncoding:
-        result = this->_boolType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_boolType.get());
         break;
     case BinaryTypeEncodingType::ShortEncoding:
-        result = this->_int16Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int16Type.get());
         break;
     case BinaryTypeEncodingType::UShortEncoding:
-        result = this->_uint16Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint16Type.get());
         break;
     case BinaryTypeEncodingType::IntEncoding:
-        result = this->_int32Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int32Type.get());
         break;
     case BinaryTypeEncodingType::UIntEncoding:
-        result = this->_uint32Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint32Type.get());
         break;
     case BinaryTypeEncodingType::LongEncoding:
 #if defined(__LP64__)
         COMPILE_ASSERT(sizeof(long) == sizeof(int64_t), "sizeof long");
-        result = this->_int64Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int64Type.get());
 #else
         COMPILE_ASSERT(sizeof(long) == sizeof(int32_t), "sizeof long");
-        result = this->_int32Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int32Type.get());
 #endif
         break;
     case BinaryTypeEncodingType::ULongEncoding:
 #if defined(__LP64__)
         COMPILE_ASSERT(sizeof(unsigned long) == sizeof(uint64_t), "sizeof ulong");
-        result = this->_uint64Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint64Type.get());
 #else
         COMPILE_ASSERT(sizeof(unsigned long) == sizeof(uint32_t), "sizeof ulong");
-        result = this->_uint32Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint32Type.get());
 #endif
         break;
     case BinaryTypeEncodingType::LongLongEncoding:
-        result = this->_int64Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int64Type.get());
         break;
     case BinaryTypeEncodingType::ULongLongEncoding:
-        result = this->_uint64Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint64Type.get());
         break;
     case BinaryTypeEncodingType::CharEncoding:
-        result = this->_int8Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_int8Type.get());
         break;
     case BinaryTypeEncodingType::UCharEncoding:
-        result = this->_uint8Type.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_uint8Type.get());
         break;
     case BinaryTypeEncodingType::UnicharEncoding:
-        result = this->_unicharType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_unicharType.get());
         break;
     case BinaryTypeEncodingType::CStringEncoding:
-        result = this->_utf8CStringType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_utf8CStringType.get());
         break;
     case BinaryTypeEncodingType::FloatEncoding:
-        result = this->_floatType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_floatType.get());
         break;
     case BinaryTypeEncodingType::DoubleEncoding:
-        result = this->_doubleType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_doubleType.get());
         break;
     case BinaryTypeEncodingType::InterfaceDeclarationReference: {
         WTF::String declarationName = WTF::String(typeEncoding->details.declarationReference.name.valuePtr());
@@ -425,34 +423,34 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
         break;
     }
     case BinaryTypeEncodingType::UnionDeclarationReference: {
-        result = this->_noopType.get(); // unions are not supported
+        result = Strong<JSCell>(globalObject->vm(), this->_noopType.get()); // unions are not supported
         break;
     }
     case BinaryTypeEncodingType::PointerEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.pointer.getInnerType();
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, false);
-        if (innerType == this->_voidType.get()) {
-            result = this->_pointerConstructor.get();
+        auto innerType = this->parseType(globalObject, innerTypeEncoding, false);
+        if (innerType.get() == this->_voidType.get()) {
+            result = Strong<JSCell>(globalObject->vm(), this->_pointerConstructor.get());
         } else {
-            result = this->getReferenceType(globalObject, innerType);
+            result = this->getReferenceType(globalObject, innerType.get());
         }
 
         break;
     }
     case BinaryTypeEncodingType::VaListEncoding:
-        result = this->_noopType.get(); // Not supported
+        result = Strong<JSCell>(globalObject->vm(), this->_noopType.get()); // Not supported
         break;
     case BinaryTypeEncodingType::SelectorEncoding:
-        result = this->_objCSelectorType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_objCSelectorType.get());
         break;
     case BinaryTypeEncodingType::ClassEncoding:
-        result = this->_objCClassType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_objCClassType.get());
         break;
     case BinaryTypeEncodingType::ProtocolEncoding:
-        result = this->_objCProtocolType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_objCProtocolType.get());
         break;
     case BinaryTypeEncodingType::InstanceTypeEncoding:
-        result = this->_objCInstancetypeType.get();
+        result = Strong<JSCell>(globalObject->vm(), this->_objCInstancetypeType.get());
         break;
     case BinaryTypeEncodingType::IdEncoding:
         result = this->NSObjectConstructor(globalObject);
@@ -460,11 +458,11 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
     case BinaryTypeEncodingType::ConstantArrayEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.constantArray.getInnerType();
         size_t arraySize = typeEncoding->details.constantArray.size;
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
+        auto innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
         if (isStructMember) {
-            result = this->getIndexedRefType(globalObject, innerType, arraySize);
+            result = this->getIndexedRefType(globalObject, innerType.get(), arraySize);
         } else {
-            result = this->getReferenceType(globalObject, innerType);
+            result = this->getReferenceType(globalObject, innerType.get());
         }
 
         break;
@@ -472,14 +470,14 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
     case BinaryTypeEncodingType::ExtVectorEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.extVector.getInnerType();
         size_t arraySize = typeEncoding->details.extVector.size;
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
-        result = this->getExtVectorType(globalObject, innerType, arraySize, isStructMember);
+        auto innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
+        result = this->getExtVectorType(globalObject, innerType.get(), arraySize, isStructMember);
         break;
     }
     case BinaryTypeEncodingType::IncompleteArrayEncoding: {
         const TypeEncoding* innerTypeEncoding = typeEncoding->details.incompleteArray.getInnerType();
-        JSCell* innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
-        result = this->getReferenceType(globalObject, innerType);
+        auto innerType = this->parseType(globalObject, innerTypeEncoding, isStructMember);
+        result = this->getReferenceType(globalObject, innerType.get());
         break;
     }
     case BinaryTypeEncodingType::FunctionPointerEncoding:
@@ -492,7 +490,7 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
         result = this->getAnonymousStructConstructor(globalObject, typeEncoding->details.anonymousRecord);
         break;
     case BinaryTypeEncodingType::AnonymousUnionEncoding:
-        result = this->_noopType.get(); // unions are not supported
+        result = Strong<JSCell>(globalObject->vm(), this->_noopType.get()); // unions are not supported
         break;
     default:
         ASSERT_NOT_REACHED(); // Unknown type encoding
@@ -501,10 +499,10 @@ JSC::JSCell* TypeFactory::parseType(GlobalObject* globalObject, const Metadata::
     return result;
 }
 
-const WTF::Vector<JSC::JSCell*> TypeFactory::parseTypes(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember) {
+const WTF::Vector<Strong<JSCell>> TypeFactory::parseTypes(GlobalObject* globalObject, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember) {
     DeferGCForAWhile deferGC(globalObject->vm().heap);
 
-    WTF::Vector<JSCell*> types;
+    WTF::Vector<Strong<JSCell>> types;
     for (int i = 0; i < count; i++) {
         types.append(parseType(globalObject, typeEncodings, isStructMember));
     }
@@ -523,31 +521,35 @@ void TypeFactory::finishCreation(VM& vm, GlobalObject* globalObject) {
     this->_recordConstructorStructure.set(vm, this, RecordConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()));
     this->_recordFieldStructure.set(vm, this, RecordField::createStructure(vm, globalObject, jsNull()));
 
-    PointerPrototype* pointerPrototype = PointerPrototype::create(vm, globalObject, PointerPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
-    this->_pointerConstructor.set(vm, this, PointerConstructor::create(vm, PointerConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()), pointerPrototype));
+    auto pointerPrototype = PointerPrototype::create(vm, globalObject, PointerPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
+    this->_pointerConstructor.set(vm, this,
+                                  PointerConstructor::create(vm,
+                                                             PointerConstructor::createStructure(vm, globalObject, globalObject->functionPrototype()),
+                                                             pointerPrototype.get())
+                                      .get());
     pointerPrototype->putDirect(vm, vm.propertyNames->constructor, this->_pointerConstructor.get(), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    this->_noopType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "noop"_s, noopTypeMethodTable));
-    this->_voidType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "void"_s, voidTypeMethodTable));
-    this->_boolType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "bool"_s, boolTypeMethodTable));
-    this->_utf8CStringType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "UTF8CString"_s, utf8CStringTypeMethodTable));
-    this->_unicharType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "unichar"_s, unicharTypeMethodTable));
+    this->_noopType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "noop"_s, noopTypeMethodTable).get());
+    this->_voidType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "void"_s, voidTypeMethodTable).get());
+    this->_boolType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "bool"_s, boolTypeMethodTable).get());
+    this->_utf8CStringType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "UTF8CString"_s, utf8CStringTypeMethodTable).get());
+    this->_unicharType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "unichar"_s, unicharTypeMethodTable).get());
 
-    this->_int8Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int8"_s, int8TypeMethodTable));
-    this->_uint8Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint8"_s, uint8TypeMethodTable));
-    this->_int16Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int16"_s, int16TypeMethodTable));
-    this->_uint16Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint16"_s, uint16TypeMethodTable));
-    this->_int32Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int32"_s, int32TypeMethodTable));
-    this->_uint32Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint32"_s, uint32TypeMethodTable));
-    this->_int64Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int64"_s, int64TypeMethodTable));
-    this->_uint64Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint64"_s, uint64TypeMethodTable));
-    this->_floatType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "float"_s, floatTypeMethodTable));
-    this->_doubleType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "double"_s, doubleTypeMethodTable));
+    this->_int8Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int8"_s, int8TypeMethodTable).get());
+    this->_uint8Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint8"_s, uint8TypeMethodTable).get());
+    this->_int16Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int16"_s, int16TypeMethodTable).get());
+    this->_uint16Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint16"_s, uint16TypeMethodTable).get());
+    this->_int32Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int32"_s, int32TypeMethodTable).get());
+    this->_uint32Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint32"_s, uint32TypeMethodTable).get());
+    this->_int64Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "int64"_s, int64TypeMethodTable).get());
+    this->_uint64Type.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "uint64"_s, uint64TypeMethodTable).get());
+    this->_floatType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "float"_s, floatTypeMethodTable).get());
+    this->_doubleType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "double"_s, doubleTypeMethodTable).get());
 
-    this->_objCInstancetypeType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "instancetype"_s, objCInstancetypeTypeMethodTable));
-    this->_objCProtocolType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "protocol"_s, objCProtocolTypeMethodTable));
-    this->_objCClassType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "class"_s, objCClassTypeMethodTable));
-    this->_objCSelectorType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "selector"_s, objCSelectorTypeMethodTable));
+    this->_objCInstancetypeType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "instancetype"_s, objCInstancetypeTypeMethodTable).get());
+    this->_objCProtocolType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "protocol"_s, objCProtocolTypeMethodTable).get());
+    this->_objCClassType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "class"_s, objCClassTypeMethodTable).get());
+    this->_objCSelectorType.set(vm, this, FFISimpleType::create(vm, FFISimpleType::createStructure(vm, globalObject, globalObject->objectPrototype()), "selector"_s, objCSelectorTypeMethodTable).get());
 }
 
 void TypeFactory::visitChildren(JSCell* cell, SlotVisitor& visitor) {

--- a/src/NativeScript/Workers/JSWorkerConstructor.cpp
+++ b/src/NativeScript/Workers/JSWorkerConstructor.cpp
@@ -42,8 +42,8 @@ EncodedJSValue JSC_HOST_CALL JSWorkerConstructor::constructJSWorker(ExecState* e
     WTF::String referrer = applicationPath;
     referrer.append(relativeFilePath);
 
-    JSWorkerInstance* worker = JSWorkerInstance::create(exec->vm(), globalObject->workerInstanceStructure(), applicationPath, entryModule, referrer);
-    return JSValue::encode(worker);
+    auto worker = JSWorkerInstance::create(exec->vm(), globalObject->workerInstanceStructure(), applicationPath, entryModule, referrer);
+    return JSValue::encode(worker.get());
 }
 
 EncodedJSValue JSC_HOST_CALL JSWorkerConstructor::callJSWorker(ExecState* exec) {

--- a/src/NativeScript/Workers/JSWorkerConstructor.h
+++ b/src/NativeScript/Workers/JSWorkerConstructor.h
@@ -20,8 +20,8 @@ public:
 
     DECLARE_INFO;
 
-    static JSWorkerConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSWorkerPrototype* prototype) {
-        JSWorkerConstructor* object = new (NotNull, JSC::allocateCell<JSWorkerConstructor>(vm.heap)) JSWorkerConstructor(vm, structure);
+    static JSC::Strong<JSWorkerConstructor> create(JSC::VM& vm, JSC::Structure* structure, JSWorkerPrototype* prototype) {
+        JSC::Strong<JSWorkerConstructor> object(vm, new (NotNull, JSC::allocateCell<JSWorkerConstructor>(vm.heap)) JSWorkerConstructor(vm, structure));
         object->finishCreation(vm, prototype);
         return object;
     }

--- a/src/NativeScript/Workers/JSWorkerGlobalObject.h
+++ b/src/NativeScript/Workers/JSWorkerGlobalObject.h
@@ -10,8 +10,8 @@ class JSWorkerGlobalObject : public GlobalObject {
 public:
     typedef GlobalObject Base;
 
-    static JSWorkerGlobalObject* create(JSC::VM& vm, JSC::Structure* structure, WTF::String applicationPath) {
-        JSWorkerGlobalObject* object = new (NotNull, JSC::allocateCell<JSWorkerGlobalObject>(vm.heap)) JSWorkerGlobalObject(vm, structure);
+    static JSC::Strong<JSWorkerGlobalObject> create(JSC::VM& vm, JSC::Structure* structure, WTF::String applicationPath) {
+        JSC::Strong<JSWorkerGlobalObject> object(vm, new (NotNull, JSC::allocateCell<JSWorkerGlobalObject>(vm.heap)) JSWorkerGlobalObject(vm, structure));
         object->finishCreation(vm, applicationPath);
         return object;
     }

--- a/src/NativeScript/Workers/JSWorkerInstance.h
+++ b/src/NativeScript/Workers/JSWorkerInstance.h
@@ -18,8 +18,8 @@ public:
 
     DECLARE_INFO;
 
-    static JSWorkerInstance* create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& applicationPath, const WTF::String& entryModuleId, const WTF::String referrer) {
-        JSWorkerInstance* object = new (NotNull, JSC::allocateCell<JSWorkerInstance>(vm.heap)) JSWorkerInstance(vm, structure);
+    static JSC::Strong<JSWorkerInstance> create(JSC::VM& vm, JSC::Structure* structure, const WTF::String& applicationPath, const WTF::String& entryModuleId, const WTF::String referrer) {
+        JSC::Strong<JSWorkerInstance> object(vm, new (NotNull, JSC::allocateCell<JSWorkerInstance>(vm.heap)) JSWorkerInstance(vm, structure));
         object->finishCreation(vm, applicationPath, entryModuleId, referrer);
         return object;
     }

--- a/src/NativeScript/Workers/JSWorkerPrototype.h
+++ b/src/NativeScript/Workers/JSWorkerPrototype.h
@@ -14,8 +14,8 @@ class JSWorkerPrototype : public JSC::JSNonFinalObject {
 public:
     typedef JSC::JSNonFinalObject Base;
 
-    static JSWorkerPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
-        JSWorkerPrototype* prototype = new (NotNull, JSC::allocateCell<JSWorkerPrototype>(vm.heap)) JSWorkerPrototype(vm, structure);
+    static JSC::Strong<JSWorkerPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure) {
+        JSC::Strong<JSWorkerPrototype> prototype(vm, new (NotNull, JSC::allocateCell<JSWorkerPrototype>(vm.heap)) JSWorkerPrototype(vm, structure));
         prototype->finishCreation(vm, globalObject);
         return prototype;
     }

--- a/src/NativeScript/Workers/WorkerMessagingProxy.h
+++ b/src/NativeScript/Workers/WorkerMessagingProxy.h
@@ -11,7 +11,6 @@
 
 #include "JSWorkerInstance.h"
 #include <JavaScriptCore/InternalFunction.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 @class TNSRuntime;
 

--- a/src/NativeScript/inspector/DomainBackendDispatcher.h
+++ b/src/NativeScript/inspector/DomainBackendDispatcher.h
@@ -1,7 +1,6 @@
 #ifndef DomainBackendDispatcher_h
 #define DomainBackendDispatcher_h
 
-#include <JavaScriptCore/StrongInlines.h>
 #include <inspector/InspectorAgentBase.h>
 #include <inspector/InspectorBackendDispatcher.h>
 

--- a/src/NativeScript/inspector/DomainInspectorAgent.h
+++ b/src/NativeScript/inspector/DomainInspectorAgent.h
@@ -3,7 +3,6 @@
 
 #include "DomainBackendDispatcher.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 namespace NativeScript {
 class DomainInspectorAgent : public Inspector::InspectorAgentBase {

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -435,9 +435,14 @@ describe(module.id, function () {
                 .then(done);
         });
 
-        it("should throw errors in the argument marshalling phase", function () {
+        it("argument marshalling phase should be done asyncronously", function (done) {
             var str = NSString.alloc();
-            expect(() => str.initWithString.async(str, [])).toThrow();
+            str.initWithString.async(str, [])
+                .then(() => { throw new Error ("Promise should be rejected due to incorrect number of arguments."); })
+                .catch(err => {
+                    expect(err.toString()).toMatch(/Error.* arguments count.*0.*expected.*1/i);
+                    done();
+                });
         });
 
         it("should reject the returned promise if an error is raised in the result marshalling phase", function (done) {

--- a/tests/TestRunner/app/package.json
+++ b/tests/TestRunner/app/package.json
@@ -1,0 +1,7 @@
+{
+    "ios": {
+        "gcThrottleTime": 5,
+        "memoryCheckInterval": 0,
+        "freeMemoryRatio": 0.60
+    }
+}


### PR DESCRIPTION
Introduce settings similar to the ones in {N} Android Runtime for
configuring automatic GC triggering by the runtime. They are
specified in `app/package.json` as values in the `ios` section:

* `gcThrottleTime` - number of milliseconds which must have passed
since the last automatic GC in order to trigger one during a call from
JS to native
* `memoryCheckInterval` - number of milliseconds which must have
passed since the last automatic GC in order to check the memory
usage on the device and trigger GC if free memory is below the specified
threshold
* `freeMemoryRatio` - a floating-point value from 0 to 1 which sets the
threshold below which a GC will be triggered when the above check is made.

After implementing the feature we faced a number of different bugs leading to random
crashes after a GC has run. The fixes are included in this PR as separate commits:

* fix(runtime): Keep JS instances in Strong references after creation
* fix(bridge): Don't read returned value of a function which threw an exception
* fix(bridge): Don't read JS properties without obtaining a lock
* fix(build): Regenerate low-level interpreter after build configuration change
* fix(bridge): Marshal arguments of async calls in worker thread

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base

Implements #1035


