### PR TITLE
 fix(bridge): Synchronize access to Strong handles in collection adapters

### DIFF
--- a/build/npm/inspector_package.json
+++ b/build/npm/inspector_package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-ios-inspector",
   "description": "Telerik NativeScript Inspector for iOS Runtime",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "keywords": [
     "NativeScript",
     "iOS",

--- a/build/npm/runtime_package.json
+++ b/build/npm/runtime_package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-ios",
   "description": "Telerik NativeScript Runtime for iOS",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

* `TNSArrayAdapter`, `TNSDataAdapter` and `TNSDictionaryAdapter` hold `Strong`
references to their underlying JS objects. When the Objective-C instances of these
classes were `dealloc`-ed, these references' destructors were being called outside
of the JSC VM's lock which lead to nasty and rarely occurring crashes when such
adapters are being used in threads different than the main thread of the JSC engine.

  * Do not store `ExecState`s as calls to an adapter can be made long after the JS
state has changed. Use global object's `globalExec` instead.
  * Reset `Strong` handles inside the locked section. This way the C++ destructor
of a nullptr handle will not have to modify anything in the VM's heap.

* Dump the native and JavaScript callstacks when any
of SIGABRT SIGILL, SIGSEGV, SIGFPE or SIGBUS is received.
