### PR TITLE
fix(project-template): Correct metadata when path contains spaces

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -341,8 +341,8 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$SRCROOT/internal/Swift-Modules",
-					"$(SRCROOT)/internal",
+					"\"$SRCROOT/internal/Swift-Modules\"",
+					"\"$(SRCROOT)/internal\"",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/__PROJECT_NAME__/__PROJECT_NAME__-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/build/project-template/internal/nsld.sh
+++ b/build/project-template/internal/nsld.sh
@@ -7,21 +7,32 @@ function DELETE_SWIFT_MODULES_DIR() {
     rm -rf "$MODULES_DIR"
 }
 
+function getArch() {
+    while [[ $# -gt 0 ]]
+    do
+        case $1 in
+            -arch)
+                printf $2
+                return
+                ;;
+        esac
+        shift
+    done
+}
+
 function GEN_MODULEMAP() {
-    SWIFT_HEADER_DIR=$PER_VARIANT_OBJECT_FILE_DIR
+    ARCH_ARG=$1
+    SWIFT_HEADER_DIR=$PER_VARIANT_OBJECT_FILE_DIR/$ARCH_ARG
 
     DELETE_SWIFT_MODULES_DIR
     if [ -d "$SWIFT_HEADER_DIR" ]; then
-        HEADERS_PATHS=$(find "$SWIFT_HEADER_DIR" -name *-Swift.h 2>/dev/null)
-        if [ -n "$HEADERS_PATHS" ]; then
-            # Workaround for ARCH being set to `undefined_arch` here. Get the newest -Swift.h
-            # if more than one is found. It should be the one for the current architecture.
-            HEADER_PATH=$(ls -t "$HEADERS_PATHS" | head -n 1)
+        HEADER_PATH=$(find "$SWIFT_HEADER_DIR" -name '*-Swift.h' 2>/dev/null)
+        if [ -n "$HEADER_PATH" ]; then
             mkdir -p "$MODULES_DIR"
             CONTENT="module nsswiftsupport { \n header \"$HEADER_PATH\" \n export * \n}"
             printf "$CONTENT" > "$MODULES_DIR/module.modulemap"
         else
-            echo "NSLD: Swift bridging header '*-Swift.h' not found under $SWIFT_HEADER_DIR"
+            echo "NSLD: Swift bridging header '*-Swift.h' not found under '$SWIFT_HEADER_DIR'"
         fi
     else
         echo "NSLD: Directory for Swift headers ($SWIFT_HEADER_DIR) not found."
@@ -36,7 +47,8 @@ function GEN_METADATA() {
     popd
 }
 
-GEN_MODULEMAP
+# Workaround for ARCH being set to `undefined_arch` here. Extract it from command line arguments.
+GEN_MODULEMAP $(getArch "$@")
 printf "Generating metadata..."
 GEN_METADATA
 DELETE_SWIFT_MODULES_DIR


### PR DESCRIPTION
* Swift bridging header was not being detected correctly when
there are spaces in the path
* Parse the `-arch` command line argument, instead of relying on
the timestamp to find out the correct architecture-specific bridging
header. Timestamp yielded incorrect results because:
	1) it has 1 second precision and
	2) even if it was precise it would still be unreliable because
headers may have been created by a previous build

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

