### PR TITLE
fix: Metadata generator crashes

### DIFF
--- a/src/MetadataGenerator.cmake
+++ b/src/MetadataGenerator.cmake
@@ -1,3 +1,6 @@
+include(ProcessorCount)
+ProcessorCount(NUM_CORES)
+
 include(ExternalProject)
 ExternalProject_Add(MetadataGenerator
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/metadata-generator"
@@ -10,6 +13,7 @@ ExternalProject_Add(MetadataGenerator
         --build .
         --target install
         --use-stderr
+        --parallel ${NUM_CORES}
     INSTALL_COMMAND ""
 )
 


### PR DESCRIPTION
* Catalyst SDK crashes
* Exclude circular dependant types when some subtype is not supported
* `isStaticFramework` check when linked libraries are set explicitly
* Add integration tests

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

refs #1197, t1426491
