### PR TITLE
 fix(debugging): Improve user experience when app crashes and dispatch messages to GCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,16 @@ previous_url: /Changelogs/iOS Runtime
 
 ### Bug Fixes
 
-* **runtime:** Change the format of the stack trace to be the same as in Android([#1180](https://github.com/NativeScript/ios-runtime/pull/1180))
-* **runtime:** Native properties provided by internal classes are not available ([#1149](https://github.com/NativeScript/ios-runtime/issues/1149))
-* **runtime:** Improve error messages thrown by iOS runtime ([#1193](https://github.com/NativeScript/ios-runtime/pull/1193))
+* **debugging:** Dispatch messages to global GCD queue ([18a526e](https://github.com/NativeScript/ios-runtime/commit/18a526e))
+* **debugging:** Improve user experience when app crashes in debugger ([c09819f](https://github.com/NativeScript/ios-runtime/commit/c09819f))
 * **interop:** Reset pointer after free ([2ac4f84](https://github.com/NativeScript/ios-runtime/commit/2ac4f84))
 * **metadata-generator:** Improve detection of static frameworks ([#1177](https://github.com/NativeScript/ios-runtime/pull/1177))
-* **project-template:** Correctly get architecture in `nsld` with Xcode 11 ([#1179](https://github.com/NativeScript/ios-runtime/pull/1179))
-* **runtime:** Improve error handling in overriding properties and methods ([943948d](https://github.com/NativeScript/ios-runtime/commit/943948d))
 * **metadata-generator:** Metadata generation failed with `tns-ios@6.0.2` ([#1197](https://github.com/NativeScript/ios-runtime/pull/1197))
+* **project-template:** Correctly get architecture in `nsld` with Xcode 11 ([#1179](https://github.com/NativeScript/ios-runtime/pull/1179))
+* **runtime:** Change the format of the stack trace to be the same as in Android([#1180](https://github.com/NativeScript/ios-runtime/pull/1180))
+* **runtime:** Improve error messages thrown by iOS runtime ([#1193](https://github.com/NativeScript/ios-runtime/pull/1193))
+* **runtime:** Improve error handling in overriding properties and methods ([943948d](https://github.com/NativeScript/ios-runtime/commit/943948d))
+* **runtime:** Native properties provided by internal classes are not available ([#1149](https://github.com/NativeScript/ios-runtime/issues/1149))
 * **runtime:** null pointer dereference in signal and unhandled exception handlers ([#1199](https://github.com/NativeScript/ios-runtime/pulls/1199))
 
 6.0.2 (2019-08-07)

--- a/src/debugging/TNSDebugging.h
+++ b/src/debugging/TNSDebugging.h
@@ -376,16 +376,18 @@ static void TNSEnableRemoteInspector(int argc, char** argv,
       }
       return ^(NSString* message, NSError* error) {
         if (message) {
-            // Keep a working copy for calling into the VM after releasing inspectorLock
-            TNSRuntimeInspector* tempInspector = nil;
-            @synchronized(inspectorLock()) {
-                tempInspector = inspector;
-            }
+            dispatch_async(dispatch_get_global_queue(0, 0), ^{
+              // Keep a working copy for calling into the VM after releasing inspectorLock
+              TNSRuntimeInspector* tempInspector = nil;
+              @synchronized(inspectorLock()) {
+                  tempInspector = inspector;
+              }
 
-            if (tempInspector) {
-                // NSLog(@"NativeScript Debugger receiving: %@", message);
-                [tempInspector dispatchMessage:message];
-            }
+              if (tempInspector) {
+                  // NSLog(@"NativeScript Debugger receiving: %@", message);
+                  [tempInspector dispatchMessage:message];
+              }
+            });
         } else {
             clearInspector();
 


### PR DESCRIPTION
* **fix(debugging): Improve user experience when app crashes in debugger**
  * Log exceptions the same way as outside of debugger
  * Additionally warn that app is being kept alive on purpose
  * Drop locks before entering loop so that expression evaluation
continues to work
  * Stop loop when debugger detaches

* **fix(debugging): Dispatch messages to global GCD queue**
Incoming debugger messages could cause a breakpoint to be
triggered (e.g. invalid evaluation expression with break on
exceptions turned on). We deadlocked when we didn't dispatch
them and didn't release the current thread, because no other
debugger message could be processed.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #1200, #1201
