### PR TITLE
Improvements to pointer initialization and conversions to string

### DIFF
--- a/src/NativeScript/Interop.h
+++ b/src/NativeScript/Interop.h
@@ -88,6 +88,9 @@ private:
     JSC::WriteBarrier<NSErrorWrapperConstructor> _nsErrorWrapperConstructor;
 
     JSC::WeakGCMap<const void*, PointerInstance> _pointerToInstance;
+    // Special case when the pointer is -1. It is the "deleted" value of WeakGCMap's hashing
+    // function and cannot be added to the map as a key;
+    JSC::Weak<PointerInstance> minusOnePointerInstance;
 };
 
 static inline Interop* interop(JSC::ExecState* execState) {

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -341,6 +341,15 @@ JSValue Interop::pointerInstanceForPointer(ExecState* execState, void* value) {
         return jsNull();
     }
 
+    if (reinterpret_cast<intptr_t>(value) == -1) {
+        if (!this->minusOnePointerInstance) {
+            auto pointerInstance = PointerInstance::create(execState, this->_pointerInstanceStructure.get(), value);
+            this->minusOnePointerInstance = pointerInstance.get();
+        }
+
+        return this->minusOnePointerInstance.get();
+    }
+
     if (PointerInstance* pointerInstance = this->_pointerToInstance.get(value)) {
         return pointerInstance;
     }

--- a/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
@@ -35,6 +35,12 @@ EncodedJSValue JSC_HOST_CALL PointerConstructor::constructPointerInstance(ExecSt
     if (execState->argumentCount() == 1) {
         auto arg0 = execState->argument(0);
 
+        if (arg0.isObject()) {
+            if (JSWrapperObject* wrapper = jsCast<JSWrapperObject*>(arg0)) {
+                arg0 = wrapper->internalValue();
+            }
+        }
+
         if (!arg0.isAnyInt()) {
             auto scope = DECLARE_THROW_SCOPE(execState->vm());
             return throwVMError(execState, scope, createError(execState, "Pointer constructor's first arg must be an integer."_s));

--- a/src/NativeScript/Marshalling/Pointer/PointerPrototype.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerPrototype.cpp
@@ -42,6 +42,20 @@ static EncodedJSValue JSC_HOST_CALL pointerProtoFuncToString(ExecState* execStat
     return JSValue::encode(result);
 }
 
+static EncodedJSValue JSC_HOST_CALL pointerProtoFuncToHexString(ExecState* execState) {
+    PointerInstance* pointer = jsCast<PointerInstance*>(execState->thisValue());
+    const void* value = pointer->data();
+    JSValue result = jsString(execState, WTF::String::format("%p", value));
+    return JSValue::encode(result);
+}
+
+static EncodedJSValue JSC_HOST_CALL pointerProtoFuncToDecimalString(ExecState* execState) {
+    PointerInstance* pointer = jsCast<PointerInstance*>(execState->thisValue());
+    const void* value = pointer->data();
+    JSValue result = jsString(execState, WTF::String::format("%ld", static_cast<intptr_t>(reinterpret_cast<size_t>(value))));
+    return JSValue::encode(result);
+}
+
 static EncodedJSValue JSC_HOST_CALL pointerProtoFuncToNumber(ExecState* execState) {
     PointerInstance* pointer = jsCast<PointerInstance*>(execState->thisValue());
     const void* value = pointer->data();
@@ -56,5 +70,7 @@ void PointerPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject) {
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(globalObject->globalExec(), "subtract"), 1, pointerProtoFuncSubtract, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     this->putDirectNativeFunction(vm, globalObject, vm.propertyNames->toString, 0, pointerProtoFuncToString, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(globalObject->globalExec(), "toNumber"), 0, pointerProtoFuncToNumber, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(globalObject->globalExec(), "toHexString"), 0, pointerProtoFuncToHexString, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    this->putDirectNativeFunction(vm, globalObject, Identifier::fromString(globalObject->globalExec(), "toDecimalString"), 0, pointerProtoFuncToDecimalString, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 }
 } // namespace NativeScript

--- a/tests/TestRunner/app/Marshalling/PointerTests.js
+++ b/tests/TestRunner/app/Marshalling/PointerTests.js
@@ -18,6 +18,14 @@ describe(module.id, function () {
         expect(pointer.toString()).toBe(`<Pointer: ${hexMinusOneForCurrentBitness}>`);
     });
 
+    it("Pointer from a wrapped Number", function () {
+        const number = 0x12abcdef;
+        var pointer = new interop.Pointer(new Number(number));
+        expect(pointer instanceof interop.Pointer).toBe(true);
+        expect(pointer.toNumber()).toBe(number);
+        expect(pointer.toString()).toBe(`<Pointer: 0x${number.toString(16)}>`);
+    });
+
     it("PointerArithmetic", function () {
         var pointer = new interop.Pointer(0xFFFFFFFE);
         expect(pointer.toNumber()).toBe(0xFFFFFFFE);

--- a/tests/TestRunner/app/Marshalling/PointerTests.js
+++ b/tests/TestRunner/app/Marshalling/PointerTests.js
@@ -9,6 +9,15 @@ describe(module.id, function () {
         expect(pointer.toString()).toBe('<Pointer: 0x1>');
     });
 
+    it("SimplePointer -1", function () {
+        var pointer = new interop.Pointer(-1);
+        expect(pointer instanceof interop.Pointer).toBe(true);
+        const hexMinusOneForCurrentBitness = "0x" + "f".repeat(interop.sizeof(interop.types.id)*2);
+        // Subtraction used as a workaround for expect(<p>).toBe(<n>) failing due to rounding of 64-bit numbers
+        expect(pointer.toNumber() - new Number(hexMinusOneForCurrentBitness)).toBe(0);
+        expect(pointer.toString()).toBe(`<Pointer: ${hexMinusOneForCurrentBitness}>`);
+    });
+
     it("PointerArithmetic", function () {
         var pointer = new interop.Pointer(0xFFFFFFFE);
         expect(pointer.toNumber()).toBe(0xFFFFFFFE);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

* fix(interop): Special case for pointers with address -1
    The "deleted" value of WeakGCMap's hashing function is -1
    and such pointer's cannot be added to the `_pointerToInstance` map.
    refs #921

* fix(interop): Construct Pointer from a wrapped number
    This adds support for the following syntax `interop.Pointer(new Number(number))`.

* fix(interop): Add methods `toHexString` and `toDecimalString` to Pointer
    This allows for correct serialization of pointers through strings. Which can be
    used for passing native objects to workers as discussed in https://github.com/NativeScript/ios-runtime/issues/620#issuecomment-449045591.
    The need for these methods arises from the fact that `toNumber` can't
    be used for negative pointer values, due to JavaScript's values
    inability to represent very large and/or negative 64-bit integer values
    as integers.
    
    There is a real-world use-case for the value of `-1` shown in #921
