### PR TITLE
fix(inspector): Catch and log inspector_modules.js loading errors

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.h
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.h
@@ -19,8 +19,9 @@ public:
     static bool logToSystemConsole();
     static void setLogToSystemConsole(bool);
 
-protected:
     virtual void messageWithTypeAndLevel(MessageType, MessageLevel, JSC::ExecState*, Ref<Inspector::ScriptArguments>&&) override;
+
+protected:
     virtual void count(JSC::ExecState*, Ref<Inspector::ScriptArguments>&&) override;
     virtual void profile(JSC::ExecState*, const String& title) override;
     virtual void profileEnd(JSC::ExecState*, const String& title) override;

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.h
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.h
@@ -26,6 +26,8 @@
 #ifndef GlobalObjectInspectorController_h
 #define GlobalObjectInspectorController_h
 
+#include "GlobalObjectConsoleClient.h"
+
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorAgentRegistry.h>
 #include <JavaScriptCore/InspectorEnvironment.h>
@@ -102,7 +104,7 @@ public:
     void pause();
     void reportAPIException(JSC::ExecState*, JSC::Exception*);
 
-    JSC::ConsoleClient* consoleClient() const {
+    GlobalObjectConsoleClient* consoleClient() const {
         return m_consoleClient.get();
     }
 
@@ -155,7 +157,7 @@ private:
     void appendAPIBacktrace(Inspector::ScriptCallStack* callStack);
 
     std::unique_ptr<Inspector::InjectedScriptManager> m_injectedScriptManager;
-    std::unique_ptr<JSC::ConsoleClient> m_consoleClient;
+    std::unique_ptr<GlobalObjectConsoleClient> m_consoleClient;
     Ref<WTF::Stopwatch> m_executionStopwatch;
     Inspector::JSGlobalObjectScriptDebugServer m_scriptDebugServer;
     Inspector::AgentRegistry m_agents;


### PR DESCRIPTION
`inspector_modules.js` is loaded whenever a new debugger connection is established.
When the application is built with `--bundle` however, the file is missing and debugging
is not working correctly. Log the rejection reason to the console so that errors with it don't
silently remain undetected in the future.

related to #1054, #1055, #1056, #1057

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.