### PR TITLE
 fix(workers): Objective-C autoreleased objects leak 

### DIFF
--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -29,7 +29,7 @@ static UInt8 getSystemVersion() {
     UInt8 majorVersion = (UInt8)[versionTokens[0] intValue];
     UInt8 minorVersion = (UInt8)[versionTokens[1] intValue];
 
-    return encodeVersion(majorVersion, minorVersion);
+    return iosVersion = encodeVersion(majorVersion, minorVersion);
 }
 std::unordered_map<std::string, MembersCollection> getMetasByJSNames(MembersCollection members) {
     std::unordered_map<std::string, MembersCollection> result;


### PR DESCRIPTION
Each worker task should have its own autorelease pool so that
objects don't remain in memory throughout the whole worker's
lifetime.

Cache result in getSystemVersion - this caching has been broken with https://github.com/NativeScript/ios-runtime/commit/850e5e45794db79c5d3a35fe0af7c8542fc8d528#diff-d14ec105c5ba1de0835c6d67c97a4ef6

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #1137 
