### PR TITLE
fix: fix waitForDebugger handling

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -235,7 +235,6 @@ TNSCreateInspectorServer(TNSInspectorFrontendConnectedHandler connectedHandler,
       }
     });
     dispatch_source_set_cancel_handler(listenSource, ^{
-      isWaitingForDebugger = NO;
       listenSource = nil;
       close(listenSocket);
     });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
After the 5.1.1 releases of the CLI and the Runtime, the CLI is always sending `AttachRequest` before a debug session which is clearing the `listenSource`. In this way, the app is resumed and the `--debug-brk` flag is not working properly. 

## What is the new behavior?
In order to avoid that, we do not resume the app when closing the listening source anymore. It will be resumed only when a debugging client is attached or when the 30 secs timeout is reached.

