### PR TITLE
fix(runtime): Respect availability attributes for protocols and base classes

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -89,7 +89,7 @@ JSC::EncodedJSValue JSC_HOST_CALL NSObjectAlloc(JSC::ExecState* execState) {
 
 static Strong<ObjCProtocolWrapper> createProtocolWrapper(GlobalObject* globalObject, const ProtocolMeta* protocolMeta, Protocol* aProtocol) {
     Structure* prototypeStructure = ObjCPrototype::createStructure(globalObject->vm(), globalObject, globalObject->objectPrototype());
-    auto prototype = ObjCPrototype::create(globalObject->vm(), globalObject, prototypeStructure, protocolMeta);
+    auto prototype = ObjCPrototype::create(globalObject->vm(), globalObject, prototypeStructure, protocolMeta, /*klass*/ nullptr);
     Structure* protocolWrapperStructure = ObjCProtocolWrapper::createStructure(globalObject->vm(), globalObject, globalObject->objectPrototype());
     auto protocolWrapper = ObjCProtocolWrapper::create(globalObject->vm(), protocolWrapperStructure, prototype.get(), protocolMeta, aProtocol);
     prototype->materializeProperties(globalObject->vm(), globalObject);

--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -693,15 +693,7 @@ public:
         return this->_constructorTokens.valuePtr();
     }
 
-    bool isImplementedInClass(Class klass, bool isStatic) const {
-        // class can be null for Protocol prototypes, treat all members in a protocol as implemented
-        if (klass == nullptr) {
-            return true;
-        }
-
-        return nullptr != (isStatic ? class_getClassMethod(klass, this->selector()) : class_getInstanceMethod(klass, this->selector()));
-    }
-
+    bool isImplementedInClass(Class klass, bool isStatic) const;
     bool isAvailableInClass(Class klass, bool isStatic) const {
         return this->isAvailable() && this->isImplementedInClass(klass, isStatic);
     }

--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -292,6 +292,12 @@ struct GlobalTable {
 
     const InterfaceMeta* findInterfaceMeta(const char* identifierString, size_t length, unsigned hash) const;
 
+    const ProtocolMeta* findProtocol(WTF::StringImpl* identifier) const;
+
+    const ProtocolMeta* findProtocol(const char* identifierString) const;
+
+    const ProtocolMeta* findProtocol(const char* identifierString, size_t length, unsigned hash) const;
+
     const Meta* findMeta(WTF::StringImpl* identifier, bool onlyIfAvailable = true) const;
 
     const Meta* findMeta(const char* identifierString, bool onlyIfAvailable = true) const;

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -283,10 +283,12 @@ vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>&
     if (firstInitIndex != -1) {
         for (int i = firstInitIndex; i < instanceMethods->count; i++) {
             const MethodMeta* method = instanceMethods.value()[i].valuePtr();
-            if (method->isInitializer() && method->isAvailableInClass(klass, /*isStatic*/ false)) {
-                container.push_back(method);
-            } else {
+            if (!method->isInitializer()) {
                 break;
+            }
+            
+            if (method->isAvailableInClass(klass, /*isStatic*/ false)) {
+                container.push_back(method);
             }
         }
     }

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -28,14 +28,12 @@ static UInt8 getSystemVersion() {
     UInt8 majorVersion = (UInt8)[versionTokens[0] intValue];
     UInt8 minorVersion = (UInt8)[versionTokens[1] intValue];
 
-    iosVersion = (majorVersion << 3) | minorVersion;
-
-    return iosVersion;
+    return encodeVersion(majorVersion, minorVersion);
 }
-std::unordered_map<std::string, std::vector<const MemberMeta*>> getMetasByJSNames(std::vector<const MemberMeta*> members) {
-    std::unordered_map<std::string, std::vector<const MemberMeta*>> result;
+std::unordered_map<std::string, MembersCollection> getMetasByJSNames(MembersCollection members) {
+    std::unordered_map<std::string, MembersCollection> result;
     for (auto member : members) {
-        result[member->jsName()].push_back(member);
+        result[member->jsName()].add(member);
     }
     return result;
 }
@@ -43,6 +41,42 @@ std::unordered_map<std::string, std::vector<const MemberMeta*>> getMetasByJSName
 static int compareIdentifiers(const char* nullTerminated, const char* notNullTerminated, size_t length) {
     int result = strncmp(nullTerminated, notNullTerminated, length);
     return (result == 0) ? strlen(nullTerminated) - length : result;
+}
+
+const InterfaceMeta* GlobalTable::findInterfaceMeta(WTF::StringImpl* identifier) const {
+    return this->findInterfaceMeta(reinterpret_cast<const char*>(identifier->characters8()), identifier->length(), identifier->hash());
+}
+
+const InterfaceMeta* GlobalTable::findInterfaceMeta(const char* identifierString) const {
+    unsigned hash = WTF::StringHasher::computeHashAndMaskTop8Bits<LChar>(reinterpret_cast<const LChar*>(identifierString));
+    return this->findInterfaceMeta(identifierString, strlen(identifierString), hash);
+}
+
+const InterfaceMeta* GlobalTable::findInterfaceMeta(const char* identifierString, size_t length, unsigned hash) const {
+    const Meta* meta = MetaFile::instance()->globalTable()->findMeta(identifierString, length, hash, /*onlyIfAvailable*/ false);
+    if (meta == nullptr) {
+        return nullptr;
+    }
+
+    assert(meta->type() == MetaType::Interface);
+    if (meta->type() != MetaType::Interface) {
+        return nullptr;
+    }
+
+    const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(meta);
+    if (interfaceMeta->isAvailable()) {
+        return interfaceMeta;
+    } else {
+        const char* baseName = static_cast<const InterfaceMeta*>(interfaceMeta)->baseName();
+
+        NSLog(@"** \"%s\" introduced in iOS SDK %d.%d is currently unavailable, attempting to load its base: \"%s\". **",
+              std::string(identifierString, length).c_str(),
+              getMajorVersion(interfaceMeta->introducedIn()),
+              getMinorVersion(interfaceMeta->introducedIn()),
+              baseName);
+
+        return this->findInterfaceMeta(baseName);
+    }
 }
 
 const Meta* GlobalTable::findMeta(WTF::StringImpl* identifier, bool onlyIfAvailable) const {
@@ -79,21 +113,9 @@ bool Meta::isAvailable() const {
 // BaseClassMeta
 const MemberMeta* BaseClassMeta::member(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable) const {
 
-    std::vector<const MemberMeta*> members = this->members(identifier, length, type, includeProtocols, onlyIfAvailable);
+    MembersCollection members = this->members(identifier, length, type, includeProtocols, onlyIfAvailable);
     ASSERT(members.size() <= 1);
-    return members.size() == 1 ? members[0] : nullptr;
-}
-const MethodMeta* BaseClassMeta::member(const char* identifier, size_t length, MemberType type, size_t paramsCount, bool includeProtocols, bool onlyIfAvailable) const {
-    const std::vector<const MemberMeta*> metas = this->members(identifier, length, type, includeProtocols, onlyIfAvailable);
-
-    if (metas.size() == 0) {
-        return nullptr;
-    }
-    const MemberMeta* result = Metadata::getProperFunctionFromContainer<const MemberMeta*>(metas, paramsCount, [&](const MemberMeta* const& meta) {
-        return ((MethodMeta*)meta)->encodings()->count - 1;
-    });
-
-    return (MethodMeta*)result;
+    return members.size() == 1 ? *members.begin() : nullptr;
 }
 
 void collectInheritanceChainMembers(const char* identifier, size_t length, MemberType type, bool onlyIfAvailable, const BaseClassMeta* derivedClass, std::function<void(const MemberMeta*)> collectMember) {
@@ -135,9 +157,9 @@ void collectInheritanceChainMembers(const char* identifier, size_t length, Membe
     }
 }
 
-const std::vector<const MemberMeta*> BaseClassMeta::members(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable) const {
+const MembersCollection BaseClassMeta::members(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable) const {
 
-    std::vector<const MemberMeta*> result;
+    MembersCollection result;
 
     if (type == MemberType::InstanceMethod || type == MemberType::StaticMethod) {
 
@@ -151,12 +173,12 @@ const std::vector<const MemberMeta*> BaseClassMeta::members(const char* identifi
             membersMap.emplace(method->encodings()->count, member);
         });
         for (std::map<int, const MemberMeta*>::iterator it = membersMap.begin(); it != membersMap.end(); ++it) {
-            result.push_back(it->second);
+            result.add(it->second);
         }
 
     } else { // member is a property
         collectInheritanceChainMembers(identifier, length, type, onlyIfAvailable, this, [&](const MemberMeta* member) {
-            result.push_back(member);
+            result.add(member);
         });
     }
 
@@ -169,9 +191,9 @@ const std::vector<const MemberMeta*> BaseClassMeta::members(const char* identifi
         for (Array<String>::iterator it = protocols->begin(); it != protocols->end(); ++it) {
             const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(MetaFile::instance()->globalTable()->findMeta((*it).valuePtr()));
             if (protocolMeta != nullptr) {
-                const std::vector<const MemberMeta*> members = protocolMeta->members(identifier, length, type, onlyIfAvailable);
+                const MembersCollection members = protocolMeta->members(identifier, length, type, onlyIfAvailable);
                 if (members.size() > 0) {
-                    result.insert(result.end(), members.begin(), members.end());
+                    result.add(members.begin(), members.end());
                 }
             }
         }
@@ -180,33 +202,33 @@ const std::vector<const MemberMeta*> BaseClassMeta::members(const char* identifi
     return result;
 }
 
-std::vector<const PropertyMeta*> BaseClassMeta::instancePropertiesWithProtocols(std::vector<const PropertyMeta*>& container) const {
-    this->instanceProperties(container);
+std::vector<const PropertyMeta*> BaseClassMeta::instancePropertiesWithProtocols(std::vector<const PropertyMeta*>& container, Class klass) const {
+    this->instanceProperties(container, klass);
     for (Array<String>::iterator it = protocols->begin(); it != protocols->end(); ++it) {
         const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(MetaFile::instance()->globalTable()->findMeta((*it).valuePtr(), false));
         if (protocolMeta != nullptr)
-            protocolMeta->instancePropertiesWithProtocols(container);
+            protocolMeta->instancePropertiesWithProtocols(container, klass);
     }
     return container;
 }
 
-std::vector<const PropertyMeta*> BaseClassMeta::staticPropertiesWithProtocols(std::vector<const PropertyMeta*>& container) const {
-    this->staticProperties(container);
+std::vector<const PropertyMeta*> BaseClassMeta::staticPropertiesWithProtocols(std::vector<const PropertyMeta*>& container, Class klass) const {
+    this->staticProperties(container, klass);
     for (Array<String>::iterator it = protocols->begin(); it != protocols->end(); ++it) {
         const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(MetaFile::instance()->globalTable()->findMeta((*it).valuePtr(), false));
         if (protocolMeta != nullptr)
-            protocolMeta->staticPropertiesWithProtocols(container);
+            protocolMeta->staticPropertiesWithProtocols(container, klass);
     }
     return container;
 }
 
-vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>& container) const {
+vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>& container, Class klass) const {
     // search in instance methods
     int16_t firstInitIndex = this->initializersStartIndex;
     if (firstInitIndex != -1) {
         for (int i = firstInitIndex; i < instanceMethods->count; i++) {
             const MethodMeta* method = instanceMethods.value()[i].valuePtr();
-            if (method->isInitializer()) {
+            if (method->isInitializer() && method->isAvailableInClass(klass, /*isStatic*/ false)) {
                 container.push_back(method);
             } else {
                 break;
@@ -216,12 +238,12 @@ vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>&
     return container;
 }
 
-vector<const MethodMeta*> BaseClassMeta::initializersWithProtcols(vector<const MethodMeta*>& container) const {
-    this->initializers(container);
+vector<const MethodMeta*> BaseClassMeta::initializersWithProtocols(vector<const MethodMeta*>& container, Class klass) const {
+    this->initializers(container, klass);
     for (Array<String>::iterator it = this->protocols->begin(); it != this->protocols->end(); it++) {
         const ProtocolMeta* protocolMeta = static_cast<const ProtocolMeta*>(MetaFile::instance()->globalTable()->findMeta((*it).valuePtr(), false));
         if (protocolMeta != nullptr)
-            protocolMeta->initializersWithProtcols(container);
+            protocolMeta->initializersWithProtocols(container, klass);
     }
     return container;
 }

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -68,7 +68,7 @@ const InterfaceMeta* GlobalTable::findInterfaceMeta(const char* identifierString
     if (interfaceMeta->isAvailable()) {
         return interfaceMeta;
     } else {
-        const char* baseName = static_cast<const InterfaceMeta*>(interfaceMeta)->baseName();
+        const char* baseName = interfaceMeta->baseName();
 
         NSLog(@"** \"%s\" introduced in iOS SDK %d.%d is currently unavailable, attempting to load its base: \"%s\". **",
               std::string(identifierString, length).c_str(),
@@ -286,7 +286,7 @@ vector<const MethodMeta*> BaseClassMeta::initializers(vector<const MethodMeta*>&
             if (!method->isInitializer()) {
                 break;
             }
-            
+
             if (method->isAvailableInClass(klass, /*isStatic*/ false)) {
                 container.push_back(method);
             }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -169,12 +169,10 @@ const WTF::Vector<WriteBarrier<ObjCConstructorWrapper>>& ObjCConstructorBase::in
         const Metadata::InterfaceMeta* metadata = this->metadata();
 
         do {
-            std::vector<const Metadata::MethodMeta*> initializers = metadata->initializersWithProtcols();
+            std::vector<const Metadata::MethodMeta*> initializers = metadata->initializersWithProtocols(this->klass());
             for (const Metadata::MethodMeta* method : initializers) {
-                if (method->isAvailable()) {
-                    auto constructorWrapper = ObjCConstructorWrapper::create(vm, globalObject, globalObject->objCConstructorWrapperStructure(), this->_klass, method);
-                    this->_initializers.append(WriteBarrier<ObjCConstructorWrapper>(vm, this, constructorWrapper.get()));
-                }
+                auto constructorWrapper = ObjCConstructorWrapper::create(vm, globalObject, globalObject->objCConstructorWrapperStructure(), this->_klass, method);
+                this->_initializers.append(WriteBarrier<ObjCConstructorWrapper>(vm, this, constructorWrapper.get()));
             }
 
             metadata = metadata->baseMeta();
@@ -216,9 +214,9 @@ static JSValue getInitializerForSwiftStyleConstruction(ExecState* execState, Obj
     std::vector<const Metadata::MethodMeta*> initializers;
     initializers.reserve(16);
     do {
-        interface->initializersWithProtcols(initializers);
+        interface->initializersWithProtocols(initializers, constructor->klass());
         for (const Metadata::MethodMeta* method : initializers) {
-            if (method->isAvailable() && strcmp(method->constructorTokens(), ctorMetadata.data()) == 0) {
+            if (strcmp(method->constructorTokens(), ctorMetadata.data()) == 0) {
                 result = method;
                 break;
             }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
@@ -105,7 +105,7 @@ void ObjCConstructorNative::getOwnPropertyNames(JSObject* object, ExecState* exe
         }
 
         for (Array<Metadata::String>::iterator it = baseClassMeta->protocols->begin(); it != baseClassMeta->protocols->end(); it++) {
-            const ProtocolMeta* protocolMeta = (const ProtocolMeta*)MetaFile::instance()->globalTable()->findMeta((*it).valuePtr());
+            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTable()->findProtocol((*it).valuePtr());
             if (protocolMeta != nullptr) {
                 baseClassMetaStack.push_back(protocolMeta);
             }

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.h
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.h
@@ -47,6 +47,8 @@ public:
 
     ObjCConstructorDerived* build(JSC::ExecState*);
 
+    Class klass();
+
 private:
     JSC::Strong<ObjCConstructorDerived> _constructor;
 

--- a/src/NativeScript/ObjC/ObjCMethodCall.h
+++ b/src/NativeScript/ObjC/ObjCMethodCall.h
@@ -12,24 +12,20 @@
 #include "FFICall.h"
 #include "FunctionWrapper.h"
 #include "JavaScriptCore/IsoSubspace.h"
-
-namespace Metadata {
-struct MemberMeta;
-struct MethodMeta;
-} // namespace Metadata
+#include "Metadata.h"
 
 namespace NativeScript {
 class ObjCMethodWrapper : public FunctionWrapper {
 public:
     typedef FunctionWrapper Base;
 
-    static JSC::Strong<ObjCMethodWrapper> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, std::vector<const Metadata::MemberMeta*> metadata) {
+    static JSC::Strong<ObjCMethodWrapper> create(JSC::VM& vm, GlobalObject* globalObject, JSC::Structure* structure, Metadata::MembersCollection metadata) {
         JSC::Strong<ObjCMethodWrapper> cell(vm, new (NotNull, JSC::allocateCell<ObjCMethodWrapper>(vm.heap)) ObjCMethodWrapper(vm, structure));
         cell->finishCreation(vm, globalObject, metadata);
         return cell;
     }
 
-    static Strong<ObjCMethodWrapper> create(JSC::ExecState* execState, std::vector<const Metadata::MemberMeta*> metadata) {
+    static Strong<ObjCMethodWrapper> create(JSC::ExecState* execState, Metadata::MembersCollection metadata) {
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
         return create(execState->vm(), globalObject, globalObject->objCMethodWrapperStructure(), metadata);
     }
@@ -50,7 +46,7 @@ private:
         : Base(vm, structure) {
     }
 
-    void finishCreation(JSC::VM&, GlobalObject*, std::vector<const Metadata::MemberMeta*> methods);
+    void finishCreation(JSC::VM&, GlobalObject*, Metadata::MembersCollection methods);
 
     static void preInvocation(FFICall*, JSC::ExecState*, FFICall::Invocation&);
     static void postInvocation(FFICall*, JSC::ExecState*, FFICall::Invocation&);

--- a/src/NativeScript/ObjC/ObjCMethodCall.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCall.mm
@@ -25,9 +25,9 @@ using namespace Metadata;
 
 const ClassInfo ObjCMethodWrapper::s_info = { "ObjCMethodWrapper", &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(ObjCMethodWrapper) };
 
-void ObjCMethodWrapper::finishCreation(VM& vm, GlobalObject* globalObject, std::vector<const MemberMeta*> methods) {
+void ObjCMethodWrapper::finishCreation(VM& vm, GlobalObject* globalObject, MembersCollection methods) {
     ASSERT(methods.size() > 0);
-    Base::finishCreation(vm, methods.front()->jsName());
+    Base::finishCreation(vm, (*methods.begin())->jsName());
 
     size_t maxParamsCount = 0;
     for (auto m : methods) {
@@ -146,12 +146,7 @@ void ObjCMethodWrapper::preInvocation(FFICall* callee, ExecState* execState, FFI
         bool isInstance = !class_isMetaClass(object_getClass(target));
         NSLog(@"> %@[%@ %@]", isInstance ? @"-" : @"+", NSStringFromClass(object_getClass(target)), NSStringFromSelector(call->_selector));
 #endif
-        if (call->_isOptional && ![target respondsToSelector:call->_selector]) {
-            // Unimplemented optional method: Silently perform a dummy call to nil object
-            invocation.setArgument(0, nil);
-        } else {
-            invocation.setArgument(0, target);
-        }
+        invocation.setArgument(0, target);
         invocation.setArgument(1, call->_selector);
         invocation.function = call->_msgSend;
     }

--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -56,7 +56,7 @@ void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyNam
     ObjCMethodWrapper* wrapper = jsDynamicCast<ObjCMethodWrapper*>(execState->vm(), object->get(execState, propertyName));
     Strong<ObjCMethodWrapper> strongWrapper;
     if (!wrapper) {
-        std::vector<const Metadata::MemberMeta*> methodMetas;
+        MembersCollection methodMetas;
 
         auto currentClass = meta;
         do {

--- a/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
+++ b/src/NativeScript/ObjC/ObjCProtocolWrapper.mm
@@ -42,9 +42,9 @@ bool ObjCProtocolWrapper::getOwnPropertySlot(JSObject* object, ExecState* execSt
 
     ObjCProtocolWrapper* protocol = jsCast<ObjCProtocolWrapper*>(object);
 
-    std::vector<const MemberMeta*> metas = protocol->_metadata->getStaticMethods(propertyName.publicName());
+    MembersCollection metas = protocol->_metadata->getStaticMethods(propertyName.publicName(), nullptr);
     if (metas.size() > 0) {
-        SymbolLoader::instance().ensureModule(metas[0]->topLevelModule());
+        SymbolLoader::instance().ensureModule((*metas.begin())->topLevelModule());
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
 

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -23,8 +23,8 @@ public:
 
     static const unsigned StructureFlags;
 
-    static JSC::Strong<ObjCPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::BaseClassMeta* metadata) {
-        JSC::Strong<ObjCPrototype> prototype(vm, new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure));
+    static JSC::Strong<ObjCPrototype> create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const Metadata::BaseClassMeta* metadata, Class klass) {
+        JSC::Strong<ObjCPrototype> prototype(vm, new (NotNull, JSC::allocateCell<ObjCPrototype>(globalObject->vm().heap)) ObjCPrototype(globalObject->vm(), structure, klass));
         prototype->finishCreation(vm, globalObject, metadata);
         return prototype;
     }
@@ -39,13 +39,18 @@ public:
 
     void materializeProperties(JSC::VM& vm, GlobalObject* globalObject);
 
-    const Metadata::BaseClassMeta* metadata() {
+    const Metadata::BaseClassMeta* metadata() const {
         return this->_metadata;
     }
 
+    Class klass() const {
+        return this->_klass;
+    }
+
 private:
-    ObjCPrototype(JSC::VM& vm, JSC::Structure* structure)
-        : Base(vm, structure) {
+    ObjCPrototype(JSC::VM& vm, JSC::Structure* structure, Class klass)
+        : Base(vm, structure)
+        , _klass(klass) {
     }
 
     void finishCreation(JSC::VM&, JSC::JSGlobalObject*, const Metadata::BaseClassMeta*);
@@ -59,6 +64,8 @@ private:
     static void getOwnPropertyNames(JSC::JSObject*, JSC::ExecState*, JSC::PropertyNameArray&, JSC::EnumerationMode);
 
     const Metadata::BaseClassMeta* _metadata;
+
+    Class _klass;
 };
 } // namespace NativeScript
 

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -162,7 +162,7 @@ void ObjCPrototype::getOwnPropertyNames(JSObject* object, ExecState* execState, 
         }
 
         for (Metadata::Array<Metadata::String>::iterator it = baseClassMeta->protocols->begin(); it != baseClassMeta->protocols->end(); it++) {
-            const ProtocolMeta* protocolMeta = (const ProtocolMeta*)MetaFile::instance()->globalTable()->findMeta((*it).valuePtr());
+            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTable()->findProtocol((*it).valuePtr());
             if (protocolMeta != nullptr)
                 baseClassMetaStack.push_back(protocolMeta);
         }

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -61,23 +61,15 @@ bool ObjCPrototype::getOwnPropertySlot(JSObject* object, ExecState* execState, P
 
     ObjCPrototype* prototype = jsCast<ObjCPrototype*>(object);
 
-    std::vector<const MemberMeta*> methods = prototype->_metadata->getInstanceMethods(propertyName.publicName());
+    MembersCollection methods = prototype->_metadata->getInstanceMethods(propertyName.publicName(), prototype->klass());
 
     if (methods.size() > 0) {
+        SymbolLoader::instance().ensureModule((*methods.begin())->topLevelModule());
 
-        std::unordered_map<std::string, std::vector<const MemberMeta*>> metasByJsName = Metadata::getMetasByJSNames(methods);
-
-        for (auto& methodNameAndMetas : metasByJsName) {
-            std::vector<const MemberMeta*>& metas = methodNameAndMetas.second;
-
-            ASSERT(metas.size() > 0);
-            SymbolLoader::instance().ensureModule(metas[0]->topLevelModule());
-
-            GlobalObject* globalObject = jsCast<GlobalObject*>(prototype->globalObject());
-            auto method = ObjCMethodWrapper::create(globalObject->vm(), globalObject, globalObject->objCMethodWrapperStructure(), metas);
-            object->putDirect(execState->vm(), propertyName, method.get());
-            propertySlot.setValue(object, static_cast<unsigned>(PropertyAttribute::None), method.get());
-        }
+        GlobalObject* globalObject = jsCast<GlobalObject*>(prototype->globalObject());
+        auto method = ObjCMethodWrapper::create(globalObject->vm(), globalObject, globalObject->objCMethodWrapperStructure(), methods);
+        object->putDirect(execState->vm(), propertyName, method.get());
+        propertySlot.setValue(object, static_cast<unsigned>(PropertyAttribute::None), method.get());
 
         return true;
     }
@@ -108,13 +100,13 @@ bool ObjCPrototype::put(JSCell* cell, ExecState* execState, PropertyName propert
 bool ObjCPrototype::defineOwnProperty(JSObject* object, ExecState* execState, PropertyName propertyName, const PropertyDescriptor& propertyDescriptor, bool shouldThrow) {
     ObjCPrototype* prototype = jsCast<ObjCPrototype*>(object);
     VM& vm = execState->vm();
+    Class klass = prototype->klass();
 
-    if (const PropertyMeta* propertyMeta = prototype->_metadata->instanceProperty(propertyName.publicName())) {
+    if (const PropertyMeta* propertyMeta = prototype->_metadata->instanceProperty(propertyName.publicName(), klass)) {
         if (!propertyDescriptor.isAccessorDescriptor()) {
             WTFCrash();
         }
 
-        Class klass = jsCast<ObjCConstructorBase*>(prototype->get(execState, execState->vm().propertyNames->constructor))->klass();
         PropertyDescriptor nativeProperty;
         prototype->getOwnPropertyDescriptor(execState, propertyName, nativeProperty);
 
@@ -150,6 +142,7 @@ bool ObjCPrototype::defineOwnProperty(JSObject* object, ExecState* execState, Pr
 
 void ObjCPrototype::getOwnPropertyNames(JSObject* object, ExecState* execState, PropertyNameArray& propertyNames, EnumerationMode enumerationMode) {
     ObjCPrototype* prototype = jsCast<ObjCPrototype*>(object);
+    Class klass = prototype->klass();
 
     std::vector<const BaseClassMeta*> baseClassMetaStack;
     baseClassMetaStack.push_back(prototype->_metadata);
@@ -159,12 +152,12 @@ void ObjCPrototype::getOwnPropertyNames(JSObject* object, ExecState* execState, 
         baseClassMetaStack.pop_back();
 
         for (Metadata::ArrayOfPtrTo<MethodMeta>::iterator it = baseClassMeta->instanceMethods->begin(); it != baseClassMeta->instanceMethods->end(); it++) {
-            if ((*it)->isAvailable())
+            if ((*it)->isAvailableInClass(klass, /*isStatic*/ false))
                 propertyNames.add(Identifier::fromString(execState, (*it)->jsName()));
         }
 
         for (Metadata::ArrayOfPtrTo<PropertyMeta>::iterator it = baseClassMeta->instanceProps->begin(); it != baseClassMeta->instanceProps->end(); it++) {
-            if ((*it)->isAvailable())
+            if ((*it)->isAvailableInClass(klass, /*isStatic*/ false))
                 propertyNames.add(Identifier::fromString(execState, (*it)->jsName()));
         }
 
@@ -179,33 +172,31 @@ void ObjCPrototype::getOwnPropertyNames(JSObject* object, ExecState* execState, 
 }
 
 void ObjCPrototype::materializeProperties(VM& vm, GlobalObject* globalObject) {
-    std::vector<const PropertyMeta*> properties = this->_metadata->instancePropertiesWithProtocols();
+    std::vector<const PropertyMeta*> properties = this->_metadata->instancePropertiesWithProtocols(this->klass());
 
     for (const PropertyMeta* propertyMeta : properties) {
-        if (propertyMeta->isAvailable()) {
-            SymbolLoader::instance().ensureModule(propertyMeta->topLevelModule());
+        SymbolLoader::instance().ensureModule(propertyMeta->topLevelModule());
 
-            const MethodMeta* getter = (propertyMeta->getter() != nullptr && propertyMeta->getter()->isAvailable()) ? propertyMeta->getter() : nullptr;
-            const MethodMeta* setter = (propertyMeta->setter() != nullptr && propertyMeta->setter()->isAvailable()) ? propertyMeta->setter() : nullptr;
+        const MethodMeta* getter = (propertyMeta->getter() != nullptr && propertyMeta->getter()->isAvailable()) ? propertyMeta->getter() : nullptr;
+        const MethodMeta* setter = (propertyMeta->setter() != nullptr && propertyMeta->setter()->isAvailable()) ? propertyMeta->setter() : nullptr;
 
-            PropertyDescriptor descriptor;
-            descriptor.setConfigurable(true);
-            Strong<ObjCMethodWrapper> strongGetter;
-            Strong<ObjCMethodWrapper> strongSetter;
-            if (getter) {
-                std::vector<const MemberMeta*> getters(1, getter);
-                strongGetter = ObjCMethodWrapper::create(vm, globalObject, globalObject->objCMethodWrapperStructure(), getters);
-                descriptor.setGetter(strongGetter.get());
-            }
-
-            if (setter) {
-                std::vector<const MemberMeta*> setters(1, setter);
-                strongSetter = ObjCMethodWrapper::create(vm, globalObject, globalObject->objCMethodWrapperStructure(), setters);
-                descriptor.setSetter(strongSetter.get());
-            }
-
-            Base::defineOwnProperty(this, globalObject->globalExec(), Identifier::fromString(globalObject->globalExec(), propertyMeta->jsName()), descriptor, false);
+        PropertyDescriptor descriptor;
+        descriptor.setConfigurable(true);
+        Strong<ObjCMethodWrapper> strongGetter;
+        Strong<ObjCMethodWrapper> strongSetter;
+        if (getter) {
+            MembersCollection getters = { getter };
+            strongGetter = ObjCMethodWrapper::create(vm, globalObject, globalObject->objCMethodWrapperStructure(), getters);
+            descriptor.setGetter(strongGetter.get());
         }
+
+        if (setter) {
+            MembersCollection setters = { setter };
+            strongSetter = ObjCMethodWrapper::create(vm, globalObject, globalObject->objCMethodWrapperStructure(), setters);
+            descriptor.setSetter(strongSetter.get());
+        }
+
+        Base::defineOwnProperty(this, globalObject->globalExec(), Identifier::fromString(globalObject->globalExec(), propertyMeta->jsName()), descriptor, false);
     }
 }
 }

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -247,7 +247,7 @@ Strong<ObjCConstructorNative> TypeFactory::getObjCNativeConstructor(GlobalObject
 
     VM& vm = globalObject->vm();
 
-    const InterfaceMeta* metadata = static_cast<const InterfaceMeta*>(MetaFile::instance()->globalTable()->findMeta(klassName.impl()));
+    const InterfaceMeta* metadata = MetaFile::instance()->globalTable()->findInterfaceMeta(klassName.impl());
     Class klass = Nil;
 
     if (metadata) {
@@ -289,7 +289,7 @@ Strong<ObjCConstructorNative> TypeFactory::getObjCNativeConstructor(GlobalObject
     }
 
     Structure* prototypeStructure = ObjCPrototype::createStructure(vm, globalObject, parentPrototype);
-    auto prototype = ObjCPrototype::create(vm, globalObject, prototypeStructure, metadata);
+    auto prototype = ObjCPrototype::create(vm, globalObject, prototypeStructure, metadata, klass);
 
     Structure* constructorStructure = ObjCConstructorNative::createStructure(vm, globalObject, parentConstructor);
     auto constructor = ObjCConstructorNative::create(vm, globalObject, constructorStructure, prototype.get(), klass);

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -259,6 +259,9 @@ Strong<ObjCConstructorNative> TypeFactory::getObjCNativeConstructor(GlobalObject
     }
 
     if (!metadata || !klass) {
+        if (klassName == "NSObject") {
+            @throw [NSException exceptionWithName:NSGenericException reason:@"fatal error: NativeScript cannot create constructor for NSObject." userInfo:nil];
+        }
 #ifdef DEBUG
         NSLog(@"** Can not create constructor for \"%@\". Casting it to \"NSObject\". **", klassName.createCFString().autorelease());
 #endif

--- a/tests/TestFixtures/Api/TNSVersions.h
+++ b/tests/TestFixtures/Api/TNSVersions.h
@@ -6,50 +6,53 @@
 //  Copyright (c) 2015 Jason Zhekov. All rights reserved.
 //
 
-#define generateVersionDeclarations(V1, V2)                                                                                           \
-    __attribute__((availability(ios, introduced = V1)))                                                                               \
-        @interface TNSInterface##V2##Plus : NSObject                                                                                  \
-                                            @end                                                                                      \
-                                                                                                                                      \
-                                            @interface TNSInterfaceMembers##V2 : NSObject                                             \
-                                                                                 @property int property                               \
-                                                                                 __attribute__((availability(ios, introduced = V1))); \
-                                                                                                                                      \
-    +(void)staticMethod                                                                                                               \
-        __attribute__((availability(ios, introduced = V1)));                                                                          \
-                                                                                                                                      \
-    -(void)instanceMethod                                                                                                             \
-        __attribute__((availability(ios, introduced = V1)));                                                                          \
-    @end                                                                                                                              \
-                                                                                                                                      \
-        __attribute__((availability(ios, introduced = V1))) void TNSFunction##V2##Plus();                                             \
-                                                                                                                                      \
-    __attribute__((availability(ios, introduced = V1))) extern const int TNSConstant##V2##Plus;                                       \
-                                                                                                                                      \
-    enum TNSEnum##V2##Plus {                                                                                                          \
-        TNSEnum##V2##Member                                                                                                           \
-    }                                                                                                                                 \
+#define generateVersionDeclarations(V1, V2)                                                     \
+    __attribute__((availability(ios, introduced = V1)))                                         \
+        @interface TNSInterface                                                                 \
+    ##V2##Plus : NSObject                                                                       \
+                 @end                                                                           \
+                                                                                                \
+    @interface TNSInterfaceMembers                                                              \
+    ##V2 : NSObject                                                                             \
+           @property int property                                                               \
+           __attribute__((availability(ios, introduced = V1)));                                 \
+                                                                                                \
+    +(void)staticMethod                                                                         \
+        __attribute__((availability(ios, introduced = V1)));                                    \
+                                                                                                \
+    -(void)instanceMethod                                                                       \
+        __attribute__((availability(ios, introduced = V1)));                                    \
+    @end                                                                                        \
+                                                                                                \
+    __attribute__((availability(ios, introduced = V1))) void TNSFunction##V2##Plus();           \
+                                                                                                \
+    __attribute__((availability(ios, introduced = V1))) extern const int TNSConstant##V2##Plus; \
+                                                                                                \
+    enum TNSEnum##V2##Plus {                                                                    \
+        TNSEnum##V2##Member                                                                     \
+    }                                                                                           \
     __attribute__((availability(ios, introduced = V1)))
 
 #ifndef generateVersionImpl
 #define generateVersion(V1, V2) \
     generateVersionDeclarations(V1, V2)
 #else
-#define generateVersion(V1, V2)                 \
-    generateVersionDeclarations(V1, V2);        \
-                                                \
-    @implementation TNSInterface                \
-    ##V2##Plus                                  \
-        @end                                    \
-                                                \
-        @implementation TNSInterfaceMembers##V2 \
-        + (void)staticMethod{}                  \
-                                                \
-        - (void)instanceMethod {}               \
-    @end                                        \
-                                                \
-    void TNSFunction##V2##Plus() {}             \
-                                                \
+#define generateVersion(V1, V2)          \
+    generateVersionDeclarations(V1, V2); \
+                                         \
+    @implementation TNSInterface         \
+    ##V2##Plus                           \
+        @end                             \
+                                         \
+    @implementation TNSInterfaceMembers  \
+    ##V2                                 \
+        + (void)staticMethod{}           \
+                                         \
+        - (void)instanceMethod {}        \
+    @end                                 \
+                                         \
+    void TNSFunction##V2##Plus() {}      \
+                                         \
     const int TNSConstant##V2##Plus = 0
 #endif
 
@@ -68,3 +71,19 @@ generateMinors(12);
 generateMinors(13);
 generateMinors(14);
 generateMinors(15);
+
+// max availability version that can be currently represented in the binary metadata is 31.7 (major << 3 | minor) -> uint8_t
+#define MAX_AVAILABILITY 31.7
+
+@interface TNSInterfaceAlwaysAvailable : NSObject
+@end
+
+__attribute__((availability(ios, introduced = MAX_AVAILABILITY)))
+@interface TNSInterfaceNeverAvailable : TNSInterfaceAlwaysAvailable
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+@interface TNSInterfaceNeverAvailableDescendant : TNSInterfaceNeverAvailable
+@end
+#pragma clang diagnostic pop

--- a/tests/TestFixtures/Api/TNSVersions.h
+++ b/tests/TestFixtures/Api/TNSVersions.h
@@ -75,7 +75,37 @@ generateMinors(15);
 // max availability version that can be currently represented in the binary metadata is 31.7 (major << 3 | minor) -> uint8_t
 #define MAX_AVAILABILITY 31.7
 
-@interface TNSInterfaceAlwaysAvailable : NSObject
+__attribute__((availability(ios, introduced = MAX_AVAILABILITY)))
+@protocol TNSProtocolNeverAvailable<NSObject>
+
+@property(class, readonly) int staticPropertyFromProtocolNeverAvailable;
+@property(class, readonly) int staticPropertyFromProtocolNeverAvailableNotImplemented;
+
++ (void)staticMethodFromProtocolNeverAvailable;
++ (void)staticMethodFromProtocolNeverAvailableNotImplemented;
+
+@property(readonly) int propertyFromProtocolNeverAvailable;
+@property(readonly) int propertyFromProtocolNeverAvailableNotImplemented;
+
+- (void)methodFromProtocolNeverAvailable;
+- (void)methodFromProtocolNeverAvailableNotImplemented;
+
+@end
+
+__attribute__((availability(ios, introduced = 1.0)))
+@protocol TNSProtocolAlwaysAvailable<NSObject>
+
+@property(class, readonly) int staticPropertyFromProtocolAlwaysAvailable;
+
++ (void)staticMethodFromProtocolAlwaysAvailable;
+
+@property(readonly) int propertyFromProtocolAlwaysAvailable;
+
+- (void)methodFromProtocolAlwaysAvailable;
+
+@end
+
+@interface TNSInterfaceAlwaysAvailable : NSObject <TNSProtocolNeverAvailable, TNSProtocolAlwaysAvailable>
 @end
 
 __attribute__((availability(ios, introduced = MAX_AVAILABILITY)))

--- a/tests/TestFixtures/Api/TNSVersions.m
+++ b/tests/TestFixtures/Api/TNSVersions.m
@@ -9,3 +9,12 @@
 #define generateVersionImpl
 #import "TNSVersions.h"
 #undef generateVersionImpl
+
+@implementation TNSInterfaceAlwaysAvailable
+@end
+
+@implementation TNSInterfaceNeverAvailable : TNSInterfaceAlwaysAvailable
+@end
+
+@implementation TNSInterfaceNeverAvailableDescendant : TNSInterfaceNeverAvailable
+@end

--- a/tests/TestFixtures/Api/TNSVersions.m
+++ b/tests/TestFixtures/Api/TNSVersions.m
@@ -10,7 +10,44 @@
 #import "TNSVersions.h"
 #undef generateVersionImpl
 
+#pragma clang diagnostic push
+// Ignore warnings about not implemented required protocol members.
+// Those coming from TNSProtocolNeverAvailable are intentionally left unimplemented
+#pragma clang diagnostic ignored "-Wobjc-protocol-property-synthesis"
+#pragma clang diagnostic ignored "-Wobjc-property-implementation"
+#pragma clang diagnostic ignored "-Wprotocol"
+
 @implementation TNSInterfaceAlwaysAvailable
+
++ (int)staticPropertyFromProtocolAlwaysAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+    return 12;
+}
+
++ (int)staticPropertyFromProtocolNeverAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+    return 23;
+}
+
++ (void)staticMethodFromProtocolAlwaysAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
++ (void)staticMethodFromProtocolNeverAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
+@synthesize propertyFromProtocolAlwaysAvailable;
+@synthesize propertyFromProtocolNeverAvailable;
+
+- (void)methodFromProtocolAlwaysAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
+- (void)methodFromProtocolNeverAvailable {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
 @end
 
 @implementation TNSInterfaceNeverAvailable : TNSInterfaceAlwaysAvailable
@@ -18,3 +55,5 @@
 
 @implementation TNSInterfaceNeverAvailableDescendant : TNSInterfaceNeverAvailable
 @end
+
+#pragma clang diagnostic pop

--- a/tests/TestFixtures/Interfaces/TNSConstructorResolution.h
+++ b/tests/TestFixtures/Interfaces/TNSConstructorResolution.h
@@ -11,7 +11,21 @@ typedef struct TNSCStructure {
     int y;
 } TNSCStructure;
 
-@interface TNSCInterface : NSObject
+@protocol TNSCProtocol
+// Ensure we have unimplemented methods before and after
+// the implemented ones (in alphabetical order)
+@optional
+- (id)initAWithIntNotImplemented:(int)x andInt:(int)y andInt:(int)z;
+
+@required
+- (id)initWithInt:(int)x andInt:(int)y;
+
+@optional
+- (id)initWithStringOptional:(NSString*)x andString:(NSString*)y;
+- (id)initZWithIntNotImplemented:(int)x andInt:(int)y andInt:(int)z;
+@end
+
+@interface TNSCInterface : NSObject <TNSCProtocol>
 - (id)initWithEmpty;
 - (id)initWithPrimitive:(int)x;
 - (id)initWithStructure:(TNSCStructure)x;

--- a/tests/TestFixtures/Interfaces/TNSConstructorResolution.m
+++ b/tests/TestFixtures/Interfaces/TNSConstructorResolution.m
@@ -38,4 +38,15 @@
     }
     return [super init];
 }
+
+- (id)initWithInt:(int)x andInt:(int)y {
+    TNSLog([NSString stringWithFormat:@"%@ %d %d called", NSStringFromSelector(_cmd), x, y]);
+    return [super init];
+}
+
+- (id)initWithStringOptional:(NSString*)x andString:(NSString*)y {
+    TNSLog([NSString stringWithFormat:@"%@ %@ %@ called", NSStringFromSelector(_cmd), x, y]);
+    return [super init];
+}
+
 @end

--- a/tests/TestFixtures/Interfaces/TNSInheritance.h
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.h
@@ -20,6 +20,16 @@
 @protocol TNSIBaseProtocol
 
 @optional
+@property(class) int staticBaseImplementedOptionalProperty;
+@property(class) int staticBaseNotImplementedOptionalProperty;
+
++ (void)staticBaseImplementedOptionalMethod;
++ (void)staticBaseNotImplementedOptionalMethod;
++ (void)staticBaseNotImplementedOptionalMethodImplementedInJavaScript;
+
+@property int baseImplementedOptionalProperty;
+@property int baseNotImplementedOptionalProperty;
+
 - (void)baseImplementedOptionalMethod;
 - (void)baseNotImplementedOptionalMethod;
 - (void)baseNotImplementedOptionalMethodImplementedInJavaScript;
@@ -29,6 +39,9 @@
 @end
 
 @interface TNSIBaseInterface (TNSIBaseCategory)
++ (void)staticBaseImplementedCategoryMethod;
++ (void)staticBaseNotImplementedCategoryMethod;
+
 - (void)baseImplementedCategoryMethod;
 - (void)baseNotImplementedCategoryMethod;
 - (void)baseNotImplementedNativeCategoryMethodOverridenInJavaScript;
@@ -37,15 +50,25 @@
 @protocol TNSIDerivedProtocol
 
 @optional
++ (void)staticDerivedImplementedOptionalMethod;
++ (void)staticDerivedNotImplementedOptionalMethod;
+@property(class) int staticDerivedImplementedOptionalProperty;
+@property(class) int staticDerivedNotImplementedOptionalProperty;
+
 - (void)derivedImplementedOptionalMethod;
 - (void)derivedNotImplementedOptionalMethod;
 - (void)derivedNotImplementedOptionalMethodImplementedInJavaScript;
+@property int derivedImplementedOptionalProperty;
+@property int derivedNotImplementedOptionalProperty;
 @end
 
 @interface TNSIDerivedInterface : TNSIBaseInterface <TNSIDerivedProtocol>
 @end
 
 @interface TNSIDerivedInterface (TNSIDerivedCategory)
++ (void)staticDerivedImplementedCategoryMethod;
++ (void)staticDerivedNotImplementedCategoryMethod;
+
 - (void)derivedImplementedCategoryMethod;
 - (void)derivedNotImplementedCategoryMethod;
 - (void)derivedNotImplementedNativeCategoryMethodOverridenInJavaScript;

--- a/tests/TestFixtures/Interfaces/TNSInheritance.m
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.m
@@ -28,6 +28,20 @@
 @end
 
 @implementation TNSIBaseInterface
+
++ (int)staticBaseImplementedOptionalProperty {
+    return -1;
+}
+
++ (void)setStaticBaseImplementedOptionalProperty:(int)x {
+}
+
++ (void)staticBaseImplementedOptionalMethod {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
+@synthesize baseImplementedOptionalProperty;
+
 - (void)baseImplementedOptionalMethod {
     TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
 }
@@ -36,18 +50,40 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincomplete-implementation"
 @implementation TNSIBaseInterface (TNSIBaseCategory)
++ (void)staticBaseImplementedCategoryMethod {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
 - (void)baseImplementedCategoryMethod {
     TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
 }
 @end
 
 @implementation TNSIDerivedInterface
++ (int)staticDerivedImplementedOptionalProperty {
+    return -1;
+}
+
++ (void)setStaticDerivedImplementedOptionalProperty:(int)x {
+}
+
+@synthesize derivedImplementedOptionalProperty;
+
++ (void)staticDerivedImplementedOptionalMethod {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
 - (void)derivedImplementedOptionalMethod {
     TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
 }
+
 @end
 
 @implementation TNSIDerivedInterface (TNSIDerivedCategory)
++ (void)staticDerivedImplementedCategoryMethod {
+    TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
+}
+
 - (void)derivedImplementedCategoryMethod {
     TNSLog([NSString stringWithFormat:@"%@ called", NSStringFromSelector(_cmd)]);
 }

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -222,7 +222,7 @@ describe(module.id, function () {
 
         expect(TNSGetOutput()).toBe(expectedOutput);
      });
-     
+
     it("TypedefPointerClass", function () {
         expect(TNSApi.alloc().init().strokeColor).toBeNull();
     });
@@ -692,7 +692,7 @@ describe(module.id, function () {
             var counter = 0;
 
             Object.getOwnPropertyNames(global).forEach(function (name) {
-                // console.debug(name);
+//                console.debug(`Symbol global.${name}`);
 
                 // according to SDK headers kCFAllocatorUseContext is of type id, but in fact it is not
                 if (name == "kCFAllocatorUseContext" ||
@@ -715,13 +715,13 @@ describe(module.id, function () {
 
                 if (NSObject.isPrototypeOf(symbol) || symbol === NSObject) {
                     var klass = symbol;
-                    expect(klass).toBeDefined();
+                    expect(klass).toBeDefined(`Class ${name} should be defined.`);
 
-                    // console.debug(klass);
+//                    console.debug(`Entering class ${klass}`);
 
                     Object.getOwnPropertyNames(klass).forEach(function (y) {
                         if (klass.respondsToSelector(y)) {
-                            // console.debug(name, y);
+//                            console.debug(`Checking class member ${name} . ${y}`);
 
                             // supportedVideoFormats is a property and it's getter is being called the value is read below.
                             // We skip it because it will throw "Supported video formats should be called on individual configuration class."
@@ -729,7 +729,7 @@ describe(module.id, function () {
                                 return;
                             }
                             var method = klass[y];
-                            expect(method).toBeDefined();
+                            expect(method).toBeDefined(`Static method ${name} . ${y} should be defined.`);
 
                             counter++;
                         }
@@ -737,13 +737,13 @@ describe(module.id, function () {
 
                     Object.getOwnPropertyNames(klass.prototype).forEach(function (y) {
                         if (klass.instancesRespondToSelector(y)) {
-                            // console.debug(name, "proto", y);
+//                            console.debug(`Checking instance member ${name} . ${y}`);
 
                             var property = Object.getOwnPropertyDescriptor(klass.prototype, y);
 
                             if (!property) {
                                 var method = klass.prototype[y];
-                                expect(method).toBeDefined();
+                                expect(method).toBeDefined(`Instance method -[${name} ${y}] should be defined.`);
                             }
 
                             counter++;

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -197,6 +197,32 @@ describe(module.id, function () {
         expect(field.secureTextEntry).toBe(true);
     });
 
+     it("SpecialCaseProperty_When_CustomSelector_ImplementedInJS", function () {
+        var field = new (UITextField.extend({
+            get secureTextEntry() {
+                TNSLog("getter");
+                return this._secureTextEntry;
+            },
+            set secureTextEntry(val) {
+                this._secureTextEntry = val;
+                TNSLog("setter:" + val);
+            }
+        }))();
+        var expectedOutput = "";
+
+        expect(field.secureTextEntry).toBeUndefined(); expectedOutput+="getter";
+
+        field.secureTextEntry = true; expectedOutput+="setter:true";
+
+        expect(field.secureTextEntry).toBe(true); expectedOutput+="getter";
+
+        field.secureTextEntry = false; expectedOutput+="setter:false";
+
+        expect(field.secureTextEntry).toBe(false); expectedOutput+="getter";
+
+        expect(TNSGetOutput()).toBe(expectedOutput);
+     });
+     
     it("TypedefPointerClass", function () {
         expect(TNSApi.alloc().init().strokeColor).toBeNull();
     });

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -46,6 +46,27 @@ describe("Constructing Objective-C classes with new operator", function () {
         expect(actual).toBe("initWithString:str calledinitWithString:str called");
     });
 
+    it("WithInt:andInt from protocol", function () {
+        var instance1 = new TNSCInterface(5, 10);
+        var instance2 = new (TNSCInterface.extend({}))(100, 500);
+
+        var actual = TNSGetOutput();
+        expect(actual).toBe("initWithInt:andInt: 5 10 calledinitWithInt:andInt: 100 500 called");
+    });
+
+    it("WithStringOptional:andString from protocol", function () {
+        var instance1 = new TNSCInterface("s1", "s2");
+        var instance2 = new (TNSCInterface.extend({}))("s3", "s4");
+
+        var actual = TNSGetOutput();
+        expect(actual).toBe("initWithStringOptional:andString: s1 s2 calledinitWithStringOptional:andString: s3 s4 called");
+    });
+
+    it("initAWithIntNotImplemented:andInt:andInt and initZWithIntNotImplemented:andInt:andInt from protocol should be missing", function () {
+        expect(() => new TNSCInterface(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation.");
+        expect(() => new (TNSCInterface.extend({}))(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation.");
+    });
+
     it("NSArray with JS array constructor", function () {
         var nsarray = new NSArray([1, 2, 3]);
         expect(nsarray.class()).toBe(NSArray);

--- a/tests/TestRunner/app/VersionDiffTests.js
+++ b/tests/TestRunner/app/VersionDiffTests.js
@@ -72,4 +72,10 @@ describe(module.id, function() {
             check(value, major, minor);
         });
     });
+
+    it("Base class which is unavailable should be skipped", function() {
+        // Test case inspired from MTLArrayType(8.0) : MTLType(11.0) : NSObject
+        // TNSInterfaceNeverAvailableDescendant : TNSInterfaceNeverAvailable(API31.7 - skipped) : TNSInterfaceAlwaysAvailable
+        expect(Object.getPrototypeOf(TNSInterfaceNeverAvailableDescendant).toString()).toBe(TNSInterfaceAlwaysAvailable.toString(), "TNSInterfaceNeverAvailable base class should be skipped as it is unavailable");
+    });
 });

--- a/tests/TestRunner/app/VersionDiffTests.js
+++ b/tests/TestRunner/app/VersionDiffTests.js
@@ -78,4 +78,37 @@ describe(module.id, function() {
         // TNSInterfaceNeverAvailableDescendant : TNSInterfaceNeverAvailable(API31.7 - skipped) : TNSInterfaceAlwaysAvailable
         expect(Object.getPrototypeOf(TNSInterfaceNeverAvailableDescendant).toString()).toBe(TNSInterfaceAlwaysAvailable.toString(), "TNSInterfaceNeverAvailable base class should be skipped as it is unavailable");
     });
+
+    it("Members of a protocol which is unavailable should be skipped only when not implemented by class", function() {
+       expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable)).toContain("staticPropertyFromProtocolNeverAvailable", "TNSProtocolNeverAvailable static properties that are implemented should be present although the protocol is unavailable");
+       expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable)).not.toContain("staticPropertyFromProtocolNeverAvailableNotImplemented", "TNSProtocolNeverAvailable unimplemented static properties should be skipped");
+       expect(TNSInterfaceAlwaysAvailable.staticMethodFromProtocolNeverAvailable).toBeDefined("TNSProtocolNeverAvailable static methods that are implemented should be present although the protocol is unavailable");
+       expect(TNSInterfaceAlwaysAvailable.staticMethodFromProtocolNeverAvailableNotImplemented).toBeUndefined("TNSProtocolNeverAvailable unimplemented static methods should be skipped");
+       expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable.prototype)).toContain("propertyFromProtocolNeverAvailable", "TNSProtocolNeverAvailable properties that are implemented should be present although the protocol is unavailable");
+       expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable.prototype)).not.toContain("propertyFromProtocolNeverAvailableNotImplemented", "TNSProtocolNeverAvailable unimplemented properties should be skipped");
+       expect(new TNSInterfaceAlwaysAvailable().methodFromProtocolNeverAvailable).toBeDefined("TNSProtocolNeverAvailable methods that are implemented should be present although the protocol is unavailable");
+       expect(new TNSInterfaceAlwaysAvailable().methodFromProtocolNeverAvailableNotImplemented).toBeUndefined("TNSProtocolNeverAvailable unimplemented methods should be skipped");
+    });
+
+    it("Members of a protocol which is available should be present", function() {
+        const obj = new TNSInterfaceAlwaysAvailable();
+        let expectedOutput = "";
+        expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable.prototype)).toContain("propertyFromProtocolAlwaysAvailable", "TNSProtocolAlwaysAvailable properties should be present as it is available");
+        expect(obj.propertyFromProtocolAlwaysAvailable).toBe(0);
+       
+        expect(obj.methodFromProtocolAlwaysAvailable).toBeDefined("TNSProtocolAlwaysAvailable methods should be present as it is available");
+        obj.methodFromProtocolAlwaysAvailable(); expectedOutput += "methodFromProtocolAlwaysAvailable called";
+        expect(TNSGetOutput()).toBe(expectedOutput);
+       
+        TNSClearOutput();
+       
+        expectedOutput = "";
+        expect(Object.getOwnPropertyNames(TNSInterfaceAlwaysAvailable)).toContain("staticPropertyFromProtocolAlwaysAvailable", "TNSProtocolAlwaysAvailable static properties should be present as it is available");
+        TNSInterfaceAlwaysAvailable.staticPropertyFromProtocolAlwaysAvailable; expectedOutput += "staticPropertyFromProtocolAlwaysAvailable called";
+       
+        expect(TNSInterfaceAlwaysAvailable.staticMethodFromProtocolAlwaysAvailable).toBeDefined("TNSProtocolAlwaysAvailable static methods should be present as it is available");
+        TNSInterfaceAlwaysAvailable.staticMethodFromProtocolAlwaysAvailable(); expectedOutput += "staticMethodFromProtocolAlwaysAvailable called";
+       
+       expect(TNSGetOutput()).toBe(expectedOutput);
+    });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

* Filter members which are unavailable in the current SDK 
  * Add `isImplementedInClass` and `isAvailableInClass` methods in
`PropertyMeta` and `MethodMeta` which additionally check whether a Class
instance supports a given optional method

  * Use `isAvailableInClass` instead of `isAvailable` in `getOwnPropertyNames`
of `ObjCPrototype`, `ObjCConstructorBase`, `ObjCConstructorNative` and
in `materializeProperties` of `ObjCConstructorNative`

  * Filter via `isAvailableInClass` in `BaseClassMeta`'s various
method and property getters

  * Change `MembersCollection` to be a `HashSet` to avoid adding the same
member more than once when collecting them from the inheritance chain

  * Remove unused functions from `BaseClassMeta`

  * Add `findInterfaceMeta` function with fallback to the base interface
if the desired one is unavailable in the current SDK version (instead
of the hardcoded `NSObject` so far)

  * Remove hacky patch from `ObjCMethodWrapper::preInvocation` which
fixed the symptoms of #978 but not its root cause. Namely, that
unimplemented optional methods were returned as available properties
in `getOwnPropertyNames`.

  * Modify fixtures and add test cases for methods availability in
`InheritanceTests.js`

  * Add test case for unavailable base class

  * Add test case for property with custom selector in ApiTests. The getter
of `secureTextEntry`(`isSecureText`) overrides the default `secureTextEntry`

  * Add `encodeVersion` `getMajorVersion` and `getMinorVersion` helpers

* Never check for availability of protocols 
 Apple regularly create new protocols and move existing
interface members there. E.g. iOS 12.0 introduced the
UIFocusItemScrollableContainer protocol in UIKit which
contained members that have existed in UIScrollView
since iOS 2.0.

  * Create `findProtocol` function in `GlobalTable`
  * Use it instead of `findMeta` everwhere where a protocol is looked for
  * Add tests

refs #1084, #1085
