### PR TITLE
 Fix breakpoints in onNavigatingTo and add stacktrace to console.trace() message

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -208,7 +208,7 @@ WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType ty
 
     if (type == JSC::MessageType::Trace) {
         RefPtr<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, Inspector::ScriptCallStack::maxCallStackSizeToCapture));
-        builder.append(("\n" + dumpJsCallStack(*callStack.get())).c_str());
+        builder.append(("\n" + getCallStack(*callStack.get())).c_str());
     }
     return builder.toString();
 }

--- a/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
+++ b/src/NativeScript/inspector/GlobalObjectConsoleClient.cpp
@@ -1,6 +1,7 @@
 #include "GlobalObjectConsoleClient.h"
 #include "GlobalObjectInspectorController.h"
 #include "InspectorTimelineAgent.h"
+#include "JSErrors.h"
 #include <GlobalObject.h>
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/ConsoleMessage.h>
@@ -185,7 +186,6 @@ void GlobalObjectConsoleClient::recordEnd(ExecState*, Ref<Inspector::ScriptArgum
 
 WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType type, JSC::ExecState* exec, Ref<Inspector::ScriptArguments>&& arguments) {
 
-    RefPtr<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, 1));
     StringBuilder builder;
 
     if (type == JSC::MessageType::Dir) {
@@ -204,6 +204,11 @@ WTF::String GlobalObjectConsoleClient::createMessageFromArguments(MessageType ty
                 builder.append(argAsString);
             }
         }
+    }
+
+    if (type == JSC::MessageType::Trace) {
+        RefPtr<Inspector::ScriptCallStack> callStack(Inspector::createScriptCallStackForConsole(exec, Inspector::ScriptCallStack::maxCallStackSizeToCapture));
+        builder.append(("\n" + dumpJsCallStack(*callStack.get())).c_str());
     }
     return builder.toString();
 }

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -373,25 +373,18 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
               });
           CFRunLoopWakeUp(runloop);
       }
-      NSArray* inspectorRunloopModes =
-          @[NSRunLoopCommonModes, TNSInspectorRunLoopMode];
       return ^(NSString* message, NSError* error) {
         if (message) {
-            CFRunLoopRef runloop = CFRunLoopGetMain();
-            CFRunLoopPerformBlock(
-                runloop, (__bridge CFTypeRef)(inspectorRunloopModes), ^{
-                  // Keep a working copy for calling into the VM after releasing inspectorLock
-                  TNSRuntimeInspector* tempInspector = nil;
-                  @synchronized(inspectorLock()) {
-                      tempInspector = inspector;
-                  }
+            // Keep a working copy for calling into the VM after releasing inspectorLock
+            TNSRuntimeInspector* tempInspector = nil;
+            @synchronized(inspectorLock()) {
+                tempInspector = inspector;
+            }
 
-                  if (tempInspector) {
-                      // NSLog(@"NativeScript Debugger receiving: %@", message);
-                      [tempInspector dispatchMessage:message];
-                  }
-                });
-            CFRunLoopWakeUp(runloop);
+            if (tempInspector) {
+                // NSLog(@"NativeScript Debugger receiving: %@", message);
+                [tempInspector dispatchMessage:message];
+            }
         } else {
             clearInspector();
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
1. console.trace() doesn't print stacktrace
2. Breakpoints in onNavigatingTo are not respected

## What is the new behavior?
1. console.trace() works as expected
2. Breakpoints are evaluated on time

Related to #1099 and #1021 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

