### PR TITLE
refactor(debugging): Chrome DevTools Runtime domain logic

### DIFF
--- a/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.cpp
@@ -126,6 +126,7 @@ GlobalObjectInspectorController::GlobalObjectInspectorController(GlobalObject& g
     m_consoleAgent = consoleAgent.get();
     m_logAgent = logAgent.get();
     m_consoleClient = std::make_unique<GlobalObjectConsoleClient>(m_consoleAgent, m_logAgent);
+    m_runtimeAgent = runtimeAgent.get();
 
     m_agents.append(WTFMove(inspectorAgent));
     m_agents.append(WTFMove(pageAgent));

--- a/src/NativeScript/inspector/GlobalObjectInspectorController.h
+++ b/src/NativeScript/inspector/GlobalObjectInspectorController.h
@@ -50,6 +50,7 @@ class InspectorConsoleAgent;
 class InspectorLogAgent;
 class InspectorDebuggerAgent;
 class InspectorTimelineAgent;
+class JSGlobalObjectRuntimeAgent;
 class JSGlobalObjectConsoleClient;
 class ScriptCallStack;
 } // namespace Inspector
@@ -120,6 +121,10 @@ public:
         return m_timelineAgent;
     }
 
+    Inspector::JSGlobalObjectRuntimeAgent* runtimeAgent() const {
+        return m_runtimeAgent;
+    }
+
     void setTimelineAgent(Inspector::InspectorTimelineAgent* timelineAgent) {
         m_timelineAgent = timelineAgent;
     }
@@ -166,6 +171,7 @@ private:
     Inspector::InspectorLogAgent* m_logAgent{ nullptr };
     Inspector::InspectorDebuggerAgent* m_debuggerAgent{ nullptr };
     Inspector::InspectorTimelineAgent* m_timelineAgent{ nullptr };
+    Inspector::JSGlobalObjectRuntimeAgent* m_runtimeAgent{ nullptr };
 
     Ref<Inspector::FrontendRouter> m_frontendRouter;
     Ref<Inspector::BackendDispatcher> m_backendDispatcher;

--- a/src/NativeScript/inspector/InspectorPageAgent.mm
+++ b/src/NativeScript/inspector/InspectorPageAgent.mm
@@ -4,6 +4,7 @@
 #include <JavaScriptCore/Completion.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/inspector/ContentSearchUtilities.h>
+#include <JavaScriptCore/inspector/agents/JSGlobalObjectRuntimeAgent.h>
 #include <JavaScriptCore/yarr/RegularExpression.h>
 #include <map>
 #include <vector>
@@ -26,6 +27,14 @@ void InspectorPageAgent::willDestroyFrontendAndBackend(DisconnectReason) {
 }
 
 void InspectorPageAgent::enable(ErrorString&) {
+    RefPtr<Protocol::Runtime::ExecutionContextDescription> desc = Protocol::Runtime::ExecutionContextDescription::create()
+                                                                      .setId(1)
+                                                                      .setIsPageContext(true)
+                                                                      .setName(m_frameUrl)
+                                                                      .setFrameId(m_frameIdentifier)
+                                                                      .release();
+
+    m_globalObject.inspectorController().runtimeAgent()->frontendDispatcher()->executionContextCreated(desc);
 }
 
 void InspectorPageAgent::disable(ErrorString&) {
@@ -179,7 +188,7 @@ void InspectorPageAgent::archive(ErrorString&, String* out_data) {
 void InspectorPageAgent::setForcedAppearance(ErrorString&, const String& in_appearance) {
     ASSERT_NOT_REACHED();
 }
-    
+
 void InspectorPageAgent::getResourceContent(ErrorString& errorString, const String& in_frameId, const String& in_url, String* out_content, bool* out_base64Encoded) {
     if (in_url == m_frameUrl) {
         *out_base64Encoded = false;


### PR DESCRIPTION
Move the logic from core modules to iOS runtime. This way watches
and expressions evaluation in console will work for apps which
do not use the core modules (e.g. TestRunner of iOS runtime):

* Send `executionContextCreated` event when PageAgent is enabled
* Add dummy implementation for `Runtime.compileScript` message

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #905
Merge along with https://github.com/NativeScript/NativeScript/pull/8072