### PR TITLE
fix(runtime): Lookup into native MD tables when searching by name

### DIFF
--- a/src/NativeScript/CMakeLists.txt
+++ b/src/NativeScript/CMakeLists.txt
@@ -57,6 +57,7 @@ set(HEADER_FILES
     Marshalling/Reference/IndexedRefPrototype.h
     Marshalling/Reference/ExtVectorTypeInstance.h
     Metadata/Metadata.h
+    Metadata/MetadataInlines.h
     Metadata/KnownUnknownClassPair.h
     NativeScript-Prefix.h
     NativeScript.h

--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -322,7 +322,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
     if (symbolName == nullptr)
         return false;
 
-    const Meta* symbolMeta = Metadata::MetaFile::instance()->globalTable()->findMeta(symbolName);
+    const Meta* symbolMeta = Metadata::MetaFile::instance()->globalTableJs()->findMeta(symbolName);
     if (symbolMeta == nullptr)
         return false;
 
@@ -331,6 +331,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
 
     switch (symbolMeta->type()) {
     case Interface: {
+        auto interfaceMeta = static_cast<const InterfaceMeta*>(symbolMeta);
         Class klass = objc_getClass(symbolMeta->name());
         if (!klass) {
             SymbolLoader::instance().ensureModule(symbolMeta->topLevelModule());
@@ -338,7 +339,7 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
         }
 
         if (klass) {
-            auto constructor = globalObject->_typeFactory.get()->getObjCNativeConstructor(globalObject, symbolMeta->jsName(), ProtocolMetas());
+            auto constructor = globalObject->_typeFactory.get()->getObjCNativeConstructor(globalObject, ConstructorKey(klass), interfaceMeta);
             strongSymbolWrapper = constructor;
             globalObject->_objCConstructors.insert({ ConstructorKey(klass), constructor });
         }
@@ -437,8 +438,8 @@ bool GlobalObject::getOwnPropertySlot(JSObject* object, ExecState* execState, Pr
 // Once we start grouping declarations by modules, this can be safely restored.
 void GlobalObject::getOwnPropertyNames(JSObject* object, ExecState* execState, PropertyNameArray& propertyNames, EnumerationMode enumerationMode) {
     if (!jsCast<GlobalObject*>(object)->hasDebugger()) {
-        const GlobalTable* globalTable = MetaFile::instance()->globalTable();
-        for (const Meta* meta : *globalTable) {
+        auto globalTableJs = MetaFile::instance()->globalTableJs();
+        for (const Meta* meta : *globalTableJs) {
             if (meta->isAvailable()) {
                 propertyNames.add(Identifier::fromString(execState, meta->jsName()));
             }
@@ -458,7 +459,7 @@ Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, const Prot
         return kvp->second;
     }
 
-    const InterfaceMeta* meta = MetaFile::instance()->globalTable()->findInterfaceMeta(class_getName(klass));
+    const InterfaceMeta* meta = MetaFile::instance()->globalTableNativeInterfaces()->findInterfaceMeta(class_getName(klass));
     if (!searchBaseClasses && meta == nullptr) {
         return Strong<ObjCConstructorBase>();
     }
@@ -477,7 +478,7 @@ Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, const Prot
         Class firstBaseWithMeta = klass;
         while (!meta) {
             firstBaseWithMeta = class_getSuperclass(firstBaseWithMeta);
-            meta = MetaFile::instance()->globalTable()->findInterfaceMeta(class_getName(firstBaseWithMeta));
+            meta = MetaFile::instance()->globalTableNativeInterfaces()->findInterfaceMeta(class_getName(firstBaseWithMeta));
         }
 
         ConstructorKey fallbackConstructorKey(firstBaseWithMeta, klass, protocols);
@@ -485,7 +486,7 @@ Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, const Prot
         //     1) It is more concrete than the first base class with meta; or is unrelated to it
         // and 2) It has metadata which is available on the current device
         if (fallback && fallback != klass && fallback != firstBaseWithMeta && ([fallback isSubclassOfClass:firstBaseWithMeta] || ![firstBaseWithMeta isSubclassOfClass:fallback])) {
-            if (auto metadata = MetaFile::instance()->globalTable()->findInterfaceMeta(class_getName(fallback))) {
+            if (auto metadata = MetaFile::instance()->globalTableNativeInterfaces()->findInterfaceMeta(class_getName(fallback))) {
                 // We have a hinted fallback class and it has metadata. Treat instances as if they are inheriting from the fallback class.
                 // This way all members known from the metadata will be exposed to JS (if the actual class implements them).
                 fallbackConstructorKey = ConstructorKey(fallback, klass, protocols); // fallback is known (coming from a public header), the actual returned type is unknown (without metadata)
@@ -522,17 +523,7 @@ Strong<ObjCProtocolWrapper> GlobalObject::protocolWrapperFor(Protocol* aProtocol
     }
 
     CString protocolName = protocol_getName(aProtocol);
-    const Meta* meta = MetaFile::instance()->globalTable()->findMeta(protocolName.data());
-    if (meta && meta->type() != MetaType::ProtocolType) {
-        WTF::String newProtocolname = WTF::String::format("%sProtocol", protocolName.data());
-
-        size_t protocolIndex = 2;
-        while (objc_getProtocol(newProtocolname.utf8().data())) {
-            newProtocolname = WTF::String::format("%sProtocol%d", protocolName.data(), protocolIndex++);
-        }
-
-        meta = MetaFile::instance()->globalTable()->findMeta(newProtocolname.utf8().data());
-    }
+    const Meta* meta = MetaFile::instance()->globalTableNativeProtocols()->findMeta(protocolName.data());
     ASSERT(meta && meta->type() == MetaType::ProtocolType);
 
     auto protocolWrapper = createProtocolWrapper(this, static_cast<const ProtocolMeta*>(meta), aProtocol);
@@ -591,7 +582,7 @@ bool GlobalObject::callJsUncaughtErrorCallback(ExecState* execState, Exception* 
 const Meta* getUIApplicationMainMeta() {
     static const Meta* meta = nullptr;
     if (!meta) {
-        meta = Metadata::MetaFile::instance()->globalTable()->findMeta("UIApplicationMain");
+        meta = Metadata::MetaFile::instance()->globalTableJs()->findMeta("UIApplicationMain");
     }
 
     return meta;

--- a/src/NativeScript/Metadata/MetadataInlines.h
+++ b/src/NativeScript/Metadata/MetadataInlines.h
@@ -1,0 +1,169 @@
+//
+//  MetadataInlines.h
+//  NativeScript
+//
+//  Created by Martin Bekchiev on 31.10.19.
+//
+
+#ifndef MetadataInlines_h
+#define MetadataInlines_h
+
+namespace Metadata {
+
+inline int compareIdentifiers(const char* nullTerminated, const char* notNullTerminated, size_t length) {
+    int result = strncmp(nullTerminated, notNullTerminated, length);
+    return (result == 0) ? strlen(nullTerminated) - length : result;
+}
+
+// GlobalTable
+
+template <GlobalTableType TYPE>
+const InterfaceMeta* GlobalTable<TYPE>::findInterfaceMeta(WTF::StringImpl* identifier) const {
+    return this->findInterfaceMeta(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash());
+}
+
+template <GlobalTableType TYPE>
+const InterfaceMeta* GlobalTable<TYPE>::findInterfaceMeta(const char* identifierString) const {
+    unsigned hash = WTF::StringHasher::computeHashAndMaskTop8Bits<LChar>(reinterpret_cast<const LChar*>(identifierString));
+    return this->findInterfaceMeta(identifierString, strlen(identifierString), hash);
+}
+
+template <GlobalTableType TYPE>
+const InterfaceMeta* GlobalTable<TYPE>::findInterfaceMeta(const char* identifierString, size_t length, unsigned hash) const {
+    const Meta* meta = this->findMeta(identifierString, length, hash, /*onlyIfAvailable*/ false);
+    if (meta == nullptr) {
+        return nullptr;
+    }
+
+    // Meta should be an interface, but it could       also be a protocol in case of a
+    // private interface having the same name as a public protocol
+    assert(meta->type() == MetaType::Interface || (meta->type() == MetaType::ProtocolType && objc_getClass(meta->name()) != nullptr && objc_getProtocol(meta->name()) != nullptr));
+
+    if (meta->type() != MetaType::Interface) {
+        return nullptr;
+    }
+
+    const InterfaceMeta* interfaceMeta = static_cast<const InterfaceMeta*>(meta);
+    if (interfaceMeta->isAvailable()) {
+        return interfaceMeta;
+    } else {
+        const char* baseName = interfaceMeta->baseName();
+
+        WTFLogAlways("** \"%s\" introduced in iOS SDK %d.%d is currently unavailable, attempting to load its base: \"%s\". **",
+                     std::string(identifierString, length).c_str(),
+                     getMajorVersion(interfaceMeta->introducedIn()),
+                     getMinorVersion(interfaceMeta->introducedIn()),
+                     baseName);
+
+        return this->findInterfaceMeta(baseName);
+    }
+}
+
+template <GlobalTableType TYPE>
+const ProtocolMeta* GlobalTable<TYPE>::findProtocol(WTF::StringImpl* identifier) const {
+    return this->findProtocol(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash());
+}
+
+template <GlobalTableType TYPE>
+const ProtocolMeta* GlobalTable<TYPE>::findProtocol(const char* identifierString) const {
+    unsigned hash = WTF::StringHasher::computeHashAndMaskTop8Bits<LChar>(reinterpret_cast<const LChar*>(identifierString));
+    return this->findProtocol(identifierString, strlen(identifierString), hash);
+}
+
+template <GlobalTableType TYPE>
+const ProtocolMeta* GlobalTable<TYPE>::findProtocol(const char* identifierString, size_t length, unsigned hash) const {
+    // Do not check for availability when returning a protocol. Apple regularly create new protocols and move
+    // existing interface members there (e.g. iOS 12.0 introduced the UIFocusItemScrollableContainer protocol
+    // in UIKit which contained members that have existed in UIScrollView since iOS 2.0)
+
+    auto meta = this->findMeta(identifierString, length, hash, /*onlyIfAvailable*/ false);
+    ASSERT(!meta || meta->type() == ProtocolType);
+    return static_cast<const ProtocolMeta*>(meta);
+}
+
+template <GlobalTableType TYPE>
+const Meta* GlobalTable<TYPE>::findMeta(WTF::StringImpl* identifier, bool onlyIfAvailable) const {
+    return this->findMeta(reinterpret_cast<const char*>(identifier->utf8().data()), identifier->length(), identifier->hash(), onlyIfAvailable);
+}
+
+template <GlobalTableType TYPE>
+const Meta* GlobalTable<TYPE>::findMeta(const char* identifierString, bool onlyIfAvailable) const {
+    unsigned hash = WTF::StringHasher::computeHashAndMaskTop8Bits<LChar>(reinterpret_cast<const LChar*>(identifierString));
+    return this->findMeta(identifierString, strlen(identifierString), hash, onlyIfAvailable);
+}
+
+template <GlobalTableType TYPE>
+const Meta* GlobalTable<TYPE>::findMeta(const char* identifierString, size_t length, unsigned hash, bool onlyIfAvailable) const {
+    int bucketIndex = hash % buckets.count;
+    if (this->buckets[bucketIndex].isNull()) {
+        return nullptr;
+    }
+    const ArrayOfPtrTo<Meta>& bucketContent = buckets[bucketIndex].value();
+    for (ArrayOfPtrTo<Meta>::iterator it = bucketContent.begin(); it != bucketContent.end(); it++) {
+        const Meta* meta = (*it).valuePtr();
+        const char* name = getName(*meta);
+        if (compareIdentifiers(name, identifierString, length) == 0) {
+            return onlyIfAvailable ? (meta->isAvailable() ? meta : nullptr) : meta;
+        }
+    }
+    return nullptr;
+}
+
+template <GlobalTableType TYPE>
+inline const char* GlobalTable<TYPE>::getName(const Meta& meta) {
+    return TYPE == GlobalTableType::ByJsName ? meta.jsName() : meta.name();
+}
+
+// GlobalTable::iterator
+
+template <GlobalTableType TYPE>
+const Meta* GlobalTable<TYPE>::iterator::getCurrent() {
+    return this->_globalTable->buckets[_topLevelIndex].value()[_bucketIndex].valuePtr();
+}
+
+template <GlobalTableType TYPE>
+typename GlobalTable<TYPE>::iterator& GlobalTable<TYPE>::iterator::operator++() {
+    this->_bucketIndex++;
+    this->findNext();
+    return *this;
+}
+
+template <GlobalTableType TYPE>
+const Meta* GlobalTable<TYPE>::iterator::operator*() {
+    return this->getCurrent();
+}
+
+template <GlobalTableType TYPE>
+bool GlobalTable<TYPE>::iterator::operator==(const iterator& other) const {
+    return _globalTable == other._globalTable && _topLevelIndex == other._topLevelIndex && _bucketIndex == other._bucketIndex;
+}
+
+template <GlobalTableType TYPE>
+bool GlobalTable<TYPE>::iterator::operator!=(const iterator& other) const {
+    return !(*this == other);
+}
+
+template <GlobalTableType TYPE>
+void GlobalTable<TYPE>::iterator::findNext() {
+    if (this->_topLevelIndex == this->_globalTable->buckets.count) {
+        return;
+    }
+
+    do {
+        if (!this->_globalTable->buckets[_topLevelIndex].isNull()) {
+            int bucketLength = this->_globalTable->buckets[_topLevelIndex].value().count;
+            while (this->_bucketIndex < bucketLength) {
+                if (this->getCurrent() != nullptr) {
+                    return;
+                }
+                this->_bucketIndex++;
+            }
+        }
+        this->_bucketIndex = 0;
+        this->_topLevelIndex++;
+    } while (this->_topLevelIndex < this->_globalTable->buckets.count);
+}
+
+} // namespace Metadata
+
+#endif /* MetadataInlines_h */

--- a/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
+++ b/src/NativeScript/ObjC/Constructor/ObjCConstructorNative.mm
@@ -105,7 +105,7 @@ void ObjCConstructorNative::getOwnPropertyNames(JSObject* object, ExecState* exe
         }
 
         for (Array<Metadata::String>::iterator it = baseClassMeta->protocols->begin(); it != baseClassMeta->protocols->end(); it++) {
-            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTable()->findProtocol((*it).valuePtr());
+            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTableJs()->findProtocol((*it).valuePtr());
             if (protocolMeta != nullptr) {
                 baseClassMetaStack.push_back(protocolMeta);
             }

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -211,7 +211,7 @@ void ObjCPrototype::getOwnPropertyNames(JSObject* object, ExecState* execState, 
         }
 
         for (Metadata::Array<Metadata::String>::iterator it = baseClassMeta->protocols->begin(); it != baseClassMeta->protocols->end(); it++) {
-            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTable()->findProtocol((*it).valuePtr());
+            const ProtocolMeta* protocolMeta = MetaFile::instance()->globalTableJs()->findProtocol((*it).valuePtr());
             if (protocolMeta != nullptr)
                 baseClassMetaStack.push_back(protocolMeta);
         }

--- a/src/NativeScript/TypeFactory.h
+++ b/src/NativeScript/TypeFactory.h
@@ -54,7 +54,9 @@ public:
 
     const WTF::Vector<JSC::Strong<JSC::JSCell>> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember);
 
-    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructor(GlobalObject*, const WTF::String& klassName, const Metadata::ProtocolMetas& protocols);
+    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructorByNativeName(GlobalObject* globalObject, const WTF::String& klassName, const Metadata::ProtocolMetas& protocols);
+    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructorByJsName(GlobalObject* globalObject, const WTF::String& klassName, const Metadata::ProtocolMetas& protocols);
+    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructor(GlobalObject*, const Metadata::InterfaceMeta* metadata, const Metadata::ProtocolMetas& protocols);
 
     JSC::Strong<ObjCConstructorNative> getObjCNativeConstructor(GlobalObject*, const ConstructorKey& constructorKey, const Metadata::InterfaceMeta* metadata,
                                                                 const tns::instrumentation::Frame& frame = tns::instrumentation::Frame());

--- a/tests/TestFixtures/CMakeLists.txt
+++ b/tests/TestFixtures/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     Interfaces/TNSConstructorResolution.h
     Interfaces/TNSInheritance.h
     Interfaces/TNSMethodCalls.h
+    Interfaces/TNSSwiftLike.h
     Marshalling/TNSAllocLog.h
     Marshalling/TNSFunctionPointers.h
     Marshalling/TNSObjCTypes.h
@@ -35,6 +36,7 @@ set(SOURCE_FILES
     Interfaces/TNSConstructorResolution.m
     Interfaces/TNSInheritance.m
     Interfaces/TNSMethodCalls.m
+    Interfaces/TNSSwiftLike.m
     Marshalling/TNSAllocLog.m
     Marshalling/TNSFunctionPointers.m
     Marshalling/TNSObjCTypes.m

--- a/tests/TestFixtures/Interfaces/TNSSwiftLike.h
+++ b/tests/TestFixtures/Interfaces/TNSSwiftLike.h
@@ -1,0 +1,20 @@
+//
+//  TNSSwiftLike.h
+//  TestFixtures
+//
+//  Created by Martin Bekchiev on 30.10.19.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+__attribute__((objc_runtime_name("_TtC17NativeScriptTests12TNSSwiftLike")))
+@interface TNSSwiftLike : NSObject
+
+@end
+
+@interface TNSSwiftLikeFactory : NSObject
++ (TNSSwiftLike*)create;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/tests/TestFixtures/Interfaces/TNSSwiftLike.m
+++ b/tests/TestFixtures/Interfaces/TNSSwiftLike.m
@@ -1,0 +1,18 @@
+//
+//  TNSSwiftLike.m
+//  TestFixtures
+//
+//  Created by Martin Bekchiev on 30.10.19.
+//
+
+#import "TNSSwiftLike.h"
+
+@implementation TNSSwiftLike
+
+@end
+
+@implementation TNSSwiftLikeFactory
++ (TNSSwiftLike*)create {
+    return [TNSSwiftLike new];
+}
+@end

--- a/tests/TestFixtures/TestFixtures.h
+++ b/tests/TestFixtures/TestFixtures.h
@@ -21,6 +21,7 @@
 #import "Interfaces/TNSConstructorResolution.h"
 #import "Interfaces/TNSInheritance.h"
 #import "Interfaces/TNSMethodCalls.h"
+#import "Interfaces/TNSSwiftLike.h"
 
 #import "Marshalling/TNSAllocLog.h"
 #import "Marshalling/TNSFunctionPointers.h"

--- a/tests/TestRunner/app/MetadataTests.js
+++ b/tests/TestRunner/app/MetadataTests.js
@@ -3,4 +3,13 @@ describe("Metadata", function () {
         var object = TNSPropertyMethodConflictClass.alloc().init();
         expect(object.conflict).toBe(false);
     });
+
+    it("Swift objects with uncached constructors should be marshalled correctly", function () {
+        expect(global.TNSSwiftLikeFactory).toBeDefined();
+        expect(global.TNSSwiftLikeFactory.name).toBe("TNSSwiftLikeFactory");
+        const swiftLikeObj = TNSSwiftLikeFactory.create();
+        expect(swiftLikeObj.constructor).toBe(global.TNSSwiftLike);
+        expect(swiftLikeObj.constructor.name).toBe("NativeScriptTests.TNSSwiftLike");
+        expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe("NativeScriptTests.TNSSwiftLike");
+    });
 });


### PR DESCRIPTION
Querying metadata for Objective-C interfaces and protocols should
not be done by the JS name when the string we search for is actually
their native name

* Introduce 2 additional global tables in metadata for Interfaces and Protocols
indexed by their native name
* Make `Metadata::GlobalTable` a template struct and move its implementation
to `MetadataInlines.h`
* Use the correct global table depending on the name and entity being looked up
* Add unit test with an `objc_runtime_name` attribute emulating that it's been
generated by the Swift compiler

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

refs #712 