### PR TITLE
fix(webkit): Make JSC log to system logs instead of stderr

### DIFF
--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -689,7 +689,11 @@ describe(module.id, function () {
 
     it("Unimplemented properties from UIBarItem class should be provided by the inheritors", function () {
         var classConstructors = ["UIBarButtonItem", "UITabBarItem"];
-        var props = ["enabled", "image", "imageInsets", "landscapeImagePhone", "landscapeImagePhoneInsets", "title"];
+        var props = ["enabled", "image", "imageInsets", "title"];
+        if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 11, minorVersion: 0, patchVersion: 0})) {
+            props = props.concat("landscapeImagePhone", "landscapeImagePhoneInsets");
+        }
+       
         for (var klass of classConstructors) {
             var instance = new global[klass]();
             for (var prop of props) {
@@ -705,9 +709,13 @@ describe(module.id, function () {
         ];
         var props = [
             "depthPlane", "level", "loadAction", "resolveDepthPlane", "resolveLevel", "resolveSlice",
-            "resolveTexture", "slice", "storeAction", "storeActionOptions", "texture"
+            "resolveTexture", "slice", "storeAction", "texture"
         ];
         
+        if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 11, minorVersion: 0, patchVersion: 0})) {
+            props = props.concat("storeActionOptions");
+        }
+       
         for (var klass of classConstructors) {
             var instance = new global[klass]();
             for (var prop of props) {


### PR DESCRIPTION
Since the implementation of #1064 it has been made possible
for {N} users to switch on different JSC diagnostic options.
The problem was that to view the logs users had to use the Xcode
debugger, because they weren't visible in the system logs and
could not be captured by {N} CLI. With this change now all
applications that retrieve system logs from the device will process
them. We will also be able to add automated tests that ensure
these options' correct functionality.

related to #1004

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

