### PR TITLE
fix(metadata): Ressurrect "includeNotFoundErrors" option of CLang

### DIFF
--- a/build/scripts/build-metadata-generator.sh
+++ b/build/scripts/build-metadata-generator.sh
@@ -12,6 +12,7 @@ xcodebuild -configuration "Release" -target "MetadataGenerator" -project $NATIVE
 
 checkpoint "Packaging metadata-generator"
 mkdir -p "$DIST_DIR" && pushd "$_"
+rm -rf metadataGenerator
 cp -R "$WORKSPACE/cmake-build/metadataGenerator" "."
 cp "$WORKSPACE/build/scripts/build-step-metadata-generator.py" "metadataGenerator/bin/"
 popd

--- a/build/scripts/build-step-metadata-generator.py
+++ b/build/scripts/build-step-metadata-generator.py
@@ -70,7 +70,7 @@ def save_stream_to_file(filename, stream):
 # noinspection PyShadowingNames
 def generate_metadata(arch):
     # metadata generator arguments
-    generator_call = ["./objc-metadata-generator", "-verbose"
+    generator_call = ["./objc-metadata-generator", "-verbose",
                       "-output-bin", "{}/metadata-{}.bin".format(conf_build_dir, arch),
                       "-output-umbrella", "{}/umbrella-{}.h".format(conf_build_dir, arch),
                       "-docset-path", docset_path]

--- a/build/scripts/build-step-metadata-generator.py
+++ b/build/scripts/build-step-metadata-generator.py
@@ -59,6 +59,7 @@ docset_path = os.path.join(os.path.expanduser("~"),
                            "Library/Developer/Shared/Documentation/DocSets/com.apple.adc.documentation.{}.docset"
                            .format(docset_platform))
 yaml_output_folder = env_or_none("TNS_DEBUG_METADATA_PATH")
+strict_includes = env_or_none("TNS_DEBUG_METADATA_STRICT_INCLUDES")
 
 
 def save_stream_to_file(filename, stream):
@@ -74,6 +75,9 @@ def generate_metadata(arch):
                       "-output-bin", "{}/metadata-{}.bin".format(conf_build_dir, arch),
                       "-output-umbrella", "{}/umbrella-{}.h".format(conf_build_dir, arch),
                       "-docset-path", docset_path]
+
+    if strict_includes is not None:
+        generator_call.extend(["-strict-includes={}".format(strict_includes)])
 
     # optionally add typescript output folder
     if typescript_output_folder is not None:

--- a/build/scripts/build-step-metadata-generator.py
+++ b/build/scripts/build-step-metadata-generator.py
@@ -70,7 +70,7 @@ def save_stream_to_file(filename, stream):
 # noinspection PyShadowingNames
 def generate_metadata(arch):
     # metadata generator arguments
-    generator_call = ["./objc-metadata-generator",
+    generator_call = ["./objc-metadata-generator", "-verbose"
                       "-output-bin", "{}/metadata-{}.bin".format(conf_build_dir, arch),
                       "-output-umbrella", "{}/umbrella-{}.h".format(conf_build_dir, arch),
                       "-docset-path", docset_path]


### PR DESCRIPTION
Also add diagnostic output to stderr stream and enable it by default
in `build-step-metadata-generator.py`

This option is still needed in some cases and I couldn't find a way to disable it.
These are the issues we've run into with its disabling so far:

* In Objective-C mode level-db framework breaks parsing because it includes
c++ headers without checking whether the compiler is in C++ mode

* In Objective-C++ mode many issues occurred. Some of them might be circumventable
but the one which made me discard the effors was that enums are lost due to the
following definition taken from CoreFoundation:
```
#if (__cplusplus)
#define CF_OPTIONS(_type, _name) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _type
#else
#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
#endif
```

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs https://github.com/NativeScript/ios-runtime/issues/1117#issuecomment-481989276