### PR TITLE
fix(project-template): Correctly get architecture in `nsld` with Xcode 11

### DIFF
--- a/build/project-template/internal/nsld.sh
+++ b/build/project-template/internal/nsld.sh
@@ -15,6 +15,10 @@ function getArch() {
                 printf $2
                 return
                 ;;
+            -target)
+                printf `echo $2 | cut -f1 -d'-'`
+                return
+                ;;
         esac
         shift
     done


### PR DESCRIPTION
Xcode 11 doesn't specify an `-arch` argument but uses `-target` instead

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

