### PR TITLE
fix(runtime): Expose base class missing properties in inheritors

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -353,10 +353,12 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
 
         auto protocol = createProtocolWrapper(globalObject, static_cast<const ProtocolMeta*>(symbolMeta), aProtocol);
         strongSymbolWrapper = protocol;
+        // Protocols that are not implemented or referred with @protocol at compile time do not have corresponding
+        // protocol objects at runtime. `objc_getProtocol` returns `nullptr for them!
+        // See Protocol Objects section at https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocProtocols.html#//apple_ref/doc/uid/TP30001163-CH15
         if (aProtocol) {
             globalObject->_objCProtocolWrappers.insert({ aProtocol, protocol });
         }
-
         break;
     }
     case Union: {

--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -13,8 +13,11 @@
 #include <wtf/RetainPtr.h>
 
 namespace Metadata {
+
 struct BaseClassMeta;
-}
+struct PropertyMeta;
+
+} // namespace Metadata
 
 namespace NativeScript {
 class ObjCPrototype : public JSC::JSDestructibleObject {
@@ -38,6 +41,8 @@ public:
     static WTF::String className(const JSObject* object, JSC::VM&);
 
     void materializeProperties(JSC::VM& vm, GlobalObject* globalObject);
+
+    void defineNativeProperty(JSC::VM& vm, GlobalObject* globalObject, const Metadata::PropertyMeta* propertyMeta);
 
     const Metadata::BaseClassMeta* metadata() const {
         return this->_metadata;

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -687,6 +687,35 @@ describe(module.id, function () {
         expect(result).toBe('method called');
     });
 
+    it("Unimplemented properties from UIBarItem class should be provided by the inheritors", function () {
+        var classConstructors = ["UIBarButtonItem", "UITabBarItem"];
+        var props = ["enabled", "image", "imageInsets", "landscapeImagePhone", "landscapeImagePhoneInsets", "title"];
+        for (var klass of classConstructors) {
+            var instance = new global[klass]();
+            for (var prop of props) {
+                expect(instance[prop]).toBeDefined(`"${prop}" must be defined in instances of "${klass}"`);
+            }
+        }
+    });
+ 
+    it("Unimplemented properties from MTLRenderPassAttachmentDescriptor class should be provided by the inheritors", function () {
+        var classConstructors = [ 
+            "MTLRenderPassDepthAttachmentDescriptor", "MTLRenderPassStencilAttachmentDescriptor", 
+            "MTLRenderPassColorAttachmentDescriptor"
+        ];
+        var props = [
+            "depthPlane", "level", "loadAction", "resolveDepthPlane", "resolveLevel", "resolveSlice",
+            "resolveTexture", "slice", "storeAction", "storeActionOptions", "texture"
+        ];
+        
+        for (var klass of classConstructors) {
+            var instance = new global[klass]();
+            for (var prop of props) {
+                expect(instance[prop]).toBeDefined(`"${prop}" must be defined in instances of "${klass}"`);
+            }
+        }
+    });
+
     if (TNSIsConfigurationDebug) {
         it("ApiIterator", function () {
             var counter = 0;


### PR DESCRIPTION
Fix issue with missing `imageInsets`, `landscapeImagePhone`, `title` properties of UITabBarItem.
These properties are declared in `UIBarItem` but it actually doesn't implement them. Some of its
successors like `UITabBarItem` however do, and we need to expose them there.

This regression has been introduced with #1086 (which addressed #1084, #1085)

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
