### PR TITLE
chore(Gameraww): Fix crash on startup

### DIFF
--- a/examples/Gameraww/app/DetailViewController.js
+++ b/examples/Gameraww/app/DetailViewController.js
@@ -26,7 +26,7 @@ var JSDetailViewController = UIViewController.extend({
         this.toggleTopBarVisibility();
     },
 
-    prefersStatusBarHidden: function () {
+    get prefersStatusBarHidden() {
         var navigationController = this.navigationController;
         var navigationBarHidden = navigationController.navigationBarHidden;
         return navigationBarHidden;

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -1620,6 +1620,17 @@ describe(module.id, function () {
         TNSClearOutput();
     });
 
+    it('PropertyOverrides: errors', function () {
+        expect(() => TNSIDerivedInterface.extend({
+                get derivedImplementedOptionalProperty() {
+                }
+        })).toThrowError('Property "derivedImplementedOptionalProperty" requires a setter function.');
+        expect(() => TNSIDerivedInterface.extend({
+            derivedImplementedOptionalProperty: function() {
+            } 
+        })).toThrowError('Cannot override native property "derivedImplementedOptionalProperty" with a function, define it as a JS property instead.');
+    });
+         
     it('ConstructorOverrideAndVirtualCall: prototype', function () {
         var JSObject = TNSIConstructorVirtualCalls.extend({
             initWithXAndY: function initWithXAndY(x, y) {


### PR DESCRIPTION
* Override `prefersStatusBarHidden` property with a JS property instead of a function
* Improve error handling and throw an exception when property is being overridden with a function
* Add unit tests for thrown exceptions when a property is being wrongly overridden

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

