### PR TITLE
fix(jsc): Do not send source parsed events on attach.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ previous_url: /Changelogs/iOS Runtime
 ### Bug Fixes
 
 * **metadata-generator:** Place Swift headers at the bottom of the umbrella header ([#1153](https://github.com/NativeScript/ios-runtime/issues/1153))
-
+* **jsc:** Incorrect sources shown in Chrome DevTools when attaching to application ([#1158](https://github.com/NativeScript/ios-runtime/issues/1158))
 
 5.4.1 (2019-06-06)
 =====


### PR DESCRIPTION
Here they are randomly ordered and this causes https://github.com/NativeScript/ios-runtime/issues/1158.
All sources will be sent by NativeScript on debugger enable event in
`GlobalObjectDebuggerAgent::enable()` and the order there will be the
correct one because they are taken from module loader's registry.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #1158 
