### PR TITLE
 fix(runtime): null pointer dereference in signal and unhandled exception handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ previous_url: /Changelogs/iOS Runtime
 * **metadata-generator:** Improve detection of static frameworks ([#1177](https://github.com/NativeScript/ios-runtime/pull/1177))
 * **project-template:** Correctly get architecture in `nsld` with Xcode 11 ([#1179](https://github.com/NativeScript/ios-runtime/pull/1179))
 * **runtime:** Improve error handling in overriding properties and methods ([943948d](https://github.com/NativeScript/ios-runtime/commit/943948d))
+* **metadata-generator:** Metadata generation failed with `tns-ios@6.0.2` ([#1197](https://github.com/NativeScript/ios-runtime/pull/1197))
+* **runtime:** null pointer dereference in signal and unhandled exception handlers ([#1199](https://github.com/NativeScript/ios-runtime/pulls/1199))
 
 6.0.2 (2019-08-07)
 =====

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ git clone --recursive git@github.com:NativeScript/ios-runtime.git
  - [llvm 7.0](http://releases.llvm.org/download.html#7.0.0) - used to build the [metadata generator](https://github.com/NativeScript/ios-metadata-generator) submodule. Be sure to have the folder containing `llvm-config` in `PATH` or make a symlink to in `/usr/local/bin/`.
  - [Automake](https://www.gnu.org/software/automake/) - available in [Homebrew](http://brew.sh) as `automake`.
  - [GNU Libtool](http://www.gnu.org/software/libtool/) - available in [Homebrew](http://brew.sh) as `libtool`.
+ - [Perl (installed on macOS by default but deprecated since macOS X 10.15)](https://www.perl.org/get.html#osx)
  - Checkout all git submodules using `git submodule update --init`.
 
 ## Architecture Diagram

--- a/src/NativeScript/ObjC/TNSExceptionHandler.h
+++ b/src/NativeScript/ObjC/TNSExceptionHandler.h
@@ -16,47 +16,49 @@ static NSUncaughtExceptionHandler* oldExceptionHandler = NULL;
 
 static void TNSObjectiveCUncaughtExceptionHandler(NSException* currentException) {
     TNSRuntime* runtime = [TNSRuntime current];
-    JSGlobalContextRef context = runtime.globalContext;
-    JSObjectRef globalObject = JSContextGetGlobalObject(context);
+    if (runtime) {
+        JSGlobalContextRef context = runtime.globalContext;
+        JSObjectRef globalObject = JSContextGetGlobalObject(context);
 
-    JSStringRef uncaughtPropertyName = JSStringCreateWithUTF8CString("onerror"); // Keep in sync with JSErrors.mm
-    JSValueRef uncaughtCallback = JSObjectGetProperty(context, globalObject, uncaughtPropertyName, NULL);
-    JSStringRelease(uncaughtPropertyName);
-
-    NSDictionary *userInfo = currentException.userInfo;
-    // check whether the exception is comming form fatalErrorBeforeShutdown method
-    BOOL exceptionAlreadyReported = (userInfo && userInfo[@"sender"] && [userInfo[@"sender"] isEqualToString:@"reportFatalErrorBeforeShutdown"]);
-    if (!exceptionAlreadyReported && JSValueIsUndefined(context, uncaughtCallback)) {
-        uncaughtPropertyName = JSStringCreateWithUTF8CString("__onUncaughtError"); // Keep in sync with JSErrors.mm
-        uncaughtCallback = JSObjectGetProperty(context, globalObject, uncaughtPropertyName, NULL);
+        JSStringRef uncaughtPropertyName = JSStringCreateWithUTF8CString("onerror"); // Keep in sync with JSErrors.mm
+        JSValueRef uncaughtCallback = JSObjectGetProperty(context, globalObject, uncaughtPropertyName, NULL);
         JSStringRelease(uncaughtPropertyName);
-    }
 
-    if (!JSValueIsUndefined(context, uncaughtCallback)) {
-        JSStringRef reason = JSStringCreateWithUTF8CString(currentException.reason.UTF8String);
-        JSObjectRef error = JSObjectMakeError(
-            context, 1, (JSValueRef[]){ JSValueMakeString(context, reason) }, NULL);
-        JSStringRelease(reason);
-
-        JSValueRef wrappedException = [runtime convertObject:currentException];
-        JSStringRef nativeExceptionPropertyName = JSStringCreateWithUTF8CString("nativeException");
-        JSObjectSetProperty(context, error, nativeExceptionPropertyName,
-                            wrappedException, kJSPropertyAttributeNone, NULL);
-        JSStringRelease(nativeExceptionPropertyName);
-
-        JSValueRef callError = NULL;
-        JSObjectCallAsFunction(context, (JSObjectRef)uncaughtCallback, NULL, 1,
-                               (JSValueRef[]){ error }, &callError);
-        if (callError) {
-            JSStringRef callErrorMessage = JSValueToStringCopy(context, callError, NULL);
-            NSLog(@"Error executing uncaught error handler: %@",
-                  CFBridgingRelease(JSStringCopyCFString(CFAllocatorGetDefault(),
-                                                         callErrorMessage)));
-            JSStringRelease(callErrorMessage);
+        NSDictionary* userInfo = currentException.userInfo;
+        // check whether the exception is comming form fatalErrorBeforeShutdown method
+        BOOL exceptionAlreadyReported = (userInfo && userInfo[@"sender"] && [userInfo[@"sender"] isEqualToString:@"reportFatalErrorBeforeShutdown"]);
+        if (!exceptionAlreadyReported && JSValueIsUndefined(context, uncaughtCallback)) {
+            uncaughtPropertyName = JSStringCreateWithUTF8CString("__onUncaughtError"); // Keep in sync with JSErrors.mm
+            uncaughtCallback = JSObjectGetProperty(context, globalObject, uncaughtPropertyName, NULL);
+            JSStringRelease(uncaughtPropertyName);
         }
-    }
 
-    NSLog(@"*** JavaScript call stack:\n(\n%@\n)", [runtime getCurrentStack]);
+        if (!JSValueIsUndefined(context, uncaughtCallback)) {
+            JSStringRef reason = JSStringCreateWithUTF8CString(currentException.reason.UTF8String);
+            JSObjectRef error = JSObjectMakeError(
+                context, 1, (JSValueRef[]){ JSValueMakeString(context, reason) }, NULL);
+            JSStringRelease(reason);
+
+            JSValueRef wrappedException = [runtime convertObject:currentException];
+            JSStringRef nativeExceptionPropertyName = JSStringCreateWithUTF8CString("nativeException");
+            JSObjectSetProperty(context, error, nativeExceptionPropertyName,
+                                wrappedException, kJSPropertyAttributeNone, NULL);
+            JSStringRelease(nativeExceptionPropertyName);
+
+            JSValueRef callError = NULL;
+            JSObjectCallAsFunction(context, (JSObjectRef)uncaughtCallback, NULL, 1,
+                                   (JSValueRef[]){ error }, &callError);
+            if (callError) {
+                JSStringRef callErrorMessage = JSValueToStringCopy(context, callError, NULL);
+                NSLog(@"Error executing uncaught error handler: %@",
+                      CFBridgingRelease(JSStringCopyCFString(CFAllocatorGetDefault(),
+                                                             callErrorMessage)));
+                JSStringRelease(callErrorMessage);
+            }
+        }
+
+        NSLog(@"*** JavaScript call stack:\n(\n%@\n)", [runtime getCurrentStack]);
+    }
 
     if (oldExceptionHandler) {
         oldExceptionHandler(currentException);

--- a/src/NativeScript/TNSRuntime.mm
+++ b/src/NativeScript/TNSRuntime.mm
@@ -106,9 +106,12 @@ void sig_handler(int sig) {
     NSLog(@"NativeScript caught signal %d.", sig);
     NSLog(@"Native Stack: ");
     WTFReportBacktrace();
-    NSLog(@"JS Stack: ");
-    dumpExecJsCallStack([TNSRuntime current] -> _globalObject -> globalExec());
-
+    if (auto currentRuntime = [TNSRuntime current]) {
+        NSLog(@"JS Stack: ");
+        dumpExecJsCallStack(currentRuntime->_globalObject->globalExec());
+    } else {
+        NSLog(@"JS Stack unavailable. Current thread hasn't initialized a {N} runtime.");
+    }
     if (oldHandlers[sig]) {
         oldHandlers[sig](sig);
     }


### PR DESCRIPTION
* Do not attempt to use runtime object if `[TNSRuntime current]`
returns `nullptr`.
* Update CHANGELOG for v6.1.0

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

