### PR TITLE
chore: Speed up Jenkins build

### DIFF
--- a/build/TestRunner.xcscheme
+++ b/build/TestRunner.xcscheme
@@ -85,7 +85,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "RelWithDebInfo"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/build/scripts/build-metadata-generator.sh
+++ b/build/scripts/build-metadata-generator.sh
@@ -6,10 +6,9 @@ source "$(dirname "$0")/common.sh"
 
 checkpoint "Building metadata-generator"
 
-mkdir -p "$WORKSPACE/cmake-build" && pushd "$_"
-cmake .. -G"Xcode"
-xcodebuild -configuration "Release" -target "MetadataGenerator" -quiet
-popd
+mkdir -p "$WORKSPACE/cmake-build"
+./cmake-gen.sh
+xcodebuild -configuration "Release" -target "MetadataGenerator" -project $NATIVESCRIPT_XCODEPROJ -quiet
 
 checkpoint "Packaging metadata-generator"
 mkdir -p "$DIST_DIR" && pushd "$_"

--- a/build/scripts/build-nativescript-framework.sh
+++ b/build/scripts/build-nativescript-framework.sh
@@ -8,18 +8,18 @@ CONFIGURATION=$NATIVESCRIPT_XCODE_CONFIGURATION
 
 checkpoint "Building NativeScript.framework"
 
-mkdir -p "$WORKSPACE/cmake-build" && pushd "$_"
+mkdir -p "$WORKSPACE/cmake-build"
 # Delete the CMake cache because a previous build could have generated the runtime with a static library.
-rm -f "CMakeCache.txt"
-cmake .. -G"Xcode" -D"BUILD_SHARED_LIBS=ON"
+rm -f "$WORKSPACE/cmake-build/CMakeCache.txt"
+./cmake-gen.sh
+
 # TODO: fix build when iphoneos build is started first
 checkpoint "Building NativeScript.framework - iphonesimulator SDK"
-xcodebuild -configuration $CONFIGURATION -sdk "iphonesimulator" -target "NativeScript" -quiet
+xcodebuild -configuration $CONFIGURATION -sdk "iphonesimulator" -target "NativeScript" -project $NATIVESCRIPT_XCODEPROJ -quiet
 checkpoint "Building NativeScript.framework - iphoneos SDK"
-xcodebuild -configuration $CONFIGURATION -sdk "iphoneos" -target "NativeScript" -quiet
-popd
+xcodebuild -configuration $CONFIGURATION -sdk "iphoneos"        -target "NativeScript" -project $NATIVESCRIPT_XCODEPROJ -quiet
 
-checkpoint "Packaging NativeScript.framework"
+checkpoint "Creating fat NativeScript.framework"
 mkdir -p "$DIST_DIR" && pushd "$_"
 cp -r "$WORKSPACE/cmake-build/src/NativeScript/$CONFIGURATION-iphoneos/NativeScript.framework" "."
 rm "NativeScript.framework/NativeScript"

--- a/build/scripts/build-testrunner-application.sh
+++ b/build/scripts/build-testrunner-application.sh
@@ -16,22 +16,24 @@ rm -f "CMakeCache.txt"
 cmake .. -G"Xcode"
 
 # Define public TestRunner scheme. Xcode schemes is requried for archiving. This can be also done from Xcode GUI. However, CMake 3.1.3 has no support for generating Xcode schemes, so we have to do it manually.
-mkdir -p "$WORKSPACE/cmake-build/NativeScript.xcodeproj/xcshareddata/xcschemes"
-cp "$WORKSPACE/build/TestRunner.xcscheme" "$WORKSPACE/cmake-build/NativeScript.xcodeproj/xcshareddata/xcschemes/TestRunner.xcscheme"
+mkdir -p "$NATIVESCRIPT_XCODEPROJ/xcshareddata/xcschemes"
+cp "$WORKSPACE/build/TestRunner.xcscheme" "$NATIVESCRIPT_XCODEPROJ/xcshareddata/xcschemes/TestRunner.xcscheme"
 
-xcodebuild \
--configuration "$CONFIGURATION" \
--sdk "iphoneos" \
--scheme "TestRunner" \
-ARCHS="armv7 arm64" \
-ONLY_ACTIVE_ARCH="NO" \
--quiet \
+# xcodebuild \
+# -configuration "$CONFIGURATION" \
+# -sdk "iphoneos" \
+# -scheme "TestRunner" \
+# ARCHS="armv7 arm64" \
+# ONLY_ACTIVE_ARCH="NO" \
+# -project $NATIVESCRIPT_XCODEPROJ \
+# -quiet \
 
 xcodebuild archive \
 -archivePath "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.xcarchive" \
 -configuration "$CONFIGURATION" \
 -sdk "iphoneos" \
 -scheme "TestRunner" \
+-project $NATIVESCRIPT_XCODEPROJ \
 -quiet \
 
 popd

--- a/build/scripts/common.sh
+++ b/build/scripts/common.sh
@@ -11,6 +11,7 @@ function checkpoint {
 }
 
 WORKSPACE=$(pwd)
+NATIVESCRIPT_XCODEPROJ=$WORKSPACE/cmake-build/NativeScript.xcodeproj
 DIST_DIR="$WORKSPACE/dist"
 NATIVESCRIPT_XCODE_CONFIGURATION="RelWithDebInfo"
 

--- a/launch-c.in
+++ b/launch-c.in
@@ -1,3 +1,6 @@
 #!/bin/sh
 export CCACHE_CPP2=true
-exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_C_COMPILER}" "$@"
+# Enable precompiled headers support by following the instructions at
+# https://ccache.samba.org/manual/latest.html#_precompiled_headers
+export CCACHE_SLOPPINESS="pch_defines,time_macros"
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_C_COMPILER}" "-fpch-preprocess" "$@"

--- a/launch-cxx.in
+++ b/launch-cxx.in
@@ -1,3 +1,6 @@
 #!/bin/sh
 export CCACHE_CPP2=true
-exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "$@"
+# Enable precompiled headers support by following the instructions at
+# https://ccache.samba.org/manual/latest.html#_precompiled_headers
+export CCACHE_SLOPPINESS="pch_defines,time_macros"
+exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "-fpch-preprocess" "$@"

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -268,21 +268,56 @@ if(${BUILD_SHARED_LIBS})
         "-framework Security"
     )
 
+    # Copy NativeScript.framework from the built location to ${NativeScriptFramework_BINARY_DIR}
+    # it could be different when invoking `xcodebuild archive`
+    add_custom_command(
+        TARGET
+        NativeScript
+        POST_BUILD COMMAND
+        if [ \"${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\" != \"$(BUILT_PRODUCTS_DIR)\" ]
+        \; then
+            ${CMAKE_COMMAND} -E make_directory
+            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
+            &&
+            ${CMAKE_COMMAND} -E copy_directory
+            $(BUILT_PRODUCTS_DIR)/NativeScript.framework
+            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/NativeScript.framework
+        \; fi
+    )
+
     # Tell linker to keep all symbols listed in exported-symbols.txt
     set_target_properties(NativeScript PROPERTIES XCODE_ATTRIBUTE_EXPORTED_SYMBOLS_FILE "${CMAKE_SOURCE_DIR}/src/NativeScript/exported-symbols.txt")
 
 
-elseif(${EMBED_STATIC_DEPENDENCIES})
-    foreach(_directory ${WEBKIT_LINK_DIRECTORIES})
-        set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${_directory}")
-    endforeach()
-    foreach(_library ${WEBKIT_LIBRARIES})
-        set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -l${_library}")
-    endforeach()
-
-    set_target_properties(NativeScript PROPERTIES
-        STATIC_LIBRARY_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${LIBFFI_LIB_DIR} -lffi"
+else()
+    # Copy libNativeScript.a from the built location to ${NativeScriptFramework_BINARY_DIR}
+    # it could be different when invoking `xcodebuild archive`
+    add_custom_command(
+        TARGET
+        NativeScript
+        POST_BUILD COMMAND
+        if [ \"${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\" != \"$(BUILT_PRODUCTS_DIR)\" ]
+        \; then
+            ${CMAKE_COMMAND} -E make_directory
+            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
+            &&
+            ${CMAKE_COMMAND} -E copy
+            $(BUILT_PRODUCTS_DIR)/libNativeScript.a
+            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/libNativeScript.a
+        \; fi
     )
+    if(${EMBED_STATIC_DEPENDENCIES})
+        foreach(_directory ${WEBKIT_LINK_DIRECTORIES})
+            set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${_directory}")
+        endforeach()
+        foreach(_library ${WEBKIT_LIBRARIES})
+            set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -l${_library}")
+        endforeach()
+
+        set_target_properties(NativeScript PROPERTIES
+            STATIC_LIBRARY_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${LIBFFI_LIB_DIR} -lffi"
+        )
+    endif()
 endif()
 
 include(EmbedResourceInHeader)

--- a/tests/TestFixtures/CMakeLists.txt
+++ b/tests/TestFixtures/CMakeLists.txt
@@ -70,3 +70,20 @@ GroupSources(TestFixtures)
 
 include(PrecompiledHeaders)
 SetPrecompiledHeader(TestFixtures TestFixtures-Prefix.h)
+
+# Copy libTestFixtures.a from the built location to ${NativeScriptFramework_BINARY_DIR}
+# it could be different when invoking `xcodebuild archive`
+add_custom_command(
+    TARGET
+    TestFixtures
+    POST_BUILD COMMAND
+    if [ \"`dirname \\\"$<TARGET_FILE:TestFixtures>\\\"`\" != \"$(TARGET_BUILD_DIR)\" ]
+    \; then
+        ${CMAKE_COMMAND} -E make_directory
+        ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
+        &&
+        ${CMAKE_COMMAND} -E copy
+        $(BUILT_PRODUCTS_DIR)/libTestFixtures.a
+        $<TARGET_FILE:TestFixtures>
+    \; fi
+)


### PR DESCRIPTION
* Optimize TestRunner build
  * Remove build command from build script
  * Add custom commands in TestFixtures and NativeScript projects
for copying the built library to its expected location in `cmake-build`.
This is necessary because when building with `xcodebuild archive` the
output files are located in a different directory (located under
~/Library/Developer/Xcode/DerivedData/). It turns out that this behavior
is by design. See: https://forums.developer.apple.com/thread/53549
  * Create cmake project using `cmake-gen.sh` so that TestRunner can be built
and linked
  * Change archive action's configuration to `RelWithDebInfo` in scheme file

* Define `NATIVESCRIPT_XCODEPROJ` environment variable in `common.sh`
* Enable precompiled headers support of ccache
Followed instructions from https://ccache.samba.org/manual/latest.html#_precompiled_headers

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.