### PR TITLE
fix: notify for AppRefreshStarted and remove the log for successful refresh request

### DIFF
--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -21,7 +21,6 @@
 
 // {N} CLI is relying on these messages. Please do not change them!
 #define LOG_DEBUGGER_PORT NSLog(@"NativeScript debugger has opened inspector socket on port %d for %@.", currentInspectorPort, [[NSBundle mainBundle] bundleIdentifier])
-#define LOG_SUCCESSFULL_REFRESH NSLog(@"Successfully refreshed the application with RefreshRequest."); notify_post(NOTIFICATION("AppRefreshSucceeded"))
 #define LOG_FAILED_REFRESH(reason) NSLog(@"Failed to refresh the application with RefreshRequest. Reason: %@", reason); notify_post(NOTIFICATION("AppRefreshFailed"))
 
 // Synchronization object for serializing access to inspector variable and data socket
@@ -433,6 +432,8 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
     notify_register_dispatch(
         NOTIFICATION("RefreshRequest"), &refreshRequestSubscription,
         dispatch_get_main_queue(), ^(int token) {
+            notify_post(NOTIFICATION("AppRefreshStarted"));
+
             JSGlobalContextRef context = runtime.globalContext;
             JSObjectRef globalObject = JSContextGetGlobalObject(context);
             JSStringRef liveSyncMethodName = JSStringCreateWithUTF8CString("__onLiveSync");
@@ -460,8 +461,8 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
                 return;
             }
             
-            LOG_SUCCESSFULL_REFRESH;
-    });   
+            notify_post(NOTIFICATION("AppRefreshSucceeded"));
+    });
 
     int attachRequestSubscription;
     notify_register_dispatch(


### PR DESCRIPTION
Currently CLI performs an additional application start when sending refresh notification to the application. The purpose of this additional application start is to ensure that the application will be started when sending the notification no matter if it is currently crashed. However, this additional operation slows down the entire livesync process with around 2-3 seconds per change. The purpose of this PR is to eliminate the delay as posting `AppRefreshStarted` notification from application. CLI starts an observer notification in order to check if the `AppRefreshStarted` will be sent from the application. In case it is sent, CLI refreshes the application via `RefreshRequest` notification. In case a such notification is not sent, CLI restarts the application in 3 seconds (this is the timeout for awaiting the notification from application).

Rel to https://github.com/NativeScript/nativescript-cli/issues/4966

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

