### PR TITLE
fix(runtime): Resend handled signal instead of exitting

### DIFF
--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -15,7 +15,6 @@
 #include <JavaScriptCore/JSModuleLoader.h>
 #include <JavaScriptCore/JSNativeStdFunction.h>
 #include <JavaScriptCore/inspector/JSGlobalObjectInspectorController.h>
-#include <iostream>
 
 #if PLATFORM(IOS)
 #import <UIKit/UIApplication.h>
@@ -114,7 +113,8 @@ void sig_handler(int sig) {
         oldHandlers[sig](sig);
     }
 
-    exit(-sig);
+    signal(sig, nullptr);
+    kill(getpid(), sig);
 }
 
 void install_handler(int sig) {


### PR DESCRIPTION
After introducing our signal handler crashes have stopped being
detected by Firebase. Uninstall our handler and re-send the signal so that
the app crashes instead of exits.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

ref https://github.com/NativeScript/ios-runtime/issues/1137#issuecomment-498586218