### PR TITLE
fix: return WrappedObject for classes with no meta

### DIFF
--- a/src/NativeScript/GlobalObject.h
+++ b/src/NativeScript/GlobalObject.h
@@ -98,7 +98,7 @@ public:
         return this->_interop.get();
     }
 
-    JSC::Strong<ObjCConstructorBase> constructorFor(Class klass, Class fallback = Nil);
+    JSC::Strong<ObjCConstructorBase> constructorFor(Class klass, Class fallback = Nil, bool searchBaseClasses = true);
 
     JSC::Strong<ObjCProtocolWrapper> protocolWrapperFor(Protocol* aProtocol);
 

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -449,7 +449,7 @@ void GlobalObject::getOwnPropertyNames(JSObject* object, ExecState* execState, P
 }
 #endif
 
-Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, Class fallback) {
+Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, Class fallback, bool searchBaseClasses) {
     ASSERT(klass);
 
     auto kvp = this->_objCConstructors.find(klass);
@@ -458,6 +458,10 @@ Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, Class fall
     }
 
     const Meta* meta = MetaFile::instance()->globalTable()->findMeta(class_getName(klass));
+    if(!searchBaseClasses && meta == nullptr) {
+        return Strong<ObjCConstructorBase>();
+    }
+    
     while (!(meta && meta->type() == MetaType::Interface)) {
         klass = class_getSuperclass(klass);
         meta = MetaFile::instance()->globalTable()->findMeta(class_getName(klass));

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -99,6 +99,12 @@ describe(module.id, function () {
         expect(object instanceof NSObject).toBe(true);
     });
 
+    it("NSStringFromClassForClassWithoutMetadata", function () {
+        var c = UITableViewCell.new();
+        // UITableViewCellContentView is internal class thus we don't have metadata for it
+        expect(NSStringFromClass(c.subviews[0].class())).toBe('UITableViewCellContentView');
+    });
+
     it("Appearance", function () {
         expect(UILabel.appearance().description.indexOf('<Customizable class: UILabel>')).not.toBe(-1);
 
@@ -410,7 +416,7 @@ describe(module.id, function () {
     if (interop.sizeof(interop.Pointer) == 8) {
         it("TaggedPointers", function () {
             expect(NSDate.dateWithTimeIntervalSinceReferenceDate(0)).toBe(NSDate.dateWithTimeIntervalSinceReferenceDate(0));
-            expect(NSDate.dateWithTimeIntervalSinceReferenceDate(0).class()).toBe(NSDate);
+            expect(NSDate.dateWithTimeIntervalSinceReferenceDate(0).class()).toBe(NSClassFromString("__NSTaggedDate"));
         });
     }
 
@@ -693,7 +699,7 @@ describe(module.id, function () {
         if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 11, minorVersion: 0, patchVersion: 0})) {
             props = props.concat("landscapeImagePhone", "landscapeImagePhoneInsets");
         }
-       
+
         for (var klass of classConstructors) {
             var instance = new global[klass]();
             for (var prop of props) {
@@ -701,21 +707,21 @@ describe(module.id, function () {
             }
         }
     });
- 
+
     it("Unimplemented properties from MTLRenderPassAttachmentDescriptor class should be provided by the inheritors", function () {
-        var classConstructors = [ 
-            "MTLRenderPassDepthAttachmentDescriptor", "MTLRenderPassStencilAttachmentDescriptor", 
+        var classConstructors = [
+            "MTLRenderPassDepthAttachmentDescriptor", "MTLRenderPassStencilAttachmentDescriptor",
             "MTLRenderPassColorAttachmentDescriptor"
         ];
         var props = [
             "depthPlane", "level", "loadAction", "resolveDepthPlane", "resolveLevel", "resolveSlice",
             "resolveTexture", "slice", "storeAction", "texture"
         ];
-        
+
         if (NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 11, minorVersion: 0, patchVersion: 0})) {
             props = props.concat("storeActionOptions");
         }
-       
+
         for (var klass of classConstructors) {
             var instance = new global[klass]();
             for (var prop of props) {

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -69,7 +69,7 @@ describe("Constructing Objective-C classes with new operator", function () {
 
     it("NSArray with JS array constructor", function () {
         var nsarray = new NSArray([1, 2, 3]);
-        expect(nsarray.class()).toBe(NSArray);
+        expect(nsarray.class()).toBe(NSClassFromString("__NSArrayI"));
     });
 
     it("Invalid empty constructor args", function () {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behaviour?
When an Objective C class is read and there is no metadata for it we are getting the constructor from the first of its parents that have metadata.

## What is the new behaviour?
When there's no metadata for a given Objective C class we are returning a wrapped object instead of it's parent constructor. 

Related to #1120