### PR TITLE
fix(metadata): Copy stderr log to yaml dir

### DIFF
--- a/build/scripts/build-step-metadata-generator.py
+++ b/build/scripts/build-step-metadata-generator.py
@@ -61,6 +61,12 @@ docset_path = os.path.join(os.path.expanduser("~"),
 yaml_output_folder = env_or_none("TNS_DEBUG_METADATA_PATH")
 
 
+def save_stream_to_file(filename, stream):
+    f = open(filename, "w")
+    f.write(stream)
+    f.close()
+
+
 # noinspection PyShadowingNames
 def generate_metadata(arch):
     # metadata generator arguments
@@ -76,6 +82,7 @@ def generate_metadata(arch):
         print("Generating TypeScript declarations in: \"{}\"".format(current_typescript_output_folder))
 
     # optionally add yaml output folder
+    current_yaml_output_folder = None
     if yaml_output_folder is not None:
         current_yaml_output_folder = yaml_output_folder + "-" + arch
         generator_call.extend(["-output-yaml", current_yaml_output_folder])
@@ -99,9 +106,12 @@ def generate_metadata(arch):
 
     # save error stream content to file
     error_log_file = "{}/metadata-generation-stderr-{}.txt".format(conf_build_dir, arch)
-    error_file = open(error_log_file, "w")
-    error_file.write(error_stream_content)
-    error_file.close()
+    print("Saving metadata generation's stderr stream to: {}".format(error_log_file))
+    save_stream_to_file(error_log_file, error_stream_content)
+    if current_yaml_output_folder is not None:
+      yaml_dir_error_log_file = "{}/metadata-generation-stderr.txt".format(current_yaml_output_folder)
+      print("Copying metadata stderr stream to: {}".format(yaml_dir_error_log_file))
+      save_stream_to_file(yaml_dir_error_log_file, error_stream_content)
 
     if child_process.returncode != 0:
         print("Error: Unable to generate metadata for {}.".format(arch))


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

Metadata generator's stderr output has always been redirected into a file
in the `platforms/ios/build/<Configuration>` directory but this has not been
documented so far and has remained quite invisible to {N} users. It's
contents however can be extremely helpful in detecting issues with
missing metadata in cases like the one in #1117

* Copy stderr text file to TNS_DEBUG_METADATA_PATH alongside all yamls
* Add messages in metadata generations output so that it becomes a bit more
visible that such a file actually exists
* Revert "fix: Ignore includeNotFoundErrors in order to keep visiting the entire AST"
  It seems that emitting such errors doesn't change the number of
  generated metadata items. Omitting them, however, can hide source
  code issues that prevent some entities' metadata from being
  parsed and generated (e.g. see #1117)
