### PR TITLE
fix(api): Correct argument check in __releaseNativeCounterpart

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -133,7 +133,7 @@ static EncodedJSValue JSC_HOST_CALL releaseNativeCounterpart(ExecState* execStat
     }
 
     auto arg0 = execState->argument(0);
-    auto wrapper = jsCast<ObjCWrapperObject*>(arg0);
+    auto wrapper = jsDynamicCast<ObjCWrapperObject*>(execState->vm(), arg0);
     if (!wrapper) {
         auto scope = DECLARE_THROW_SCOPE(execState->vm());
         WTF::String message("Argument is an object which is not a native wrapper.");

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -475,6 +475,32 @@ describe(module.id, function () {
             const output = TNSGetOutput();
             expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
         });
+
+        it("throws when object is not a native wrapper", function () {
+            const expectedError = /argument.*not a native wrapper/i;
+            expect(() => __releaseNativeCounterpart(0)).toThrowError(expectedError);
+            expect(() => __releaseNativeCounterpart("")).toThrowError(expectedError);
+            expect(() => __releaseNativeCounterpart([])).toThrowError(expectedError);
+            expect(() => __releaseNativeCounterpart({})).toThrowError(expectedError);
+            expect(() => __releaseNativeCounterpart(null)).toThrowError(expectedError);
+            expect(() => __releaseNativeCounterpart(undefined)).toThrowError(expectedError);
+        });
+
+        it("sets object to nil", function () {
+            var arr = NSArray.arrayWithArray([1,2,3]);
+            expect(arr.count).toBe(3);
+            __releaseNativeCounterpart(arr);
+
+            expect(arr.toString()).toBe(null);
+            expect(typeof arr).toBe(typeof {});
+
+            // Extract from [Working with nil](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/WorkingwithObjects/WorkingwithObjects.html#//apple_ref/doc/uid/TP40011210-CH4-SW22):
+            // If you expect a return value from a message sent to nil, the return value will be
+            // nil for object return types, 0 for numeric types, and NO for BOOL types. Returned
+            // structures have all members initialized to zero.
+            expect(arr.count).toBe(0);
+        });
+
     });
     describe("async", function () {
         it("should work", function (done) {


### PR DESCRIPTION
* Change `jsCast` to `jsDynamicCast`
* Add tests for when the argument is not an ObjectiveC object
* Add test for checking that the JS wrapper's instance after
the release is set to `nil`

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

refs https://github.com/NativeScript/ios-runtime/issues/1062#issuecomment-461849820