### PR TITLE
Add NS_LD variable to be used for alternate linker

### DIFF
--- a/build/project-template/internal/nsld.sh
+++ b/build/project-template/internal/nsld.sh
@@ -42,7 +42,8 @@ GEN_MODULEMAP
 printf "Generating metadata..."
 GEN_METADATA
 DELETE_SWIFT_MODULES_DIR
-$TOOLCHAIN_DIR/usr/bin/clang $@
+$NS_LD="${NS_LD:-"$TOOLCHAIN_DIR/usr/bin/clang"}"
+$NS_LD "$@"
 
 
 

--- a/build/project-template/internal/nsld.sh
+++ b/build/project-template/internal/nsld.sh
@@ -42,7 +42,7 @@ GEN_MODULEMAP
 printf "Generating metadata..."
 GEN_METADATA
 DELETE_SWIFT_MODULES_DIR
-$NS_LD="${NS_LD:-"$TOOLCHAIN_DIR/usr/bin/clang"}"
+NS_LD="${NS_LD:-"$TOOLCHAIN_DIR/usr/bin/clang"}"
 $NS_LD "$@"
 
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
nsld.sh script always calls $TOOLCHAIN_DIR/usr/bin/clang.

## What is the new behavior?
Introduce new NS_LD variable that can point to an alternate linker that user wants to use. If not set - then we call the default one.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

