### PR TITLE
fix(project-template): Remove build scripts from target

### DIFF
--- a/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
+++ b/build/project-template/__PROJECT_NAME__.xcodeproj/project.pbxproj
@@ -7,11 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		42C751E7232B769100186695 /* nativescript-pre-link in Resources */ = {isa = PBXBuildFile; fileRef = 42C751E2232B769100186695 /* nativescript-pre-link */; };
-		42C751E8232B769100186695 /* strip-dynamic-framework-architectures.sh in Resources */ = {isa = PBXBuildFile; fileRef = 42C751E3232B769100186695 /* strip-dynamic-framework-architectures.sh */; };
-		42C751E9232B769100186695 /* nsld.sh in Resources */ = {isa = PBXBuildFile; fileRef = 42C751E4232B769100186695 /* nsld.sh */; };
-		42C751EA232B769100186695 /* nativescript-post-build in Resources */ = {isa = PBXBuildFile; fileRef = 42C751E5232B769100186695 /* nativescript-post-build */; };
-		42C751EB232B769100186695 /* nativescript-pre-build in Resources */ = {isa = PBXBuildFile; fileRef = 42C751E6232B769100186695 /* nativescript-pre-build */; };
 		858B842D18CA22B800AB12DE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 858B833A18CA111C00AB12DE /* InfoPlist.strings */; };
 		CD45EE7C18DC2D5800FB50C0 /* app in Resources */ = {isa = PBXBuildFile; fileRef = CD45EE7A18DC2D5800FB50C0 /* app */; };
 		CD62955D1BB2678900AE3A93 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CD62955C1BB2678900AE3A93 /* main.m */; };
@@ -198,12 +193,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD45EE7C18DC2D5800FB50C0 /* app in Resources */,
-				42C751EB232B769100186695 /* nativescript-pre-build in Resources */,
-				42C751EA232B769100186695 /* nativescript-post-build in Resources */,
 				858B842D18CA22B800AB12DE /* InfoPlist.strings in Resources */,
-				42C751E7232B769100186695 /* nativescript-pre-link in Resources */,
-				42C751E8232B769100186695 /* strip-dynamic-framework-architectures.sh in Resources */,
-				42C751E9232B769100186695 /* nsld.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Otherwise, they ended up being included in the app bundle.

The following files have been removed from the app target in the project template:
* nativescript-pre-build
* nativescript-post-build
* nativescript-pre-link 
* strip-dynamic-framework-architectures.sh 
* nsld.sh

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

_**Note** To avoid regressing this, we should add integration tests that verify that no unexpected files appear in the built app bundles!_