### PR TITLE
fix(project-template): Find Swift bridging header when building metadata

### DIFF
--- a/build/project-template/internal/nsld.sh
+++ b/build/project-template/internal/nsld.sh
@@ -4,38 +4,36 @@ source ./.build_env_vars.sh
 MODULES_DIR=$SRCROOT/internal/Swift-Modules
 
 function DELETE_SWIFT_MODULES_DIR() {
-  rm -rf $MODULES_DIR
+    rm -rf $MODULES_DIR
 }
 
 function GEN_MODULEMAP() {
-  DERIVED_SOURCES=$DERIVED_FILES_DIR
+    SWIFT_HEADER_DIR=$PER_VARIANT_OBJECT_FILE_DIR
 
-  if [ -d "$DERIVED_SOURCES" ]; then
-    count=`ls $DERIVED_SOURCES/*-Swift.h 2>/dev/null | wc -l`
-
-      if [ $count == 1 ]
-      then
-          HEADER_PATH=`find $DERIVED_SOURCES -name *-Swift.h`
-          DELETE_SWIFT_MODULES_DIR
-
-          mkdir -p $MODULES_DIR
-          CONTENT="module nsswiftsupport { \n header \"$HEADER_PATH\" \n export * \n}"
-          printf "$CONTENT" > "$MODULES_DIR/module.modulemap"
-      else
-      echo "NSLD: Swift bridging header '*-Swift.h' not found"
-      fi
-  else
-    echo "NSLD: Derived sources directory not found"
-  fi
-
+    DELETE_SWIFT_MODULES_DIR
+    if [ -d "$SWIFT_HEADER_DIR" ]; then
+        HEADERS_PATHS=$(find $SWIFT_HEADER_DIR -name *-Swift.h 2>/dev/null)
+        if [ -n "$HEADERS_PATHS" ]; then
+            # Workaround for ARCH being set to `undefined_arch` here. Get the newest -Swift.h
+            # if more than one is found. It should be the one for the current architecture.
+            HEADER_PATH=$(ls -t $HEADERS_PATHS | head -n 1)
+            mkdir -p $MODULES_DIR
+            CONTENT="module nsswiftsupport { \n header \"$HEADER_PATH\" \n export * \n}"
+            printf "$CONTENT" > "$MODULES_DIR/module.modulemap"
+        else
+            echo "NSLD: Swift bridging header '*-Swift.h' not found under $SWIFT_HEADER_DIR"
+        fi
+    else
+        echo "NSLD: Directory for Swift headers ($SWIFT_HEADER_DIR) not found."
+    fi
 }
 
 function GEN_METADATA() {
-  set -e
+    set -e
 
-  pushd "$SRCROOT/internal/metadata-generator/bin"
-  ./build-step-metadata-generator.py
-  popd
+    pushd "$SRCROOT/internal/metadata-generator/bin"
+    ./build-step-metadata-generator.py
+    popd
 }
 
 GEN_MODULEMAP
@@ -44,7 +42,3 @@ GEN_METADATA
 DELETE_SWIFT_MODULES_DIR
 NS_LD="${NS_LD:-"$TOOLCHAIN_DIR/usr/bin/clang"}"
 $NS_LD "$@"
-
-
-
-


### PR DESCRIPTION
Xcode 10.2 generates the final merged `-Swift.h` file some time
after invoking the linker. Instead of that header we now
find and use the one generated for the current architecture.
It is emitted before the linker has been started.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

refs #1166

**Additional info**

The three bridging headers that get generated for a simulator build  are:
```
platforms/ios/build/TestApp.build/Debug-iphonesimulator/TestApp.build/Objects-normal/i386/TestApp-Swift.h
platforms/ios/build/TestApp.build/Debug-iphonesimulator/TestApp.build/Objects-normal/x86_64/TestApp-Swift.h
platforms/ios/build/TestApp.build/Debug-iphonesimulator/TestApp.build/DerivedSources/TestApp-Swift.h
```
We're now finding and using the one for the currently linked architecture from `Objects-normal`,
while previously we used the merged one in `DerivedSources`

