### PR TITLE
 feat(api): Provide API to release the native object wrapped by a JS one 

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -73,6 +73,7 @@ set(HEADER_FILES
     ObjC/Inheritance/ObjCClassBuilder.h
     ObjC/Inheritance/ObjCExtend.h
     ObjC/Inheritance/ObjCTypeScriptExtend.h
+    ObjC/Inheritance/TNSDerivedClassProtocol.h
 	ObjC/IsObjcObject.h
     ObjC/NSErrorWrapperConstructor.h
     ObjC/ObjCMethodCall.h
@@ -164,7 +165,7 @@ set(SOURCE_FILES
     Marshalling/Reference/IndexedRefPrototype.cpp
     Marshalling/Reference/ExtVectorTypeInstance.cpp
     Metadata/Metadata.mm
-    ObjC/AllocatedPlaceholder.cpp
+    ObjC/AllocatedPlaceholder.mm
     ObjC/Block/ObjCBlockCall.mm
     ObjC/Block/ObjCBlockCallback.cpp
     ObjC/Block/ObjCBlockType.mm

--- a/src/NativeScript/JSErrors.h
+++ b/src/NativeScript/JSErrors.h
@@ -22,6 +22,7 @@ void reportErrorIfAny(JSC::ExecState* execState, JSC::CatchScope& scope);
 void reportFatalErrorBeforeShutdown(JSC::ExecState*, JSC::Exception*, bool callJsUncaughtErrorCallback = true);
 void reportDiscardedError(JSC::ExecState* execState, GlobalObject* globalObject, JSC::Exception* exception);
 void dumpExecJsCallStack(JSC::ExecState* execState);
+std::string getExecJsCallStack(JSC::ExecState* execState);
 std::string dumpJsCallStack(const Inspector::ScriptCallStack& frames);
 std::string getCallStack(const Inspector::ScriptCallStack& frames);
 

--- a/src/NativeScript/JSErrors.mm
+++ b/src/NativeScript/JSErrors.mm
@@ -184,7 +184,7 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
                                                                                                    message.utf8().data(),
                                                                                                    jsCallstack.c_str()]
                                                                  reason:nil
-                                                                 userInfo:@{ @"sender": @"reportFatalErrorBeforeShutdown" }];
+                                                               userInfo:@{ @"sender": @"reportFatalErrorBeforeShutdown" }];
             @throw objcException;
         }
     }
@@ -192,6 +192,10 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
 
 void dumpExecJsCallStack(ExecState* execState) {
     dumpJsCallStack(createScriptCallStack(execState).get());
+}
+
+std::string getExecJsCallStack(ExecState* execState) {
+    return getCallStack(createScriptCallStack(execState).get());
 }
 
 std::string getCallStack(const Inspector::ScriptCallStack& frames) {
@@ -209,7 +213,7 @@ std::string getCallStack(const Inspector::ScriptCallStack& frames) {
 }
 
 std::string dumpJsCallStack(const Inspector::ScriptCallStack& frames) {
-    std::string jsCallstack  = getCallStack(frames);
+    std::string jsCallstack = getCallStack(frames);
 
     NSLog(@"%s", jsCallstack.c_str());
 

--- a/src/NativeScript/ObjC/AllocatedPlaceholder.h
+++ b/src/NativeScript/ObjC/AllocatedPlaceholder.h
@@ -35,21 +35,23 @@ public:
     }
 
 private:
-    id _wrappedObject;
-
-    JSC::WriteBarrier<JSC::Structure> _instanceStructure;
-
     AllocatedPlaceholder(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM& vm, GlobalObject* globalObject, id wrappedObject, JSC::Structure* instanceStructure) {
-        Base::finishCreation(vm);
-        this->_wrappedObject = wrappedObject;
-        this->_instanceStructure.set(vm, this, instanceStructure);
-    }
+    ~AllocatedPlaceholder();
+
+    void finishCreation(JSC::VM& vm, GlobalObject* globalObject, id wrappedObject, JSC::Structure* instanceStructure);
+
+    static void destroy(JSC::JSCell* cell);
 
     static void visitChildren(JSCell*, JSC::SlotVisitor&);
+
+    // Can't be a RetainPtr<id> because of issues with some types
+    // E.g. [NSTimer alloc] retain] causes an endless recursion on iPad (armv7) with iOS 10.3.3
+    id _wrappedObject;
+
+    JSC::WriteBarrier<JSC::Structure> _instanceStructure;
 };
 } // namespace NativeScript
 

--- a/src/NativeScript/ObjC/AllocatedPlaceholder.mm
+++ b/src/NativeScript/ObjC/AllocatedPlaceholder.mm
@@ -20,4 +20,18 @@ void AllocatedPlaceholder::visitChildren(JSCell* cell, JSC::SlotVisitor& visitor
 
     visitor.append(object->_instanceStructure);
 }
+
+void AllocatedPlaceholder::destroy(JSC::JSCell* cell) {
+    static_cast<AllocatedPlaceholder*>(cell)->~AllocatedPlaceholder();
+}
+
+void AllocatedPlaceholder::finishCreation(JSC::VM& vm, GlobalObject* globalObject, id wrappedObject, JSC::Structure* instanceStructure) {
+    Base::finishCreation(vm);
+    this->_wrappedObject = wrappedObject;
+    this->_instanceStructure.set(vm, this, instanceStructure);
+}
+
+AllocatedPlaceholder::~AllocatedPlaceholder() {
+}
+
 } // namespace NativeScript

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -7,6 +7,7 @@
 //
 
 #include "ObjCClassBuilder.h"
+#include "./TNSDerivedClassProtocol.h"
 #include "FFIType.h"
 #include "Interop.h"
 #include "Metadata.h"
@@ -22,10 +23,6 @@
 #include "TNSRuntime+Private.h"
 #include "TypeFactory.h"
 #include <sstream>
-
-@protocol TNSDerivedClass
-
-@end
 
 namespace NativeScript {
 using namespace JSC;
@@ -68,9 +65,6 @@ static void attachDerivedMachinery(GlobalObject* globalObject, Class newKlass, J
 
       Structure* instancesStructure = globalObject->constructorFor(blockKlass)->instancesStructure();
       auto derivedWrapper = ObjCWrapperObject::create(vm, instancesStructure, instance, globalObject);
-
-      /// TODO: This call might be unnecessary
-      gcProtect(derivedWrapper.get());
 
       Structure* superStructure = ObjCSuperObject::createStructure(vm, globalObject, superPrototype);
       auto superObject = ObjCSuperObject::create(vm, superStructure, derivedWrapper.get(), globalObject);

--- a/src/NativeScript/ObjC/Inheritance/TNSDerivedClassProtocol.h
+++ b/src/NativeScript/ObjC/Inheritance/TNSDerivedClassProtocol.h
@@ -1,0 +1,15 @@
+//
+//  TNSDerivedClassProtocol.h
+//  NativeScript
+//
+//  Created by Martin Bekchiev on 29.01.19.
+//
+
+#ifndef TNSDerivedClassProtocol_h
+#define TNSDerivedClassProtocol_h
+
+@protocol TNSDerivedClass
+
+@end
+
+#endif /* TNSDerivedClassProtocol_h */

--- a/src/NativeScript/ObjC/ObjCWrapperObject.h
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.h
@@ -33,9 +33,7 @@ public:
         return this->_wrappedObject.get();
     }
 
-    void setWrappedObject(id wrappedObject) {
-        this->_wrappedObject = wrappedObject;
-    }
+    void setWrappedObject(id wrappedObject);
 
     static WTF::String className(const JSObject* object, JSC::VM&);
 

--- a/src/NativeScript/ObjC/ObjCWrapperObject.h
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.h
@@ -35,6 +35,8 @@ public:
 
     void setWrappedObject(id wrappedObject);
 
+    void removeFromCache();
+
     static WTF::String className(const JSObject* object, JSC::VM&);
 
     ~ObjCWrapperObject();

--- a/src/NativeScript/ObjC/ObjCWrapperObject.mm
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.mm
@@ -48,6 +48,10 @@ bool ObjCWrapperObject::putByIndex(JSCell* cell, ExecState* execState, unsigned 
     return Base::putByIndex(cell, execState, propertyName, value, shouldThrow);
 }
 
+void ObjCWrapperObject::removeFromCache() {
+    this->_objectMap->remove(this->_wrappedObject.get());
+}
+
 void ObjCWrapperObject::setWrappedObject(id wrappedObject) {
     if (this->_wrappedObject) {
         this->_objectMap->remove(this->_wrappedObject.get());

--- a/src/NativeScript/ObjC/ObjCWrapperObject.mm
+++ b/src/NativeScript/ObjC/ObjCWrapperObject.mm
@@ -9,6 +9,7 @@
 #include "ObjCWrapperObject.h"
 #include "Interop.h"
 #include "ObjCTypes.h"
+#include "TNSDerivedClassProtocol.h"
 #include "TNSRuntime+Private.h"
 
 namespace NativeScript {
@@ -18,11 +19,10 @@ const ClassInfo ObjCWrapperObject::s_info = { "ObjCWrapperObject", &Base::s_info
 
 void ObjCWrapperObject::finishCreation(VM& vm, id wrappedObject, GlobalObject* globalObject) {
     Base::finishCreation(vm);
+    this->_objectMap = [TNSRuntime runtimeForVM:&globalObject->vm()] -> _objectMap.get();
     this->setWrappedObject(wrappedObject);
     this->_canSetObjectAtIndexedSubscript = [wrappedObject respondsToSelector:@selector(setObject:
-                                                                                        atIndexedSubscript:)];
-    this->_objectMap = [TNSRuntime runtimeForVM:&globalObject->vm()] -> _objectMap.get();
-    this->_objectMap->set(wrappedObject, this);
+                                                                                  atIndexedSubscript:)];
 }
 
 WTF::String ObjCWrapperObject::className(const JSObject* object, VM&) {
@@ -48,11 +48,38 @@ bool ObjCWrapperObject::putByIndex(JSCell* cell, ExecState* execState, unsigned 
     return Base::putByIndex(cell, execState, propertyName, value, shouldThrow);
 }
 
-ObjCWrapperObject::~ObjCWrapperObject() {
-    this->_objectMap->remove(this->wrappedObject());
+void ObjCWrapperObject::setWrappedObject(id wrappedObject) {
+    if (this->_wrappedObject) {
+        this->_objectMap->remove(this->_wrappedObject.get());
+
+        if ([this->_wrappedObject.get() conformsToProtocol:@protocol(TNSDerivedClass)] && [this->_wrappedObject retainCount] > 1) {
+            // Derived classes have additional logic for protecting JS counterparts in their retain/release methods when the retention
+            // count is above 1, after we remove the old wrapped object from the objectMap it will no longer be able to unprotect us
+            // and we do it here in order to become eligible for GC
+            gcUnprotect(this);
+        }
 #ifdef DEBUG_MEMORY
-    NSLog(@"ObjCWrapperObject soon releasing %@(%p)", object_getClass(this->_wrappedObject.get()), this->_wrappedObject.get());
+        NSLog(@"ObjCWrapperObject soon releasing %@(%p)", object_getClass(this->_wrappedObject.get()), this->_wrappedObject.get());
 #endif
-    Heap::heap(this)->releaseSoon(std::move(this->_wrappedObject));
+        Heap::heap(this)->releaseSoon(std::move(this->_wrappedObject));
+    }
+
+    this->_wrappedObject = wrappedObject;
+
+    if (wrappedObject) {
+        this->_objectMap->set(wrappedObject, this);
+
+        if ([wrappedObject conformsToProtocol:@protocol(TNSDerivedClass)] && [wrappedObject retainCount] > 1) {
+            // Derived classes have additional logic for protecting JS counterparts in their retain/release methods when the retention
+            // count is above 1,after we add the wrapped object to the objectMap we should add protect so that the unprotect in release
+            // is balanced out
+            gcProtect(this);
+        }
+    }
 }
+
+ObjCWrapperObject::~ObjCWrapperObject() {
+    this->setWrappedObject(nil);
+}
+
 }

--- a/tests/TestFixtures/CMakeLists.txt
+++ b/tests/TestFixtures/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     Interfaces/TNSConstructorResolution.h
     Interfaces/TNSInheritance.h
     Interfaces/TNSMethodCalls.h
+    Marshalling/TNSAllocLog.h
     Marshalling/TNSFunctionPointers.h
     Marshalling/TNSObjCTypes.h
     Marshalling/TNSPrimitivePointers.h
@@ -34,6 +35,7 @@ set(SOURCE_FILES
     Interfaces/TNSConstructorResolution.m
     Interfaces/TNSInheritance.m
     Interfaces/TNSMethodCalls.m
+    Marshalling/TNSAllocLog.m
     Marshalling/TNSFunctionPointers.m
     Marshalling/TNSObjCTypes.m
     Marshalling/TNSPrimitivePointers.m

--- a/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
+++ b/tests/TestFixtures/Interfaces/TNSClassWithPlaceholder.m
@@ -35,6 +35,12 @@
 
 #pragma clang diagnostic pop
 
+- (instancetype)retain {
+    TNSLog(@"retain on placeholder called");
+
+    return [super retain];
+}
+
 - (oneway void)release {
     [super release];
 

--- a/tests/TestFixtures/Marshalling/TNSAllocLog.h
+++ b/tests/TestFixtures/Marshalling/TNSAllocLog.h
@@ -1,0 +1,22 @@
+//
+//  TNSAllocLog.h
+//  NativeScript
+//
+//  Created by Martin Bekchiev on 1.02.19.
+//
+
+#ifndef TNSAllocLog_h
+#define TNSAllocLog_h
+
+@interface TNSAllocLog : NSObject
+
+// Disable ARC for TextFixtures.a and uncomment for debugging puproses
+//- (instancetype)retain;
+//- (void)release;
+
+- (instancetype)init;
+- (void)dealloc;
+
+@end
+
+#endif /* TNSAllocLog_h */

--- a/tests/TestFixtures/Marshalling/TNSAllocLog.m
+++ b/tests/TestFixtures/Marshalling/TNSAllocLog.m
@@ -1,0 +1,30 @@
+//
+//  TNSAllocLog.m
+//  NativeScript
+//
+//  Created by Martin Bekchiev on 1.02.19.
+//
+
+#import "TNSAllocLog.h"
+#import "../TNSTestCommon.h"
+
+@implementation TNSAllocLog
+
+// Disable ARC for TextFixtures.a and uncomment for debugging puproses
+//- (instancetype)retain {
+//    return [super retain];
+//}
+//- (void)release {
+//    [super release];
+//}
+
+- (instancetype)init {
+    TNSLog(@"TNSAllocLog init");
+    return [super init];
+}
+
+- (void)dealloc {
+    TNSLog(@"TNSAllocLog dealloc");
+}
+
+@end

--- a/tests/TestFixtures/TestFixtures.h
+++ b/tests/TestFixtures/TestFixtures.h
@@ -22,6 +22,7 @@
 #import "Interfaces/TNSInheritance.h"
 #import "Interfaces/TNSMethodCalls.h"
 
+#import "Marshalling/TNSAllocLog.h"
 #import "Marshalling/TNSFunctionPointers.h"
 #import "Marshalling/TNSObjCTypes.h"
 #import "Marshalling/TNSPrimitivePointers.h"

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -427,6 +427,55 @@ describe(module.id, function () {
         expect(str.normalize()).toBe(str);
     });
 
+    describe("__releaseNativeCounterpart", function () {
+        it("deallocates js derived instances created with alloc().init()", function () {
+            var P = TNSAllocLog.extend({
+                dealloc: function () {
+                    TNSAllocLog.dealloc.apply(this);
+                }
+            });
+
+            var p = P.alloc().init();
+
+            __releaseNativeCounterpart(p);
+
+            const output = TNSGetOutput();
+            expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
+        });
+
+        it("deallocates js derived instances created with new", function () {
+            var P = TNSAllocLog.extend({
+                dealloc: function () {
+                    TNSAllocLog.dealloc.apply(this);
+                }
+            });
+
+            var p = new P();
+
+            __releaseNativeCounterpart(p);
+
+            const output = TNSGetOutput();
+            expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
+        });
+
+        it("deallocates native instances created with alloc().init()", function () {
+            var p = TNSAllocLog.alloc().init();
+
+            __releaseNativeCounterpart(p);
+
+            const output = TNSGetOutput();
+            expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
+        });
+
+        it("deallocates native instances created with new", function () {
+            var p = new TNSAllocLog();
+
+            __releaseNativeCounterpart(p);
+
+            const output = TNSGetOutput();
+            expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
+        });
+    });
     describe("async", function () {
         it("should work", function (done) {
             var str = NSString.alloc();

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -3,7 +3,7 @@ describe("Constructing Objective-C classes with new operator", function () {
         TNSClearOutput();
     });
 
-    it("should not release the result of alloc", function () {
+    it("should release the result of alloc after GC", function () {
         var obj = new TNSClassWithPlaceholder();
 
         expect(obj.description).toBe("real");
@@ -59,16 +59,16 @@ describe("Constructing Objective-C classes with new operator", function () {
 
     it('allocAndNewMethodsRetaining', function () {
         var obj1 = new NSObject();
-        expect(obj1.retainCount()).toBe(1);
+        expect(obj1.retainCount()).toBe(1, "new NSObject()");
 
         var obj2 = NSObject.alloc();
-        expect(obj2.retainCount()).toBe(1);
+        expect(obj2.retainCount()).toBe(1, "NSObject.alloc()");
 
         var obj3 = NSObject.new();
-        expect(obj3.retainCount()).toBe(1);
+        expect(obj3.retainCount()).toBe(1, "NSObject.new()");
 
         var obj4 = NSObject.alloc().init();
-        expect(obj4.retainCount()).toBe(1);
+        expect(obj4.retainCount()).toBe(1, "NSObject.alloc().init()");
     });
 
     it('initializerResolving', function () {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

* Add missing `release` call in `constructObjCClass`
* Document why `AllocatedPlaceholder` can't `retain` it's wrapped instance
and why we don't call release after we create it.
* Add missing destructor call in `AllocatedPlaceholder::destroy`
* Add tests for `__releaseNativeCounterpart`
* Remove unneeded `gcProtect` call in `attachDerivedMachinery`

* fix(bridge): Remove ObjCWrapperObject from cache after dealloc

refs #1062