### PR TITLE
chore(build): Disable precompiled headers when using ccache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,15 @@ if(CCACHE_FOUND AND USE_CCACHE)
   MESSAGE( STATUS "## Using CCache when building!")
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
-endif(CCACHE_FOUND AND USE_CCACHE)
+  # Do not precompile the prefix header when using CCache. It doesn't work efficiently because
+  # of clang's logic to always require the timestamps of the precompiled prefix header to be
+  # newer than all its dependencies (and ccache's behaviour to regenerate it whenever some dependency is newer:
+  # see https://github.com/ccache/ccache/blob/b72a04dc51bb7d34ad04e9f75a07b0f92e96a262/src/manifest.c#L390)
+  MESSAGE( STATUS "## Disabling precompilation of prefix headers")
+  set(NATIVESCRIPT_PRECOMPILE_PREFIX_HEADER "NO")
+else()
+  set(NATIVESCRIPT_PRECOMPILE_PREFIX_HEADER "YES")
+endif()
 
 project(NativeScript)
 

--- a/build/scripts/build-nativescript-framework.sh
+++ b/build/scripts/build-nativescript-framework.sh
@@ -13,7 +13,11 @@ mkdir -p "$WORKSPACE/cmake-build"
 rm -f "$WORKSPACE/cmake-build/CMakeCache.txt"
 ./cmake-gen.sh
 
-# TODO: fix build when iphoneos build is started first
+# Due to the regeneration of JSC's low level interpreter when changing
+# building target between device/simulator, this order is important for
+# the performance of Jenkins builds. After building the {N} framework, we
+# build TestRunner for device and thus, it is best to build NativeScript.framework
+# for device last.
 checkpoint "Building NativeScript.framework - iphonesimulator SDK"
 xcodebuild -configuration $CONFIGURATION -sdk "iphonesimulator" -target "NativeScript" -project $NATIVESCRIPT_XCODEPROJ -quiet
 checkpoint "Building NativeScript.framework - iphoneos SDK"

--- a/build/scripts/build-testrunner-application.sh
+++ b/build/scripts/build-testrunner-application.sh
@@ -9,11 +9,9 @@ CONFIGURATION=$NATIVESCRIPT_XCODE_CONFIGURATION
 
 checkpoint "Building TestRunner application"
 
-mkdir -p "$WORKSPACE/cmake-build" && pushd "$_"
-# Delete the CMake cache because a previous build could have generated the runtime with a shared framework.
-# When using CMake 3.1 (which we have to) there is a bug that prevents building applications that link with a shared framework.
-rm -f "CMakeCache.txt"
-cmake .. -G"Xcode"
+./cmake-gen.sh
+
+pushd "$WORKSPACE/cmake-build"
 
 # Define public TestRunner scheme. Xcode schemes is requried for archiving. This can be also done from Xcode GUI. However, CMake 3.1.3 has no support for generating Xcode schemes, so we have to do it manually.
 mkdir -p "$NATIVESCRIPT_XCODEPROJ/xcshareddata/xcschemes"
@@ -28,24 +26,17 @@ ONLY_ACTIVE_ARCH="NO" \
 -project $NATIVESCRIPT_XCODEPROJ \
 -quiet \
 
-xcodebuild archive \
--archivePath "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.xcarchive" \
--configuration "$CONFIGURATION" \
--sdk "iphoneos" \
--scheme "TestRunner" \
--project $NATIVESCRIPT_XCODEPROJ \
--quiet \
-
 popd
 
-checkpoint "Exporting TestRunner"
-xcodebuild \
--exportArchive \
--archivePath "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.xcarchive" \
--exportPath "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos" \
--exportOptionsPlist "$WORKSPACE/cmake/ExportOptions.plist" \
--quiet \
+# Simulate an IPA by zipping TestRunner.app inside a `Payload` directory.
+# This way we're avoiding the costy steps of `xcodebuild archive` and `export`.
+(
+    set -e;
+    cd "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/";
+    mkdir Payload;
+    mv TestRunner.app Payload;
+    zip -r "$DIST_DIR/TestRunner.ipa" Payload;
+    mv Payload/TestRunner.app .
+)
 
-cp "$WORKSPACE/cmake-build/tests/TestRunner/$CONFIGURATION-iphoneos/TestRunner.ipa" "$DIST_DIR"
-
-checkpoint "Finished building TestRunner application - $DIST_DIR/TestRunner.ipa"
+checkpoint "Finished building TestRunner application - $DIST_DIR/TestRunner.app"

--- a/cmake/BuiltArtifactToTargetDestination.cmake
+++ b/cmake/BuiltArtifactToTargetDestination.cmake
@@ -1,0 +1,24 @@
+# Copy target's final build product from the built location to where CMake expects to find it.
+# When invoking `xcodebuild archive` it is different and we needed to explicitly perform a
+# redundant `xcodebuild build` command beforehand.
+macro(CopyBuiltArtifactToTargetDestinationIfDifferent _target)
+    PostBuildCopyIfDestDifferentThanSrc(${_target} $(TARGET_BUILD_DIR) $<TARGET_FILE:${_target}>)
+endmacro()
+
+
+macro(PostBuildCopyIfDestDifferentThanSrc _target _srcDir _dest)
+    add_custom_command(
+        TARGET
+        ${_target}
+        POST_BUILD COMMAND
+        if [ \"`dirname \\\"${_dest}\\\"`\" != \"${_srcDir}\" ]
+        \; then
+            ${CMAKE_COMMAND} -E make_directory
+            `dirname ${_dest}`
+            &&
+            ${CMAKE_COMMAND} -E copy
+            ${_srcDir}/`basename ${_dest}`
+            ${_dest}
+        \; fi
+    )
+endmacro()

--- a/cmake/PrecompiledHeaders.cmake
+++ b/cmake/PrecompiledHeaders.cmake
@@ -1,6 +1,6 @@
 macro(SetPrecompiledHeader _target _header)
-    set_target_properties(${_target} PROPERTIES
-        XCODE_ATTRIBUTE_GCC_PREFIX_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/${_header}"
-        XCODE_ATTRIBUTE_GCC_PRECOMPILE_PREFIX_HEADER "YES"
-    )
+        set_target_properties(${_target} PROPERTIES
+            XCODE_ATTRIBUTE_GCC_PREFIX_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/${_header}"
+            XCODE_ATTRIBUTE_GCC_PRECOMPILE_PREFIX_HEADER "${NATIVESCRIPT_PRECOMPILE_PREFIX_HEADER}"
+        )
 endmacro()

--- a/launch-c.in
+++ b/launch-c.in
@@ -1,6 +1,27 @@
 #!/bin/sh
-export CCACHE_CPP2=true
-# Enable precompiled headers support by following the instructions at
-# https://ccache.samba.org/manual/latest.html#_precompiled_headers
-export CCACHE_SLOPPINESS="pch_defines,time_macros"
+
+# If false, ccache will first run preprocessor to preprocess the source code and then on a cache miss run the compiler on the preprocessed source
+# code instead of the original source code. This makes cache misses slightly faster since the source code only has to be preprocessed once.
+# The downside is that some compilers won’t produce the same result (for instance diagnostics warnings) when compiling preprocessed source code.
+export CCACHE_CPP2="true"
+
+if [ -z "${CCACHE_HASHDIR+set}" ]; then
+	# You can disable CCACHE_HASHDIR to get cache hits when compiling the same source code in
+	# different directories if you don’t mind that CWD in the debug info might be incorrect.
+	export CCACHE_NOHASHDIR="true"
+fi
+
+if [ -z "${CCACHE_BASEDIR+set}" ]; then
+	# If you use absolute paths anywhere on the command line (e.g. the source code file path or an argument to compiler options like -I and -MF),
+	# you must to set base_dir to an absolute path to a “base directory”. ccache will then rewrite absolute paths under that directory to relative
+	# before computing the hash.
+	export CCACHE_BASEDIR="$(PWD)"
+fi
+
+if [ -z "${CCACHE_SLOPPINESS+set}" ]; then
+	# Enable precompiled headers support by following the instructions at
+	# https://ccache.samba.org/manual/latest.html#_precompiled_headers
+	export CCACHE_SLOPPINESS="pch_defines,time_macros"
+fi
+
 exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_C_COMPILER}" "-fpch-preprocess" "$@"

--- a/launch-cxx.in
+++ b/launch-cxx.in
@@ -1,6 +1,27 @@
 #!/bin/sh
-export CCACHE_CPP2=true
-# Enable precompiled headers support by following the instructions at
-# https://ccache.samba.org/manual/latest.html#_precompiled_headers
-export CCACHE_SLOPPINESS="pch_defines,time_macros"
+
+# If false, ccache will first run preprocessor to preprocess the source code and then on a cache miss run the compiler on the preprocessed source
+# code instead of the original source code. This makes cache misses slightly faster since the source code only has to be preprocessed once.
+# The downside is that some compilers won’t produce the same result (for instance diagnostics warnings) when compiling preprocessed source code.
+export CCACHE_CPP2="true"
+
+if [ -z "${CCACHE_HASHDIR+set}" ]; then
+	# You can disable CCACHE_HASHDIR to get cache hits when compiling the same source code in
+	# different directories if you don’t mind that CWD in the debug info might be incorrect.
+	export CCACHE_NOHASHDIR="true"
+fi
+
+if [ -z "${CCACHE_BASEDIR+set}" ]; then
+	# If you use absolute paths anywhere on the command line (e.g. the source code file path or an argument to compiler options like -I and -MF),
+	# you must to set base_dir to an absolute path to a “base directory”. ccache will then rewrite absolute paths under that directory to relative
+	# before computing the hash.
+	export CCACHE_BASEDIR="$(PWD)"
+fi
+
+if [ -z "${CCACHE_SLOPPINESS+set}" ]; then
+	# Enable precompiled headers support by following the instructions at
+	# https://ccache.samba.org/manual/latest.html#_precompiled_headers
+	export CCACHE_SLOPPINESS="pch_defines,time_macros"
+fi
+
 exec "${RULE_LAUNCH_COMPILE}" "${CMAKE_CXX_COMPILER}" "-fpch-preprocess" "$@"

--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -230,9 +230,9 @@ set(JSFILES
 )
 
 include_directories(
-    "${CMAKE_CURRENT_BINARY_DIR}" 
-    "${CMAKE_CURRENT_SOURCE_DIR}/**" 
-    "${LIBFFI_INCLUDE_DIR}" 
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/**"
+    "${LIBFFI_INCLUDE_DIR}"
     "${WEBKIT_INCLUDE_DIRECTORIES}"
 )
 
@@ -246,7 +246,7 @@ set_target_properties(NativeScript PROPERTIES
     COMPILE_FLAGS "
         -fno-exceptions -fno-rtti -fno-objc-arc
         -Werror -Wall -Wextra -Wcast-align -Wformat-security -Wmissing-format-attribute -Wpointer-arith -Wundef -Wwrite-strings
-        -Wno-shorten-64-to-32 -Wno-bool-conversion -Wno-unused-parameter -Wno-macro-redefined
+        -Wno-shorten-64-to-32 -Wno-bool-conversion -Wno-unused-parameter -Wno-macro-redefined -Wno-nonportable-include-path
     "
 )
 
@@ -275,44 +275,15 @@ if(${BUILD_SHARED_LIBS})
         "-framework Security"
     )
 
-    # Copy NativeScript.framework from the built location to ${NativeScriptFramework_BINARY_DIR}
-    # it could be different when invoking `xcodebuild archive`
-    add_custom_command(
-        TARGET
-        NativeScript
-        POST_BUILD COMMAND
-        if [ \"${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\" != \"$(BUILT_PRODUCTS_DIR)\" ]
-        \; then
-            ${CMAKE_COMMAND} -E make_directory
-            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
-            &&
-            ${CMAKE_COMMAND} -E copy_directory
-            $(BUILT_PRODUCTS_DIR)/NativeScript.framework
-            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/NativeScript.framework
-        \; fi
-    )
+    include(BuiltArtifactToTargetDestination)
+    PostBuildCopyIfDestDifferentThanSrc(NativeScript $(BUILT_PRODUCTS_DIR) ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/NativeScript.framework)
 
     # Tell linker to keep all symbols listed in exported-symbols.txt
     set_target_properties(NativeScript PROPERTIES XCODE_ATTRIBUTE_EXPORTED_SYMBOLS_FILE "${CMAKE_SOURCE_DIR}/src/NativeScript/exported-symbols.txt")
-
-
 else()
-    # Copy libNativeScript.a from the built location to ${NativeScriptFramework_BINARY_DIR}
-    # it could be different when invoking `xcodebuild archive`
-    add_custom_command(
-        TARGET
-        NativeScript
-        POST_BUILD COMMAND
-        if [ \"${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\" != \"$(BUILT_PRODUCTS_DIR)\" ]
-        \; then
-            ${CMAKE_COMMAND} -E make_directory
-            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
-            &&
-            ${CMAKE_COMMAND} -E copy
-            $(BUILT_PRODUCTS_DIR)/libNativeScript.a
-            ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/libNativeScript.a
-        \; fi
-    )
+    include(BuiltArtifactToTargetDestination)
+    CopyBuiltArtifactToTargetDestinationIfDifferent(NativeScript)
+
     if(${EMBED_STATIC_DEPENDENCIES})
         foreach(_directory ${WEBKIT_LINK_DIRECTORIES})
             set(NativeScript_LIBTOOL_FLAGS "${NativeScript_LIBTOOL_FLAGS} -L${_directory}")

--- a/tests/TestFixtures/CMakeLists.txt
+++ b/tests/TestFixtures/CMakeLists.txt
@@ -71,19 +71,5 @@ GroupSources(TestFixtures)
 include(PrecompiledHeaders)
 SetPrecompiledHeader(TestFixtures TestFixtures-Prefix.h)
 
-# Copy libTestFixtures.a from the built location to ${NativeScriptFramework_BINARY_DIR}
-# it could be different when invoking `xcodebuild archive`
-add_custom_command(
-    TARGET
-    TestFixtures
-    POST_BUILD COMMAND
-    if [ \"`dirname \\\"$<TARGET_FILE:TestFixtures>\\\"`\" != \"$(TARGET_BUILD_DIR)\" ]
-    \; then
-        ${CMAKE_COMMAND} -E make_directory
-        ${NativeScriptFramework_BINARY_DIR}/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/
-        &&
-        ${CMAKE_COMMAND} -E copy
-        $(BUILT_PRODUCTS_DIR)/libTestFixtures.a
-        $<TARGET_FILE:TestFixtures>
-    \; fi
-)
+include(BuiltArtifactToTargetDestination)
+CopyBuiltArtifactToTargetDestinationIfDifferent(TestFixtures)


### PR DESCRIPTION
Otherwise all NativeScript source files are rebuilt everytime when the
PCH file is regenerated. Which is done on every build.

* Disable precompiled headers when using CCache and suppress `nonportable-include-path` warning which occcurs with disabled precompilation. Fixing the code is beyond this PR's scope.
* Extract CMake macros for duplicated logic: `CopyBuiltArtifactToTargetDestinationIfDifferent` and `PostBuildCopyIfDestDifferentThanSrc `
* Play nicely and do not redefine CCACHE environment variables if they are already set from outside
* Optimize TestRunner build


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.