### PR TITLE
fix: Improve error messages thrown by iOS runtime

### DIFF
--- a/src/NativeScript/Calling/FFICall.h
+++ b/src/NativeScript/Calling/FFICall.h
@@ -134,8 +134,8 @@ public:
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         if (!this->_argumentCountValidator(this, execState)) {
-            WTF::String message = WTF::String::format("Actual arguments count: \"%lu\". Expected: \"%lu\". ", execState->argumentCount(), this->parametersCount());
-            throwException(execState, scope, JSC::createError(execState, message));
+            WTF::String message = WTF::String::format("Actual arguments count: \"%lu\". Expected: \"%lu\".", execState->argumentCount(), this->parametersCount());
+            throwException(execState, scope, JSC::createError(execState, message, defaultSourceAppender));
             return;
         }
 

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -128,16 +128,16 @@ static EncodedJSValue JSC_HOST_CALL time(ExecState* execState) {
 static EncodedJSValue JSC_HOST_CALL releaseNativeCounterpart(ExecState* execState) {
     if (execState->argumentCount() != 1) {
         auto scope = DECLARE_THROW_SCOPE(execState->vm());
-        WTF::String message = WTF::String::format("Actual arguments count: \"%lu\". Expected: \"%lu\". ", execState->argumentCount(), 1);
-        return JSValue::encode(throwException(execState, scope, JSC::createError(execState, message)));
+        WTF::String message = WTF::String::format("Actual arguments count: \"%lu\". Expected: \"%lu\".", execState->argumentCount(), 1);
+        return JSValue::encode(throwException(execState, scope, JSC::createError(execState, message, defaultSourceAppender)));
     }
 
     auto arg0 = execState->argument(0);
     auto wrapper = jsDynamicCast<ObjCWrapperObject*>(execState->vm(), arg0);
     if (!wrapper) {
         auto scope = DECLARE_THROW_SCOPE(execState->vm());
-        WTF::String message("Argument is an object which is not a native wrapper.");
-        return JSValue::encode(throwException(execState, scope, JSC::createError(execState, message)));
+        JSValue error = JSC::createError(execState, arg0, "is an object which is not a native wrapper."_s, defaultSourceAppender);
+        return JSValue::encode(throwException(execState, scope, error));
     }
 
     wrapper->setWrappedObject(nil);

--- a/src/NativeScript/GlobalObject.moduleLoader.mm
+++ b/src/NativeScript/GlobalObject.moduleLoader.mm
@@ -299,7 +299,7 @@ Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, ExecS
 
     if (!absoluteFilePath) {
         WTF::String errorMessage = WTF::String::format("Could not find module '%s'. Computed path '%s'.", keyValue.toWTFString(execState).utf8().data(), absolutePath.UTF8String);
-        throwException(execState, scope, createError(execState, errorMessage));
+        throwException(execState, scope, createError(execState, errorMessage, defaultSourceAppender));
         return Identifier();
     }
 

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -174,6 +174,7 @@ static EncodedJSValue JSC_HOST_CALL interopFuncFree(ExecState* execState) {
     }
 
     free(pointer->data());
+    pointer->reset();
 
     return JSValue::encode(jsUndefined());
 }
@@ -350,7 +351,11 @@ JSValue Interop::pointerInstanceForPointer(ExecState* execState, void* value) {
     }
 
     if (PointerInstance* pointerInstance = this->_pointerToInstance.get(value)) {
-        return pointerInstance;
+        // Pointer instance could have been freed, reuse it from cache only if it is still alive
+        ASSERT(pointerInstance->data() == value || pointerInstance->data() == nullptr);
+        if (pointerInstance->data()) {
+            return pointerInstance;
+        }
     }
 
     auto pointerInstance = PointerInstance::create(execState, this->_pointerInstanceStructure.get(), value);

--- a/src/NativeScript/Interop.mm
+++ b/src/NativeScript/Interop.mm
@@ -165,13 +165,12 @@ static EncodedJSValue JSC_HOST_CALL interopFuncFree(ExecState* execState) {
 
     if (!pointerValue.inherits(vm, PointerInstance::info())) {
         const char* className = PointerInstance::info()->className;
-        return JSValue::encode(scope.throwException(execState, createError(execState, WTF::String::format("Argument must be a %s.", className))));
+        return JSValue::encode(scope.throwException(execState, createError(execState, pointerValue, WTF::String::format("must be a %s.", className), defaultSourceAppender)));
     }
 
     PointerInstance* pointer = jsCast<PointerInstance*>(pointerValue);
     if (pointer->isAdopted()) {
-        const char* className = PointerInstance::info()->className;
-        return JSValue::encode(scope.throwException(execState, createError(execState, WTF::String::format("%s is adopted.", className))));
+        return JSValue::encode(scope.throwException(execState, createError(execState, pointer, "is adopted."_s, defaultSourceAppender)));
     }
 
     free(pointer->data());
@@ -205,7 +204,7 @@ static EncodedJSValue JSC_HOST_CALL interopFuncHandleof(ExecState* execState) {
     if (!hasHandle) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        return JSValue::encode(scope.throwException(execState, createError(execState, "Unknown type"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, value, "Unknown type"_s, defaultSourceAppender)));
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
@@ -221,7 +220,7 @@ static EncodedJSValue JSC_HOST_CALL interopFuncSizeof(ExecState* execState) {
     if (size == 0) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        return JSValue::encode(scope.throwException(execState, createError(execState, "Unknown type"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, value, "Unknown type"_s, defaultSourceAppender)));
     }
 
     return JSValue::encode(jsNumber(size));

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.cpp
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceConstructor.cpp
@@ -28,7 +28,7 @@ EncodedJSValue JSC_HOST_CALL FunctionReferenceConstructor::constructFunctionRefe
     if (!(execState->argumentCount() == 1 && JSC::getCallData(vm, execState->uncheckedArgument(0), callData) != CallType::None)) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        return JSValue::encode(scope.throwException(execState, createError(execState, "Function required."_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, "Exactly 1 argument which must be a function required."_s, defaultSourceAppender)));
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());

--- a/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/FunctionReference/FunctionReferenceTypeInstance.cpp
@@ -46,7 +46,7 @@ void FunctionReferenceTypeInstance::write(ExecState* execState, const JSValue& v
     if (!hasHandle) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a function reference."_s);
+        JSValue exception = createError(execState, value, "is not a function reference."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
+++ b/src/NativeScript/Marshalling/Fundamentals/FFIPrimitiveTypes.cpp
@@ -23,14 +23,14 @@ static JSValue noopType_read(ExecState* execState, const void* buffer, JSCell* s
     JSC::VM& vm = execState->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue exception = createError(execState, "Can not read from noop type."_s);
+    JSValue exception = createError(execState, "Can not read from noop type."_s, defaultSourceAppender);
     return scope.throwException(execState, exception);
 }
 static void noopType_write(ExecState* execState, const JSValue& value, void* buffer, JSCell* self) {
     JSC::VM& vm = execState->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue exception = createError(execState, "Can not write to noop type."_s);
+    JSValue exception = createError(execState, "Can not write to noop type."_s, defaultSourceAppender);
     scope.throwException(execState, exception);
 }
 static bool noopType_canConvert(ExecState* execState, const JSValue& value, JSCell* self) {
@@ -95,7 +95,7 @@ static void unicharType_write(ExecState* execState, const JSValue& value, void* 
         JSC::VM& vm = execState->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Only one character string can be converted to unichar."_s);
+        JSValue exception = createError(execState, "Only one character strings can be converted to unichar."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }
@@ -153,7 +153,7 @@ static void cStringType_write(ExecState* execState, const JSValue& value, void* 
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue exception = createError(execState, "Value is not a string."_s);
+    JSValue exception = createError(execState, value, "is not a string."_s, defaultSourceAppender);
     scope.throwException(execState, exception);
     return;
 }

--- a/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerConstructor.cpp
@@ -86,7 +86,7 @@ void PointerConstructor::write(ExecState* execState, const JSValue& value, void*
     if (!hasHandle) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a pointer."_s);
+        JSValue exception = createError(execState, value, "is not a pointer."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/Marshalling/Pointer/PointerInstance.cpp
+++ b/src/NativeScript/Marshalling/Pointer/PointerInstance.cpp
@@ -48,7 +48,9 @@ void PointerInstance::finishCreation(ExecState* execState, void* value) {
 PointerInstance::~PointerInstance() {
     if (this->_isAdopted) {
         free(this->_data);
-        this->_data = nullptr;
     }
+
+    this->reset();
 }
+
 }; // namespace NativeScript

--- a/src/NativeScript/Marshalling/Pointer/PointerInstance.h
+++ b/src/NativeScript/Marshalling/Pointer/PointerInstance.h
@@ -37,6 +37,10 @@ public:
         return this->_data;
     }
 
+    void reset() {
+        this->_data = nullptr;
+    }
+
     bool isAdopted() const {
         return this->_isAdopted;
     }

--- a/src/NativeScript/Marshalling/Record/RecordConstructor.cpp
+++ b/src/NativeScript/Marshalling/Record/RecordConstructor.cpp
@@ -77,7 +77,7 @@ static EncodedJSValue JSC_HOST_CALL recordConstructorFuncEquals(ExecState* execS
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (execState->argumentCount() != 2) {
-        return JSValue::encode(scope.throwException(execState, createError(execState, "Two arguments required."_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, "Two arguments required."_s, defaultSourceAppender)));
     }
 
     RecordConstructor* recordConstructor = jsCast<RecordConstructor*>(execState->thisValue());
@@ -92,6 +92,7 @@ JSValue RecordConstructor::read(ExecState* execState, const void* buffer, JSCell
     const size_t size = constructor->_ffiTypeMethodTable.ffiType->size;
 
     void* data = malloc(size);
+    ASSERT(buffer);
     memcpy(data, buffer, size);
     PointerInstance* pointer = jsCast<PointerInstance*>(globalObject->interop()->pointerInstanceForPointer(execState, data));
     pointer->setAdopted(true);
@@ -212,13 +213,13 @@ EncodedJSValue JSC_HOST_CALL RecordConstructor::createRecordInstance(ExecState* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (execState->argumentCount() != 1) {
-        return JSValue::encode(scope.throwException(execState, createError(execState, "One argument required."_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, "One argument required."_s, defaultSourceAppender)));
     }
 
     const JSValue value = execState->argument(0);
     if (!value.inherits(vm, PointerInstance::info())) {
         const WTF::String message = WTF::String::format("Argument must be a %s.", PointerInstance::info()->className);
-        return JSValue::encode(scope.throwException(execState, createError(execState, message)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, message, defaultSourceAppender)));
     }
 
     PointerInstance* pointer = jsCast<PointerInstance*>(value);

--- a/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ExtVectorTypeInstance.cpp
@@ -24,13 +24,14 @@ const ClassInfo ExtVectorTypeInstance::s_info = { "ExtVectorTypeInstance", &Base
 JSValue ExtVectorTypeInstance::read(ExecState* execState, const void* buffer, JSCell* self) {
     ExtVectorTypeInstance* vectorInstance = jsCast<ExtVectorTypeInstance*>(self);
     const size_t size = vectorInstance->_ffiTypeMethodTable.ffiType->size;
-    void* data = malloc(size);
 
-    memcpy(data, buffer, size);
-
-    if (!data) {
+    if (!size) {
         return jsNull();
     }
+
+    void* data = malloc(size);
+    ASSERT(buffer);
+    memcpy(data, buffer, size);
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());
     ExtVectorTypeInstance* referenceType = jsCast<ExtVectorTypeInstance*>(self);
@@ -62,7 +63,7 @@ void ExtVectorTypeInstance::write(ExecState* execState, const JSValue& value, vo
         JSC::VM& vm = execState->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a reference."_s);
+        JSValue exception = createError(execState, value, "is not a reference."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/IndexedRefTypeInstance.cpp
@@ -56,7 +56,7 @@ void IndexedRefTypeInstance::write(ExecState* execState, const JSValue& value, v
         JSC::VM& vm = execState->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a reference."_s);
+        JSValue exception = createError(execState, value, "is not a reference."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
+++ b/src/NativeScript/Marshalling/Reference/ReferenceTypeInstance.cpp
@@ -50,7 +50,7 @@ void ReferenceTypeInstance::write(ExecState* execState, const JSValue& value, vo
     if (!hasHandle) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a reference."_s);
+        JSValue exception = createError(execState, value, "is not a reference."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -823,7 +823,40 @@ struct BaseClassMeta : Meta {
         return this->member(identifier, strlen(identifier), type, includeProtocols, /*onlyIfAvailable*/ true, additionalProtocols);
     }
 
+    const MemberMeta* deepMember(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable, const ProtocolMetas& additionalProtocols) const;
+
+    const MemberMeta* deepMember(StringImpl* identifier, MemberType type, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        // Assign to a separate variable to ensure the lifetime of the string returned by utf8
+        auto identifierUtf8 = identifier->utf8();
+        const char* identif = reinterpret_cast<const char*>(identifierUtf8.data());
+        size_t length = (size_t)identifier->length();
+        return this->deepMember(identif, length, type, includeProtocols, /*onlyIfAvailable*/ true, additionalProtocols);
+    }
+
+    const MemberMeta* deepMember(const char* identifier, MemberType type, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        return this->deepMember(identifier, strlen(identifier), type, includeProtocols, /*onlyIfAvailable*/ true, additionalProtocols);
+    }
+
     /// instance methods
+    const MethodMeta* instanceMethod(const char* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto methodMeta = static_cast<const MethodMeta*>(this->member(identifier, MemberType::InstanceMethod, includeProtocols, additionalProtocols));
+        return methodMeta && methodMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? methodMeta : nullptr;
+    }
+
+    const MethodMeta* instanceMethod(StringImpl* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto methodMeta = static_cast<const MethodMeta*>(this->member(identifier, MemberType::InstanceMethod, includeProtocols, additionalProtocols));
+        return methodMeta && methodMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? methodMeta : nullptr;
+    }
+
+    const MethodMeta* deepInstanceMethod(const char* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto methodMeta = static_cast<const MethodMeta*>(this->deepMember(identifier, MemberType::InstanceMethod, includeProtocols, additionalProtocols));
+        return methodMeta && methodMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? methodMeta : nullptr;
+    }
+
+    const MethodMeta* deepInstanceMethod(StringImpl* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto methodMeta = static_cast<const MethodMeta*>(this->deepMember(identifier, MemberType::InstanceMethod, includeProtocols, additionalProtocols));
+        return methodMeta && methodMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? methodMeta : nullptr;
+    }
 
     // Remove all optional methods/properties which are not implemented in the class
     template <typename TMemberMeta>
@@ -858,6 +891,16 @@ struct BaseClassMeta : Meta {
 
     const PropertyMeta* instanceProperty(StringImpl* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
         auto propMeta = static_cast<const PropertyMeta*>(this->member(identifier, MemberType::InstanceProperty, includeProtocols, additionalProtocols));
+        return propMeta && propMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? propMeta : nullptr;
+    }
+
+    const PropertyMeta* deepInstanceProperty(const char* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto propMeta = static_cast<const PropertyMeta*>(this->deepMember(identifier, MemberType::InstanceProperty, includeProtocols, additionalProtocols));
+        return propMeta && propMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? propMeta : nullptr;
+    }
+
+    const PropertyMeta* deepInstanceProperty(StringImpl* identifier, KnownUnknownClassPair klasses, bool includeProtocols, const ProtocolMetas& additionalProtocols) const {
+        auto propMeta = static_cast<const PropertyMeta*>(this->deepMember(identifier, MemberType::InstanceProperty, includeProtocols, additionalProtocols));
         return propMeta && propMeta->isAvailableInClasses(klasses, /*isStatic*/ false) ? propMeta : nullptr;
     }
 

--- a/src/NativeScript/Metadata/Metadata.mm
+++ b/src/NativeScript/Metadata/Metadata.mm
@@ -216,6 +216,22 @@ const MemberMeta* BaseClassMeta::member(const char* identifier, size_t length, M
     return members.size() > 0 ? *members.begin() : nullptr;
 }
 
+const MemberMeta* BaseClassMeta::deepMember(const char* identifier, size_t length, MemberType type, bool includeProtocols, bool onlyIfAvailable, const ProtocolMetas& additionalProtocols) const {
+    const MemberMeta* memberMeta = nullptr;
+
+    ProtocolMetas emptyProtocols;
+    const ProtocolMetas* protocols = &additionalProtocols;
+    for (auto currentClass = this; currentClass != nullptr; currentClass = (currentClass->type() == MetaType::Interface) ? static_cast<const InterfaceMeta*>(currentClass)->baseMeta() : nullptr) {
+        if ((memberMeta = currentClass->member(identifier, length, type, includeProtocols, onlyIfAvailable, *protocols))) {
+            break;
+        }
+        // Do not recheck protocols when visiting base classes
+        protocols = &emptyProtocols;
+    }
+
+    return memberMeta;
+}
+
 void collectInheritanceChainMembers(const char* identifier, size_t length, MemberType type, bool onlyIfAvailable, const BaseClassMeta* meta, std::function<void(const MemberMeta*)> collectMember) {
 
     const ArrayOfPtrTo<MemberMeta>* members = nullptr;

--- a/src/NativeScript/ObjC/Block/ObjCBlockType.mm
+++ b/src/NativeScript/ObjC/Block/ObjCBlockType.mm
@@ -120,7 +120,7 @@ void ObjCBlockType::write(ExecState* execState, const JSValue& value, void* buff
     } else {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        JSValue exception = createError(execState, "Value is not a function."_s);
+        JSValue exception = createError(execState, value, "is not a function", defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorBase.mm
@@ -324,7 +324,7 @@ EncodedJSValue JSC_HOST_CALL ObjCConstructorBase::constructObjCClass(ExecState* 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (candidateInitializers.size() == 0) {
-        return JSValue::encode(scope.throwException(execState, createError(execState, "No initializer found that matches constructor invocation."_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, "No initializer found that matches constructor invocation."_s, defaultSourceAppender)));
     } else if (candidateInitializers.size() > 1) {
         WTF::StringBuilder errorMessage;
         errorMessage.append("More than one initializer found that matches constructor invocation:");
@@ -332,7 +332,7 @@ EncodedJSValue JSC_HOST_CALL ObjCConstructorBase::constructObjCClass(ExecState* 
             errorMessage.append(" ");
             errorMessage.append(sel_getName(static_cast<ObjCConstructorCall*>(initializer->onlyFuncInContainer())->selector()));
         }
-        return JSValue::encode(scope.throwException(execState, createError(execState, errorMessage.toString())));
+        return JSValue::encode(scope.throwException(execState, createError(execState, errorMessage.toString(), defaultSourceAppender)));
     } else {
         ObjCConstructorWrapper* initializer = candidateInitializers[0];
 

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
@@ -75,7 +75,7 @@ bool ObjCConstructorNative::put(JSCell* cell, ExecState* execState, PropertyName
                                 constructor->_metadata,
                                 MemberType::StaticMethod,
                                 klass,
-                                nullptr);
+                                ProtocolMetas());
     }
 
     return Base::put(cell, execState, propertyName, value, propertySlot);

--- a/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.mm
+++ b/src/NativeScript/ObjC/Enumeration/ObjCFastEnumerationIterator.mm
@@ -35,7 +35,7 @@ bool ObjCFastEnumerationIterator::next(ExecState* execState, JSValue& value) {
             JSC::VM& vm = execState->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            scope.throwException(execState, createError(execState, "The iterable was changed during enumeration."_s));
+            scope.throwException(execState, createError(execState, "The iterable was changed during enumeration."_s, defaultSourceAppender));
             return false;
         }
 

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.h
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.h
@@ -54,7 +54,7 @@ private:
 
     JSC::Strong<ObjCConstructorNative> _baseConstructor;
 
-    std::vector<const Metadata::ProtocolMeta*> _protocols;
+    Metadata::ProtocolMetas _protocols;
 };
 } // namespace NativeScript
 

--- a/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCClassBuilder.mm
@@ -127,12 +127,12 @@ static void addMethodToClass(ExecState* execState, Class klass, JSCell* method, 
     CallData callData;
     if (method->methodTable(vm)->getCallData(method, callData) == CallType::None) {
         WTF::String message = WTF::String::format("Method %s is not a function.", sel_getName(methodName));
-        scope.throwException(execState, createError(execState, message));
+        scope.throwException(execState, createError(execState, method, message, defaultSourceAppender));
         return;
     }
     if (!typeEncoding.isObject()) {
-        WTF::String message = WTF::String::format("Method %s has invalid type encoding", sel_getName(methodName));
-        scope.throwException(execState, createError(execState, message));
+        WTF::String message = WTF::String::format("Method %s has an invalid type encoding", sel_getName(methodName));
+        scope.throwException(execState, createError(execState, method, message, defaultSourceAppender));
         return;
     }
 
@@ -140,7 +140,7 @@ static void addMethodToClass(ExecState* execState, Class klass, JSCell* method, 
     PropertyName returnsProp = Identifier::fromString(execState, "returns");
     if (!typeEncodingObj->hasOwnProperty(execState, returnsProp)) {
         WTF::String message = WTF::String::format("Method %s is missing its return type encoding", sel_getName(methodName));
-        scope.throwException(execState, createError(execState, message));
+        scope.throwException(execState, createError(execState, typeEncodingObj, message, defaultSourceAppender));
         return;
     }
 
@@ -186,7 +186,7 @@ ObjCClassBuilder::ObjCClassBuilder(ExecState* execState, JSValue baseConstructor
     if (!baseConstructor.inherits(vm, ObjCConstructorNative::info())) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        scope.throwException(execState, createError(execState, "Extends is supported only for native classes."_s));
+        scope.throwException(execState, createError(execState, "Extends is supported only for native classes."_s, defaultSourceAppender));
         return;
     }
 
@@ -220,8 +220,7 @@ void ObjCClassBuilder::implementProtocol(ExecState* execState, JSValue protocolW
     if (!protocolWrapper.inherits(vm, ObjCProtocolWrapper::info())) {
         auto scope = DECLARE_THROW_SCOPE(vm);
 
-        WTF::String errorMessage = WTF::String::format("Protocol \"%s\" is not a protocol object.", protocolWrapper.toWTFString(execState).utf8().data());
-        scope.throwException(execState, createError(execState, errorMessage));
+        scope.throwException(execState, createError(execState, protocolWrapper, "is not a protocol object."_s, defaultSourceAppender));
         return;
     }
 
@@ -250,7 +249,7 @@ void ObjCClassBuilder::implementProtocols(ExecState* execState, JSValue protocol
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (!protocolsArray.inherits(vm, JSArray::info())) {
-        scope.throwException(execState, createError(execState, "The protocols property must be an array"_s));
+        scope.throwException(execState, createError(execState, protocolsArray, "the 'protocols' property is not an array"_s, defaultSourceAppender));
         return;
     }
 

--- a/src/NativeScript/ObjC/Inheritance/ObjCExtend.mm
+++ b/src/NativeScript/ObjC/Inheritance/ObjCExtend.mm
@@ -21,10 +21,10 @@ EncodedJSValue JSC_HOST_CALL ObjCExtendFunction(ExecState* execState) {
 
     JSValue instanceMethodsValue = execState->argument(0);
     if (!instanceMethodsValue.inherits(vm, JSObject::info())) {
-        return JSValue::encode(scope.throwException(execState, createError(execState, "Parameter must be an object"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, instanceMethodsValue, "must be an object"_s, defaultSourceAppender)));
     }
     if (instanceMethodsValue.get(execState, execState->vm().propertyNames->constructor).inherits(vm, ObjCConstructorBase::info())) {
-        return JSValue::encode(scope.throwException(execState, createError(execState, "The override object is used by another derived class"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, "The override object is used by another derived class"_s, defaultSourceAppender)));
     }
     JSObject* instanceMethods = instanceMethodsValue.toObject(execState);
 

--- a/src/NativeScript/ObjC/ObjCMethodCallback.h
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.h
@@ -50,7 +50,7 @@ private:
 };
 
 void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyName propertyName, JSCell* method, const Metadata::BaseClassMeta* meta, Metadata::MemberType memberType, Class klass,
-                             std::vector<const Metadata::ProtocolMeta*>* protocols);
+                             const Metadata::ProtocolMetas& protocols);
 
 } // namespace NativeScript
 

--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -52,22 +52,8 @@ void overrideObjcMethodCall(ExecState* execState, Class klass, JSCell* method, O
 }
 
 void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyName propertyName, JSCell* method, const Metadata::BaseClassMeta* meta, Metadata::MemberType memberType, Class klass,
-                             std::vector<const Metadata::ProtocolMeta*>* protocols) {
-    JSValue methodValue = jsUndefined();
-    PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-    if (object->getPropertySlot(execState, propertyName, slot)) {
-        if (slot.isAccessor()) {
-            JSC::VM& vm = execState->vm();
-            auto throwScope = DECLARE_THROW_SCOPE(vm);
-            WTF::String message = WTF::String::format("Cannot override native property \"%s\" with a function, define it as a JS property instead.",
-                                                      propertyName.publicName()->utf8().data());
-            throwException(execState, throwScope, JSC::createError(execState, message, defaultSourceAppender));
-            return;
-        }
-
-        methodValue = slot.getValue(execState, propertyName);
-    }
-
+                             const ProtocolMetas& protocols) {
+    JSValue methodValue = object->get(execState, propertyName);
     ObjCMethodWrapper* wrapper = jsDynamicCast<ObjCMethodWrapper*>(execState->vm(), methodValue);
     Strong<ObjCMethodWrapper> strongWrapper;
     if (!wrapper) {
@@ -84,8 +70,8 @@ void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyNam
 
         } while (methodMetas.size() == 0 && currentClass);
 
-        if (methodMetas.size() == 0 && protocols && !protocols->empty()) {
-            for (auto aProtocol : *protocols) {
+        if (methodMetas.size() == 0) {
+            for (auto aProtocol : protocols) {
                 if ((methodMetas = aProtocol->members(propertyName.publicName(), memberType, /*includeProtocols*/ true, ProtocolMetas())).size() > 0) {
                     break;
                 }

--- a/src/NativeScript/ObjC/ObjCMethodCallback.mm
+++ b/src/NativeScript/ObjC/ObjCMethodCallback.mm
@@ -61,7 +61,7 @@ void overrideObjcMethodCalls(ExecState* execState, JSObject* object, PropertyNam
             auto throwScope = DECLARE_THROW_SCOPE(vm);
             WTF::String message = WTF::String::format("Cannot override native property \"%s\" with a function, define it as a JS property instead.",
                                                       propertyName.publicName()->utf8().data());
-            throwException(execState, throwScope, JSC::createError(execState, message));
+            throwException(execState, throwScope, JSC::createError(execState, message, defaultSourceAppender));
             return;
         }
 

--- a/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
+++ b/src/NativeScript/ObjC/ObjCPrimitiveTypes.mm
@@ -84,7 +84,7 @@ static void objCProtocol_write(ExecState* execState, const JSValue& value, void*
     } else if (value.isUndefinedOrNull()) {
         *static_cast<Protocol**>(buffer) = nullptr;
     } else {
-        JSValue exception = createError(execState, "Value is not a protocol."_s);
+        JSValue exception = createError(execState, value, "is not a protocol"_s, defaultSourceAppender);
         auto scope = DECLARE_THROW_SCOPE(vm);
         scope.throwException(execState, exception);
         return;
@@ -134,7 +134,7 @@ static void objCClass_write(ExecState* execState, const JSValue& value, void* bu
         if (NSStringFromClass(wrappedObject) != nullptr) {
             *static_cast<Class*>(buffer) = wrappedObject;
         } else {
-            JSValue exception = createError(execState, "Wrapped native value is not a class."_s);
+            JSValue exception = createError(execState, "Wrapped native value is not a class."_s, defaultSourceAppender);
             auto scope = DECLARE_THROW_SCOPE(vm);
             scope.throwException(execState, exception);
             return;
@@ -142,7 +142,7 @@ static void objCClass_write(ExecState* execState, const JSValue& value, void* bu
     } else if (value.isUndefinedOrNull()) {
         *static_cast<Class*>(buffer) = nullptr;
     } else {
-        JSValue exception = createError(execState, "Value is not a class."_s);
+        JSValue exception = createError(execState, value, "is not a class."_s, defaultSourceAppender);
         auto scope = DECLARE_THROW_SCOPE(vm);
         scope.throwException(execState, exception);
         return;
@@ -177,7 +177,7 @@ static void objCSelector_write(ExecState* execState, const JSValue& value, void*
     } else {
         VM& vm = execState->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        JSValue exception = createError(execState, "Value is not a selector."_s);
+        JSValue exception = createError(execState, value, "is not a selector."_s, defaultSourceAppender);
         scope.throwException(execState, exception);
         return;
     }

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -138,7 +138,7 @@ bool ObjCPrototype::put(JSCell* cell, ExecState* execState, PropertyName propert
                                 prototype->_metadata,
                                 MemberType::InstanceMethod,
                                 klass,
-                                nullptr);
+                                ProtocolMetas());
     }
 
     return Base::put(cell, execState, propertyName, value, propertySlot);

--- a/src/NativeScript/Runtime/JSWeakRefConstructor.cpp
+++ b/src/NativeScript/Runtime/JSWeakRefConstructor.cpp
@@ -18,7 +18,7 @@ static EncodedJSValue JSC_HOST_CALL construct(ExecState* execState) {
     if (!argument.isObject()) {
         VM& vm = execState->vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
-        return JSValue::encode(scope.throwException(execState, createTypeError(execState, "Argument must be an object."_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, argument, "must be an object"_s, defaultSourceAppender)));
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());

--- a/src/NativeScript/Runtime/JSWeakRefPrototype.cpp
+++ b/src/NativeScript/Runtime/JSWeakRefPrototype.cpp
@@ -26,10 +26,11 @@ void JSWeakRefPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject) {
 
 static EncodedJSValue JSC_HOST_CALL weakRefProtoFuncGet(ExecState* execState) {
     VM& vm = execState->vm();
-    JSWeakRefInstance* self = jsDynamicCast<JSWeakRefInstance*>(vm, execState->thisValue());
+    JSC::JSValue thisValue = execState->thisValue();
+    JSWeakRefInstance* self = jsDynamicCast<JSWeakRefInstance*>(vm, thisValue);
     if (!self) {
         auto scope = DECLARE_THROW_SCOPE(vm);
-        return JSValue::encode(scope.throwException(execState, createTypeError(execState, "'this' is not weak reference"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, thisValue, "'this' is not weak reference"_s, defaultSourceAppender)));
     }
 
     JSCell* cell = self->cell();
@@ -38,10 +39,11 @@ static EncodedJSValue JSC_HOST_CALL weakRefProtoFuncGet(ExecState* execState) {
 
 static EncodedJSValue JSC_HOST_CALL weakRefProtoFuncClear(ExecState* execState) {
     VM& vm = execState->vm();
-    JSWeakRefInstance* self = jsDynamicCast<JSWeakRefInstance*>(vm, execState->thisValue());
+    JSC::JSValue thisValue = execState->thisValue();
+    JSWeakRefInstance* self = jsDynamicCast<JSWeakRefInstance*>(vm, thisValue);
     if (!self) {
         auto scope = DECLARE_THROW_SCOPE(vm);
-        return JSValue::encode(scope.throwException(execState, createTypeError(execState, "'this' is not weak reference"_s)));
+        return JSValue::encode(scope.throwException(execState, createError(execState, thisValue, "'this' is not weak reference"_s, defaultSourceAppender)));
     }
 
     self->clear();

--- a/tests/TestFixtures/Interfaces/TNSConstructorResolution.h
+++ b/tests/TestFixtures/Interfaces/TNSConstructorResolution.h
@@ -31,4 +31,6 @@ typedef struct TNSCStructure {
 - (id)initWithStructure:(TNSCStructure)x;
 - (id)initWithString:(NSString*)x;
 - (id)initWithParameter1:(NSString*)x parameter2:(NSString*)y error:(NSError**)error;
+- (id)initWithConflict1:(NSString*)x conflict2:(NSString*)y conflict3:(NSString*)z;
+- (id)initWithConflict1_:(NSString*)x conflict2_:(NSString*)y conflict3_:(NSString*)z;
 @end

--- a/tests/TestFixtures/Interfaces/TNSConstructorResolution.m
+++ b/tests/TestFixtures/Interfaces/TNSConstructorResolution.m
@@ -49,4 +49,12 @@
     return [super init];
 }
 
+- (id)initWithConflict1:(NSString*)x conflict2:(NSString*)y conflict3:(NSString*)z {
+    return [super init];
+}
+
+- (id)initWithConflict1_:(NSString*)x conflict2_:(NSString*)y conflict3_:(NSString*)z {
+    return [super init];
+}
+
 @end

--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -508,16 +508,6 @@ describe(module.id, function () {
             expect(output).toBe("TNSAllocLog initTNSAllocLog dealloc");
         });
 
-        it("throws when object is not a native wrapper", function () {
-            const expectedError = /argument.*not a native wrapper/i;
-            expect(() => __releaseNativeCounterpart(0)).toThrowError(expectedError);
-            expect(() => __releaseNativeCounterpart("")).toThrowError(expectedError);
-            expect(() => __releaseNativeCounterpart([])).toThrowError(expectedError);
-            expect(() => __releaseNativeCounterpart({})).toThrowError(expectedError);
-            expect(() => __releaseNativeCounterpart(null)).toThrowError(expectedError);
-            expect(() => __releaseNativeCounterpart(undefined)).toThrowError(expectedError);
-        });
-
         it("sets object to nil", function () {
             var arr = NSArray.arrayWithArray([1,2,3]);
             expect(arr.count).toBe(3);
@@ -532,7 +522,19 @@ describe(module.id, function () {
             // structures have all members initialized to zero.
             expect(arr.count).toBe(0);
         });
-
+        
+        it("exceptions", function () {
+            expect(() => __releaseNativeCounterpart(1, 2, 3)).toThrowError(/Actual arguments count: "3". Expected: "1". \(evaluating '__releaseNativeCounterpart\(1, 2, 3\)'\)/);
+            const getNotANativeWrapperRegex2 = (obj, objParam) => new RegExp(`${obj} is an object which is not a native wrapper. \\(evaluating '__releaseNativeCounterpart\\(${objParam}\\)'\\)`);
+            const getNotANativeWrapperRegex = obj => getNotANativeWrapperRegex2(obj, JSON.stringify(obj));
+           
+            expect(() => __releaseNativeCounterpart(0)).toThrowError(getNotANativeWrapperRegex(0));
+            expect(() => __releaseNativeCounterpart("")).toThrowError(getNotANativeWrapperRegex(""));
+            expect(() => __releaseNativeCounterpart([])).toThrowError(getNotANativeWrapperRegex2("Array", "\\[\\]"));
+            expect(() => __releaseNativeCounterpart({})).toThrowError(getNotANativeWrapperRegex({}));
+            expect(() => __releaseNativeCounterpart(null)).toThrowError(getNotANativeWrapperRegex(null));
+            expect(() => __releaseNativeCounterpart(undefined)).toThrowError(getNotANativeWrapperRegex(undefined));
+        });
     });
     describe("async", function () {
         it("should work", function (done) {

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -651,6 +651,17 @@ describe(module.id, function () {
         TNSClearOutput();
     });
 
+    it("MethodOverrides: errors", function () {
+        expect(() => NSObject.extend({
+               get isEqual() {
+               }
+        })).toThrowError(/Cannot override native method "isEqual" with a property, define it as a JS function instead. \(evaluating 'NSObject.extend\({[^$]*}\)'\)/m);
+        
+        expect(() => NSObject.extend({
+                isEqual: true
+         })).toThrowError(/true cannot override native method "isEqual". \(evaluating 'NSObject.extend\({[^$]*}\)'\)/m);
+    });
+       
     it('ConstructorOverrides: prototype', function () {
         var JSDerivedInterface = TNSDerivedInterface.extend({
             initBaseProtocolMethod1: function () {
@@ -1628,7 +1639,7 @@ describe(module.id, function () {
         expect(() => TNSIDerivedInterface.extend({
             derivedImplementedOptionalProperty: function() {
             } 
-        })).toThrowError('Cannot override native property "derivedImplementedOptionalProperty" with a function, define it as a JS property instead.');
+        })).toThrowError(/function cannot override native property "derivedImplementedOptionalProperty", define it as a JS property instead. \(evaluating 'TNSIDerivedInterface.extend\({[^$]*}\)'\)/m);
     });
          
     it('ConstructorOverrideAndVirtualCall: prototype', function () {
@@ -1764,9 +1775,11 @@ describe(module.id, function () {
             }
         };
         NSObject.extend(overrides);
-        expect(function () {
-            NSObject.extend(overrides);
-        }).toThrowError();
+        expect(() => NSObject.extend(overrides)).toThrowError("The override object is used by another derived class (evaluating 'NSObject.extend(overrides)')");
+    });
+
+    it("extends with wrong parameter type", function () {
+        expect(() => NSObject.extend(0)).toThrowError("0 must be an object (evaluating 'NSObject.extend(0)')");
     });
 
     it('ExposeWithoutImplementation', function () {
@@ -1775,6 +1788,24 @@ describe(module.id, function () {
                 'nonExistingSelector': { returns: interop.types.void, params: [interop.types.selector] }
             }
         });
+    });
+
+    it('ExposeWithWrongParams', function () {
+        expect(() => NSObject.extend({ wrongRet: function() {} }, {
+            exposedMethods: {
+                'wrongRet': { returns: "a string", params: [interop.types.selector] }
+            }
+        })).toThrowError("\"a string\" Method wrongRet has an invalid return type encoding (evaluating 'NSObject.extend')");
+        expect(() => NSObject.extend({ wrongArg: function() {} }, {
+            exposedMethods: {
+                'wrongArg': { returns: interop.types.selector, params: [3] }
+            }
+        })).toThrowError("3 Method wrongArg has an invalid type encoding for argument 1 (evaluating 'NSObject.extend')");
+        expect(() => NSObject.extend({ wrongArg: function() {} }, {
+            exposedMethods: {
+                'wrongArg': { returns: interop.types.void, params: { notArray: true } }
+            }
+        })).toThrowError("Object The 'params' property of method wrongArg is not an array (evaluating 'NSObject.extend')");
     });
 
     it('ClassName', function () {
@@ -1792,7 +1823,7 @@ describe(module.id, function () {
     it('ExtendDerivedClass', function () {
         expect(function () {
             NSObject.extend({}).extend({});
-        }).toThrowError();
+        }).toThrowError("Extends is supported only for native classes. (evaluating 'NSObject.extend({}).extend({})')");
     });
 
     it('OptionalProtocolMethodsAndCategories', function () {
@@ -1975,6 +2006,11 @@ describe(module.id, function () {
         var result = TNSTestNativeCallbacks.protocolWithNameConflict(derived);
 
         expect(result).toBe(true);
+    });
+
+    it("Incorrect protocols", function () {
+        expect(() => NSObject.extend({}, { protocols : [ NSString ] })).toThrowError("function is not a protocol object. (evaluating 'NSObject.extend({}, { protocols : [ NSString ] })')");
+        expect(() => NSObject.extend({}, { protocols : "notAnArray"})).toThrowError("\"notAnArray\" the 'protocols' property is not an array (evaluating 'NSObject.extend({}, { protocols : \"notAnArray\"})')");
     });
 
     it("Should not have base class property slot", function () {

--- a/tests/TestRunner/app/Marshalling/FunctionPointerTests.js
+++ b/tests/TestRunner/app/Marshalling/FunctionPointerTests.js
@@ -55,4 +55,8 @@ describe(module.id, function () {
         functionWithComplexFunctionPointer(f);
         expect(TNSGetOutput()).toBe('5 6 7 8');
     });
+    
+    it("Wrong argument type", function () {
+        expect(() => new interop.FunctionReference({})).toThrowError(/Exactly 1 argument which must be a function.*evaluating 'new interop.FunctionReference\({}\)'/i);
+    });
 });

--- a/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
+++ b/tests/TestRunner/app/Marshalling/ObjCTypesTests.js
@@ -275,4 +275,8 @@ describe(module.id, function () {
         expect(typeof array.firstObject).toEqual("boolean");
         expect(array.firstObject).toEqual(bool);
     });
+         
+    it("Wrong type of argument passed as block", function () {
+        expect(() => new TNSObjCTypes().methodWithSimpleBlock({})).toThrowError(/Object is not a function \(evaluating 'new TNSObjCTypes\(\).methodWithSimpleBlock\({}\)'\)/);
+    });
 });

--- a/tests/TestRunner/app/Marshalling/PointerTests.js
+++ b/tests/TestRunner/app/Marshalling/PointerTests.js
@@ -112,7 +112,7 @@ describe(module.id, function () {
         var reference = new interop.Reference();
         expect(function () {
             interop.handleof(reference);
-        }).toThrowError();
+        }).toThrowError(/Reference Unknown type \(evaluating 'interop.handleof\(reference\)'\)/);
         functionWithIntPtr(reference);
         expect(interop.handleof(reference) instanceof interop.Pointer).toBe(true);
 
@@ -120,7 +120,7 @@ describe(module.id, function () {
         });
         expect(function () {
             interop.handleof(functionReference);
-        }).toThrowError();
+        }).toThrowError(/function Unknown type \(evaluating 'interop.handleof\(functionReference\)'\)/);
         functionWithSimpleFunctionPointer(functionReference);
         expect(interop.handleof(functionReference) instanceof interop.Pointer).toBe(true);
 
@@ -150,5 +150,16 @@ describe(module.id, function () {
 
         expect(interop.sizeof(TNSSimpleStruct)).toBeGreaterThan(0);
         expect(interop.sizeof(new TNSSimpleStruct())).toBeGreaterThan(0);
+    });
+    it("free", function () {
+        const p = malloc(1);
+        expect(p.toNumber()).not.toBe(0);
+        expect(() => interop.free(p)).not.toThrow();
+        expect(p.toNumber()).toBe(0);
+
+        const adoptedPointer = interop.alloc(1);
+        expect(() => interop.free(adoptedPointer)).toThrowError(/Pointer is adopted. \(evaluating 'interop.free\(adoptedPointer\)'\)/);
+
+       expect(() => interop.free("s")).toThrowError(/"s" must be a Pointer. \(evaluating 'interop.free\("s"\)'\)/);
     });
 });

--- a/tests/TestRunner/app/Marshalling/Primitives/Function.js
+++ b/tests/TestRunner/app/Marshalling/Primitives/Function.js
@@ -224,4 +224,12 @@ describe(module.id, function () {
             functionWithUnichar('iPhone');
         }).toThrowError();
     });
+         
+    it("Wrong number of arguments", function() {
+        expect(() => functionWithProtocol(NSObjectProtocol, 1, 2)).toThrowError(/Actual arguments count: "3". Expected: "1". \(evaluating 'functionWithProtocol\(NSObjectProtocol, 1, 2\)'\)/);
+    });
+
+    it("Wrong type of argument as protocol", function() {
+        expect(() => functionWithProtocol(1)).toThrowError(/1 is not a protocol \(evaluating 'functionWithProtocol\(1\)'\)/);
+    });
 });

--- a/tests/TestRunner/app/Marshalling/ReferenceTests.js
+++ b/tests/TestRunner/app/Marshalling/ReferenceTests.js
@@ -125,6 +125,9 @@ describe(module.id, function () {
         expect(TNSSimpleStruct.equals(strRef.value, {x: 2, y: 3}));
     });
 
+    it("Wrong type of argument passed as pointer", function () {
+        expect(() => functionWith_VoidPtr(1)).toThrowError(/1 is not a pointer. \(evaluating 'functionWith_VoidPtr\(1\)'\)/);
+    });
     it("CString marshalling from JS string", function () {
         functionWithUCharPtr('test');
         expect(TNSGetOutput()).toBe('test');

--- a/tests/TestRunner/app/Modules/index.js
+++ b/tests/TestRunner/app/Modules/index.js
@@ -33,4 +33,8 @@ describe(module.id, function () {
         let requireFunc = () => require("./strict-violation-use-strict");
         expect(requireFunc).toThrowError("Cannot delete unqualified property 'x' in strict mode.");
      });
+         
+     it("require non-existent module throws", function () {
+        expect(()=> require("./non-existent")).toThrowError(/Could not find module '.\/non-existent'. Computed path '.*non-existent'. \(evaluating 'require\(".\/non-existent"\)'/);
+     });
 });

--- a/tests/TestRunner/app/ObjCConstructors.js
+++ b/tests/TestRunner/app/ObjCConstructors.js
@@ -63,8 +63,12 @@ describe("Constructing Objective-C classes with new operator", function () {
     });
 
     it("initAWithIntNotImplemented:andInt:andInt and initZWithIntNotImplemented:andInt:andInt from protocol should be missing", function () {
-        expect(() => new TNSCInterface(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation.");
-        expect(() => new (TNSCInterface.extend({}))(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation.");
+        expect(() => new TNSCInterface(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation. (evaluating 'new TNSCInterface(1, 2, 3)')");
+        expect(() => new (TNSCInterface.extend({}))(1, 2, 3)).toThrowError("No initializer found that matches constructor invocation. (evaluating 'new (TNSCInterface.extend({}))(1, 2, 3)')");
+    });
+
+    it("withConflict1:conflict2:conflict3", function () {
+        expect(() => new TNSCInterface("1", "2", "3")).toThrowError("More than one initializer found that matches constructor invocation: initWithConflict1:conflict2:conflict3: initWithConflict1_:conflict2_:conflict3_: (evaluating 'new TNSCInterface(\"1\", \"2\", \"3\")')");
     });
 
     it("NSArray with JS array constructor", function () {


### PR DESCRIPTION
* Use `defaultSourceAppender` for more detailed failed
expression identification in thrown errors
* Change `Function required` error to match the actual validation
check: `Exactly 1 argument which must be a function required`
* fix(interop): Reset pointer after free 
  * Reassign deleted pointers to `nullptr`
  * Don't reuse cached pointer instances which have been freed
* refact: Don't throw in `isValidType`
Make it a simple check whether its a valid type encoding or not
and leave exception throwing to caller. It can construct a
more meaningful error message because it has more context.

* fix(runtime): Improve error handling in overriding properties and methods
  * Add `deepInstanceProperty` and `deepInstanceMethod` getters in
`BaseClassMeta`
  * Refactor `_protocols` field to use `ProtocolMetas`
  * Check and throw errors when overriding a native method with
a JS property or a native property with a JS function
* chore: Add tests for error messages


## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

