### PR TITLE
feat: Error.prepareStackTrace method support

### DIFF
--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -578,7 +578,7 @@ describe(module.id, function () {
                 .catch(error => {
                     expect(NSThread.currentThread.isMainThread).toBe(true);
                     expect(error.toString()).toMatch("index 2 beyond bounds");
-                    expect(error.stack).toEqual("objectAtIndex@[native code]\n[native code]");
+                    expect(error.stack).toEqual("objectAtIndex([native code])\nat [native code]");
                     done();
                 });
              });
@@ -729,7 +729,7 @@ describe(module.id, function () {
             }
         }
     });
-    
+
     // Metal is unavailable on iOS Simulator and devices with processors before A7 (arm64 on iPhone 5s)
     if (!isSimulator && interop.sizeof(interop.types.id) == 8) {
         it("MetalKit private interface members can be accessed", function() {
@@ -748,7 +748,7 @@ describe(module.id, function () {
             buffer.commit();
         });
     }
-         
+
     if (TNSIsConfigurationDebug) {
         // skip test in release because it requires downloading from the internet
         it("NSURLSession.sharedSession.downloadTaskWithURLCompletionHandler's ", function(done) {
@@ -763,7 +763,7 @@ describe(module.id, function () {
            });
            downloadPhotoTask.resume();
         });
-         
+
         it("Completion handler doesn't hijack main tests execution in a worker thread", function() {
            expect(NSThread.isMainThread).toBe(true);
         });

--- a/tests/TestRunner/app/StackTraceTests.js
+++ b/tests/TestRunner/app/StackTraceTests.js
@@ -4,23 +4,74 @@ describe("StackTrace", function () {
             throw new Error("Test");
         }
         catch (ex) {
-           expect(ex.stack.startsWith("file:///app/StackTraceTests.js:4:28\nat attemptSync(file:///")).toBe(true);
+            expect(ex.stack).toMatch(new RegExp("^file:///app/StackTraceTests\\.js:\\d*:\\d*\\nat attemptSync\\(file:///"));
         }
      });
-         
+
      it("Stack trace is formatted using prepareStackTrace", function () {
         Error.prepareStackTrace = function(error, frames) {
             expect(frames.length).toBeGreaterThan(2); // the idea here is to check that the frames are passed to the method
-            expect(frames[0]).toBe("file:///app/StackTraceTests.js:19:28");
+            expect(frames[0]).toMatch(new RegExp("^file:///app/StackTraceTests\\.js:\\d*:\\d*$"));
             return `Overridden stack trace with error: ${error}`;
         };
-        
+
         try {
             throw new Error("Test");
         }
         catch (ex) {
-            console.log(ex.stack);
             expect(ex.stack).toBe("Overridden stack trace with error: Error: Test");
+        }
+     });
+         
+     it("Stack trace frames should have the needed functions", function () {
+        var lastErrorFrame;
+        Error.prepareStackTrace = function(error, frames) {
+            lastErrorFrame = {
+                thisValue: frames[0].getThis(),
+                typeName: frames[0].getTypeName(),
+                functionValue: frames[0].getFunction(),
+                functionName: frames[0].getFunctionName(),
+                stringValue: frames[0].toString(),
+                fileName: frames[0].getFileName(),
+                lineNumber: frames[0].getLineNumber(),
+                columnNumber: frames[0].getColumnNumber(),
+                evalOrigin: frames[0].getEvalOrigin(),
+                isToplevel: frames[0].isToplevel(),
+                isEval: frames[0].isEval(),
+                isNative: frames[0].isNative(),
+                isConstructor: frames[0].isConstructor(),
+                isAsync: frames[0].isAsync(),
+                isPromiseAll: frames[0].isPromiseAll(),
+                promiseIndex: frames[0].getPromiseIndex()
+            }
+            return `Overridden stack trace with error: ${error}`;
+        };
+        
+        var testFunction = function testFunction() {
+            throw new Error("Test");
+        }
+        
+        try {
+            testFunction();
+        }
+        catch (ex) {
+            expect(ex.stack).toBe("Overridden stack trace with error: Error: Test");
+            expect(lastErrorFrame.thisValue).toBe(undefined);
+            expect(lastErrorFrame.typeName).toBe(undefined);
+            expect(lastErrorFrame.functionValue.toString()).toMatch(new RegExp("^function testFunction\\(\\)"));
+            expect(lastErrorFrame.functionName).toBe("testFunction");
+            expect(lastErrorFrame.fileName).toBe("file:///app/StackTraceTests.js");
+            expect(lastErrorFrame.stringValue).toMatch(new RegExp("^testFunction\\(file:///app/StackTraceTests\\.js:\\d+:\\d+\\)$"));
+            expect(lastErrorFrame.lineNumber).toMatch(new RegExp("^\\d+$"));
+            expect(lastErrorFrame.columnNumber).toMatch(new RegExp("^\\d+$"));
+            expect(lastErrorFrame.evalOrigin).toBe(undefined);
+            expect(lastErrorFrame.isToplevel).toBe(undefined);
+            expect(lastErrorFrame.isEval).toBe(undefined);
+            expect(lastErrorFrame.isNative).toBe(false);
+            expect(lastErrorFrame.isConstructor).toBe(undefined);
+            expect(lastErrorFrame.isAsync).toBe(undefined);
+            expect(lastErrorFrame.isPromiseAll).toBe(undefined);
+            expect(lastErrorFrame.promiseIndex).toBe(undefined);
         }
      });
          

--- a/tests/TestRunner/app/StackTraceTests.js
+++ b/tests/TestRunner/app/StackTraceTests.js
@@ -1,0 +1,36 @@
+describe("StackTrace", function () {
+     it("Stack trace is correctly formatted with 'at ....'", function () {
+        try {
+            throw new Error("Test");
+        }
+        catch (ex) {
+           expect(ex.stack.startsWith("file:///app/StackTraceTests.js:4:28\nat attemptSync(file:///")).toBe(true);
+        }
+     });
+         
+     it("Stack trace is formatted using prepareStackTrace", function () {
+        Error.prepareStackTrace = function(error, frames) {
+            expect(frames.length).toBeGreaterThan(2); // the idea here is to check that the frames are passed to the method
+            expect(frames[0]).toBe("file:///app/StackTraceTests.js:19:28");
+            return `Overridden stack trace with error: ${error}`;
+        };
+        
+        try {
+            throw new Error("Test");
+        }
+        catch (ex) {
+            console.log(ex.stack);
+            expect(ex.stack).toBe("Overridden stack trace with error: Error: Test");
+        }
+     });
+         
+     it("Stack trace formatting is not broken when prepareStackTrace is not a function", function () {
+        Error.prepareStackTrace = "not really a function";
+        try {
+            throw new Error("Test");
+        }
+        catch (ex) {
+            expect(ex.stack.startsWith("file:///app/StackTraceTests.js")).toBe(true);
+        }
+     });
+});

--- a/tests/TestRunner/app/index.js
+++ b/tests/TestRunner/app/index.js
@@ -55,6 +55,7 @@ import "./VersionDiffTests";
 import "./ObjCConstructors";
 
 import "./MetadataTests";
+import "./StackTraceTests";
 
 import "./ApiTests";
 import "./DeclarationConflicts";


### PR DESCRIPTION
Related to #1135

Added support for Error.prepareStackTrace method similar to the one in V8 and changed the format of the stack trace to be the same as android (also as node and browsers) with ```at ...```

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
