### PR TITLE
fix(runtime): Constructor functions' hierarchy

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -9,6 +9,7 @@
 #ifndef __NativeScript__Metadata__
 #define __NativeScript__Metadata__
 
+#include <set>
 #include <stack>
 #include <string>
 #include <type_traits>
@@ -766,6 +767,27 @@ struct BaseClassMeta : Meta {
     PtrTo<ArrayOfPtrTo<PropertyMeta>> staticProps;
     PtrTo<Array<String>> protocols;
     int16_t initializersStartIndex;
+
+    template <typename T>
+    void forEachProtocol(const T& fun, const ProtocolMetas* additionalProtocols) const {
+        for (Array<String>::iterator it = this->protocols->begin(); it != this->protocols->end(); ++it) {
+            if (const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTable()->findProtocol((*it).valuePtr())) {
+                fun(protocolMeta);
+            }
+        }
+
+        if (additionalProtocols) {
+            for (const ProtocolMeta* protocolMeta : *additionalProtocols) {
+                fun(protocolMeta);
+            }
+        }
+    }
+
+    std::set<const ProtocolMeta*> protocolsSet() const;
+
+    std::set<const ProtocolMeta*> deepProtocolsSet() const;
+
+    void deepProtocolsSet(std::set<const ProtocolMeta*>& protocols) const;
 
     const MemberMeta* member(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable, const ProtocolMetas& additionalProtocols) const;
 

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -18,6 +18,7 @@
 #include "ObjCTypes.h"
 #include "ObjCWrapperObject.h"
 #include "PointerInstance.h"
+#include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/JSMap.h>
 #include <wtf/text/StringBuilder.h>
@@ -130,22 +131,23 @@ void ObjCConstructorBase::finishCreation(VM& vm,
                                          JSGlobalObject* globalObject,
                                          JSObject* prototype,
                                          const ConstructorKey& key) {
-    WTF::String functionName(class_getName(key.klasses.known));
+    Base::finishCreation(vm, class_getName(key.klasses.known));
 
+    WTF::String __constructorDescription("Known class: ");
+    __constructorDescription.append(class_getName(key.klasses.known));
     if (key.klasses.unknown) {
-        functionName.append("_private_");
-        functionName.append(class_getName(key.klasses.unknown));
+        __constructorDescription.append(" Unknown class: ");
+        __constructorDescription.append(class_getName(key.klasses.unknown));
     }
 
     if (key.additionalProtocols.size()) {
-        functionName.append("_protocols");
+        __constructorDescription.append(" Additional protocols:");
         for (auto proto : key.additionalProtocols) {
-            functionName.append("_");
-            functionName.append(proto->name());
+            __constructorDescription.append(" ");
+            __constructorDescription.append(proto->name());
         }
     }
-
-    Base::finishCreation(vm, functionName);
+    putDirect(vm, Identifier::fromString(&vm, "__constructorDescription"), jsString(&vm, __constructorDescription), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
 
     this->_prototype.set(vm, this, prototype);
     this->_instancesStructure.set(vm, this, ObjCWrapperObject::createStructure(vm, globalObject, prototype));

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -417,6 +417,7 @@ void ObjCClassBuilder::addInstanceMembers(ExecState* execState, JSObject* instan
 
         GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
         IMP imp = imp_implementationWithBlock(^NSUInteger(id self, NSFastEnumerationState* state, id buffer[], NSUInteger length) {
+          JSLockHolder lock(globalObject->vm());
           return TNSFastEnumerationAdapter(self, state, buffer, length, globalObject);
         });
 

--- a/tests/TestFixtures/Interfaces/TNSInheritance.h
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.h
@@ -86,8 +86,13 @@
 //- (NSURLSessionDownloadTask *)downloadTaskWithURL:(NSURL *)url completionHandler:(void (^)(NSURL * _Nullable location, NSURLResponse * _Nullable response, NSError * _Nullable error))completionHandler;
 // claim to return TNSIBaseInterface but instances are objects of an unrelated type which implements the methods
 + (TNSIBaseInterface*)instanceFromUnrelatedPrivateType;
+
 // inspired from MTLCreateSystemDefaultDevice
 //MTL_EXTERN id <MTLDevice> __nullable MTLCreateSystemDefaultDevice(void) API_AVAILABLE(macos(10.11), ios(8.0)) NS_RETURNS_RETAINED;
 + (id<TNSIBaseProtocol>)instanceFromPrivateTypeImplementingProtocol;
+
++ (id<TNSIBaseProtocol, TNSIDerivedProtocol>)instanceFromPrivateTypeImplementingTwoProtocols;
+
++ (id<TNSIBaseProtocol>)instanceFromPublicTypeImplementingProtocol;
 
 @end

--- a/tests/TestFixtures/Interfaces/TNSInheritance.m
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.m
@@ -181,4 +181,12 @@
     return [TNSIBaseInterface_Private new];
 }
 
++ (id<TNSIBaseProtocol, TNSIDerivedProtocol>)instanceFromPrivateTypeImplementingTwoProtocols {
+    return (id<TNSIBaseProtocol, TNSIDerivedProtocol>)[TNSIBaseInterface_Private new];
+}
+
++ (id<TNSIBaseProtocol>)instanceFromPublicTypeImplementingProtocol {
+    return [TNSIBaseInterface new];
+}
+
 @end

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -734,15 +734,15 @@ describe(module.id, function () {
     if (!isSimulator && interop.sizeof(interop.types.id) == 8) {
         it("MetalKit private interface members can be accessed", function() {
             const device = MTLCreateSystemDefaultDevice();
-            expect(device.toString()).toMatch(/\[object \w*?Device\]/);
+            expect(device.toString()).toMatch(/^<\w*?Device: 0x/);
             const queue = device.newCommandQueue();
-            expect(queue.toString()).toMatch(/\[object \w*?CommandQueue\]/);
+            expect(queue.toString()).toMatch(/^<\w*?CommandQueue: 0x/);
             const buffer = queue.commandBuffer();
-            expect(buffer.toString()).toMatch(/\[object \w*?CommandBuffer\]/);
+            expect(buffer.toString()).toMatch(/^<\w*?CommandBuffer: 0x/);
             const view = MTKView.alloc().initWithFrameDevice(CGRectMake(0,0,100,100), device);
-            expect(view.toString()).toMatch(/<MTKView: \w*; frame = \(0 0; 100 100\); .*>/);
+            expect(view.toString()).toMatch(/^<MTKView: 0x\w*; frame = \(0 0; 100 100\); .*>/);
             const texture = view.currentDrawable.texture;
-            expect(texture.toString()).toMatch(/\[object \w*?Texture\]/);
+            expect(texture.toString()).toMatch(/^<\w*?Texture: 0x/);
 
             buffer.presentDrawable(view.currentDrawable);
             buffer.commit();


### PR DESCRIPTION
Fix issues with `instenceof` operator returning `false`
for even public types which were being returned as `id<Proto>`
which arose with #1175

* Do not state unknown class and additional protocols in the
constructor functions' names. This lead to errors in the Firebase
plugin which relies heavily on class names to do object conversions.

* Remove redundant entries from additional protocols list before
creating a separate constructor function

* Add the pure class' constructor function to the inheritance hierarchy
of any additional constructor function (having additional protocol(s) or
wrapping an unknown private class)

* Extract `forEachProtocol` helper method

* Add unit tests

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

