### PR TITLE
fix(project-template): Add LDPLUSPLUS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ previous_url: /Changelogs/iOS Runtime
 * **interop:** Reset pointer after free ([2ac4f84](https://github.com/NativeScript/ios-runtime/commit/2ac4f84))
 * **metadata-generator:** Improve detection of static frameworks ([#1177](https://github.com/NativeScript/ios-runtime/pull/1177))
 * **metadata-generator:** Metadata generation failed with `tns-ios@6.0.2` ([#1197](https://github.com/NativeScript/ios-runtime/pull/1197))
+* **project-template:** Add LDPLUSPLUS variable ([#1203](https://github.com/NativeScript/ios-runtime/issues/1203))
 * **project-template:** Correctly get architecture in `nsld` with Xcode 11 ([#1179](https://github.com/NativeScript/ios-runtime/pull/1179))
 * **runtime:** Change the format of the stack trace to be the same as in Android([#1180](https://github.com/NativeScript/ios-runtime/pull/1180))
 * **runtime:** Improve error messages thrown by iOS runtime ([#1193](https://github.com/NativeScript/ios-runtime/pull/1193))

--- a/build/project-template/internal/nativescript-build.xcconfig
+++ b/build/project-template/internal/nativescript-build.xcconfig
@@ -8,6 +8,7 @@ FRAMEWORK_SEARCH_PATHS[sdk=*] = $(inherited) "$(SRCROOT)/internal/" "$(CONFIGURA
 
 // Launch custom linker script in order to generate metadata binary file and link it in the executable
 LD = $SRCROOT/internal/nsld.sh
+LDPLUSPLUS = $SRCROOT/internal/nsld.sh
 
 // * Uncomment this setting to generate TypeScript declarations for the iOS SDK and all linked libraries.
 // * They will be generated on each build, so you can find them after running "tns build ios" in "YOUR_APP/platforms/ios".


### PR DESCRIPTION
When C++ source files are present in the project the
build system uses LDPLUSPLUS instead of LD

refs #1203

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

