### PR TITLE
added const to avoid using `seen` as global

### DIFF
--- a/src/NativeScript/smartStringify.js
+++ b/src/NativeScript/smartStringify.js
@@ -1,5 +1,5 @@
 (function (object) {
-    seen = [];
+    const seen = [];
     var replacer = function (key, value) {
         if (value != null && typeof value == "object") {
             if (seen.indexOf(value) >= 0) {


### PR DESCRIPTION
Related to https://github.com/NativeScript/android-runtime/issues/1358

Avoid memory leak by adding `const` before the `seen` variable to use local variable.