### PR TITLE
fix: Unicode properties

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -751,13 +751,13 @@ struct BaseClassMeta : Meta {
     const MembersCollection members(const char* identifier, size_t length, MemberType type, bool includeProtocols = true, bool onlyIfAvailable = true) const;
 
     const MemberMeta* member(StringImpl* identifier, MemberType type, bool includeProtocols = true) const {
-        const char* identif = reinterpret_cast<const char*>(identifier->characters8());
+        const char* identif = reinterpret_cast<const char*>(identifier->utf8().data());
         size_t length = (size_t)identifier->length();
         return this->member(identif, length, type, includeProtocols);
     }
 
     const MethodMeta* member(StringImpl* identifier, MemberType type, size_t paramsCount, bool includeProtocols = true) const {
-        const char* identif = reinterpret_cast<const char*>(identifier->characters8());
+        const char* identif = reinterpret_cast<const char*>(identifier->utf8().data());
         size_t length = (size_t)identifier->length();
         return this->member(identif, length, type, paramsCount, includeProtocols);
     }

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -45,7 +45,7 @@ static int compareIdentifiers(const char* nullTerminated, const char* notNullTer
 }
 
 const InterfaceMeta* GlobalTable::findInterfaceMeta(WTF::StringImpl* identifier) const {
-    return this->findInterfaceMeta(reinterpret_cast<const char*>(identifier->characters8()), identifier->length(), identifier->hash());
+    return this->findInterfaceMeta(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash());
 }
 
 const InterfaceMeta* GlobalTable::findInterfaceMeta(const char* identifierString) const {
@@ -81,7 +81,7 @@ const InterfaceMeta* GlobalTable::findInterfaceMeta(const char* identifierString
 }
 
 const ProtocolMeta* GlobalTable::findProtocol(WTF::StringImpl* identifier) const {
-    return this->findProtocol(reinterpret_cast<const char*>(identifier->characters8()), identifier->length(), identifier->hash());
+    return this->findProtocol(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash());
 }
 
 const ProtocolMeta* GlobalTable::findProtocol(const char* identifierString) const {
@@ -100,7 +100,7 @@ const ProtocolMeta* GlobalTable::findProtocol(const char* identifierString, size
 }
 
 const Meta* GlobalTable::findMeta(WTF::StringImpl* identifier, bool onlyIfAvailable) const {
-    return this->findMeta(reinterpret_cast<const char*>(identifier->characters8()), identifier->length(), identifier->hash(), onlyIfAvailable);
+    return this->findMeta(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash(), onlyIfAvailable);
 }
 
 const Meta* GlobalTable::findMeta(const char* identifierString, bool onlyIfAvailable) const {

--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -113,7 +113,7 @@ void overrideObjcMethodWrapperCalls(ExecState* execState, Class klass, JSCell* m
     if (warnForMultipleOverrides) {
         WTF::String message = WTF::String::format("More than one native methods overriden! Assigning to \"%s\" will override native methods with the following selectors: %s.",
                                                   jsName.c_str(),
-                                                  metaNames.characters8());
+                                                  metaNames.toString().utf8().data());
         warn(execState, message);
     }
 }


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Getting a unicode property's value will fail (or crash in debug):

```
let obj = NSObject.alloc().init();
obj.Ł = "Ł";
console.log(obj.Ł);
```

This is caused by the following ASSERT in WebKit:
```
ALWAYS_INLINE const LChar* characters8() const { ASSERT(is8Bit()); return m_data8; }
```


In general using characters8() may lead to unexpected behavior as [here](https://github.com/NativeScript/NativeScript/issues/7120)

## What is the new behavior?
Unicode properties work as expected.

Fixes: https://github.com/NativeScript/NativeScript/issues/7120

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

