### PR TITLE
fix(runtime): Do not hide property with more accessors

### DIFF
--- a/plugins/TKLiveSync/Podfile.lock
+++ b/plugins/TKLiveSync/Podfile.lock
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - GCDWebServer (~> 3.4)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - GCDWebServer
 
 SPEC CHECKSUMS:
@@ -15,4 +15,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f5ca86f956288d6d48fd6aa384d742ee2b5999b3
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.8.4

--- a/src/NativeScript/ObjC/ObjCPrototype.mm
+++ b/src/NativeScript/ObjC/ObjCPrototype.mm
@@ -17,6 +17,7 @@
 #include "SymbolLoader.h"
 #include "TypeFactory.h"
 #include <JavaScriptCore/BuiltinNames.h>
+#include <JavaScriptCore/runtime/GetterSetter.h>
 #include <objc/runtime.h>
 
 #include "StopwatchLogger.h"
@@ -75,6 +76,23 @@ bool ObjCPrototype::getOwnPropertySlot(JSObject* object, ExecState* execState, P
     GlobalObject* globalObject = jsCast<GlobalObject*>(prototype->globalObject());
     // Check for property
     if (auto propertyMeta = prototype->_metadata->instanceProperty(propertyName.publicName(), prototype->klasses(), true, prototype->additionalProtocols())) {
+        JSValue basePrototype = prototype->getPrototypeDirect(execState->vm());
+        PropertySlot baseSlot(basePrototype, PropertySlot::InternalMethodType::Get);
+        if (basePrototype.getPropertySlot(execState, propertyName, baseSlot)) {
+            if (baseSlot.isAccessor()) {
+                auto thisGetter = propertyMeta->hasGetter();
+                auto thisSetter = propertyMeta->hasSetter();
+                auto baseGetter = !baseSlot.getterSetter()->isGetterNull();
+                auto baseSetter = !baseSlot.getterSetter()->isSetterNull();
+
+                if ((!thisGetter || baseGetter) && (!thisSetter || baseSetter)) {
+                    // condition is equivalent to (thisGetter => baseGetter) && (thisSetter => baseSetter), where '=>' means 'logically implies'
+                    // I.e., If base class provides the same or more accessors than what we've found, return false and use its property via the prototype chain
+                    return false;
+                }
+            }
+        }
+
         prototype->_definingPropertyName = propertyName;
         prototype->defineNativeProperty(execState->vm(), globalObject, propertyMeta);
         prototype->_definingPropertyName = PropertyName(nullptr);

--- a/tests/TestFixtures/Interfaces/TNSMethodCalls.h
+++ b/tests/TestFixtures/Interfaces/TNSMethodCalls.h
@@ -38,6 +38,7 @@
 
 @interface TNSBaseInterface : NSObject <TNSBaseProtocol2>
 @property int baseProperty;
+@property(readonly) int baseReadOnlyProperty;
 @property(class) int baseProperty;
 + (void)baseMethod;
 + (void)baseMethod:(NSNumber*)param;
@@ -103,6 +104,10 @@
 @end
 
 @protocol TNSDerivedProtocol2 <TNSDerivedProtocol1>
+// declare base writable property as readonly
+@property(readonly) int baseProperty;
+// declare base readonly property as writable
+@property int baseReadOnlyProperty;
 @property int derivedProtocolProperty2;
 @property(class) int derivedProtocolProperty2;
 + (void)derivedProtocolMethod2;

--- a/tests/TestFixtures/Interfaces/TNSMethodCalls.m
+++ b/tests/TestFixtures/Interfaces/TNSMethodCalls.m
@@ -73,6 +73,10 @@
 - (void)setBaseProperty:(int)value {
     TNSLog([NSString stringWithFormat:@"instance %@ called", NSStringFromSelector(_cmd)]);
 }
+- (int)baseReadOnlyProperty {
+    TNSLog([NSString stringWithFormat:@"instance %@ called", NSStringFromSelector(_cmd)]);
+    return 0;
+}
 + (int)baseProperty {
     TNSLog([NSString stringWithFormat:@"static %@ called", NSStringFromSelector(_cmd)]);
     return 0;
@@ -290,6 +294,10 @@
 @end
 
 @implementation TNSDerivedInterface
+
+- (void)setBaseReadOnlyProperty:(int)value {
+    TNSLog([NSString stringWithFormat:@"instance %@ called", NSStringFromSelector(_cmd)]);
+}
 
 - (int)derivedProtocolProperty1 {
     TNSLog([NSString stringWithFormat:@"instance %@ called", NSStringFromSelector(_cmd)]);

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -59,6 +59,7 @@ describe(module.id, function () {
             'baseProtocolProperty1Optional',
             'baseProtocolProperty2',
             'baseProtocolProperty2Optional',
+            'baseReadOnlyProperty',
             'callBaseMethod',
             'constructor',
             'initBaseCategoryMethod',
@@ -251,7 +252,60 @@ describe(module.id, function () {
         );
     });
 
-    it("PropertiesCalls", function () {
+    it("PropertiesCallsBase", function () {
+        "use strict";
+        var object = TNSBaseInterface.alloc().init();
+
+        object.baseProtocolProperty1 = 0;
+        UNUSED(object.baseProtocolProperty1);
+        object.baseProtocolProperty1Optional = 0;
+        UNUSED(object.baseProtocolProperty1Optional);
+        object.baseProtocolProperty2 = 0;
+        UNUSED(object.baseProtocolProperty2);
+        object.baseProtocolProperty2Optional = 0;
+        UNUSED(object.baseProtocolProperty2Optional);
+        object.baseProperty = 0;
+        UNUSED(object.baseProperty);
+        expect(() => object.baseReadOnlyProperty = 0).toThrowError("Attempted to assign to readonly property.");
+        UNUSED(object.baseReadOnlyProperty);
+        object.baseCategoryProtocolProperty1 = 0;
+        UNUSED(object.baseCategoryProtocolProperty1);
+        object.baseCategoryProtocolProperty1Optional = 0;
+        UNUSED(object.baseCategoryProtocolProperty1Optional);
+        object.baseCategoryProtocolProperty2 = 0;
+        UNUSED(object.baseCategoryProtocolProperty2);
+        object.baseCategoryProtocolProperty2Optional = 0;
+        UNUSED(object.baseCategoryProtocolProperty2Optional);
+        object.baseCategoryProperty = 0;
+        UNUSED(object.baseCategoryProperty);
+
+        var actual = TNSGetOutput();
+        expect(actual).toBe(
+            'instance setBaseProtocolProperty1: called' +
+            'instance baseProtocolProperty1 called' +
+            'instance setBaseProtocolProperty1Optional: called' +
+            'instance baseProtocolProperty1Optional called' +
+            'instance setBaseProtocolProperty2: called' +
+            'instance baseProtocolProperty2 called' +
+            'instance setBaseProtocolProperty2Optional: called' +
+            'instance baseProtocolProperty2Optional called' +
+            'instance setBaseProperty: called' +
+            'instance baseProperty called' +
+            'instance baseReadOnlyProperty called' +
+            'instance setBaseCategoryProtocolProperty1: called' +
+            'instance baseCategoryProtocolProperty1 called' +
+            'instance setBaseCategoryProtocolProperty1Optional: called' +
+            'instance baseCategoryProtocolProperty1Optional called' +
+            'instance setBaseCategoryProtocolProperty2: called' +
+            'instance baseCategoryProtocolProperty2 called' +
+            'instance setBaseCategoryProtocolProperty2Optional: called' +
+            'instance baseCategoryProtocolProperty2Optional called' +
+            'instance setBaseCategoryProperty: called' +
+            'instance baseCategoryProperty called'
+        );
+    });
+
+    it("PropertiesCallsDerived", function () {
         var JSDerivedInterface = TNSDerivedInterface.extend({});
         var object = JSDerivedInterface.alloc().init();
         object.baseProtocolProperty1 = 0;
@@ -264,6 +318,8 @@ describe(module.id, function () {
         UNUSED(object.baseProtocolProperty2Optional);
         object.baseProperty = 0;
         UNUSED(object.baseProperty);
+        object.baseReadOnlyProperty = 0;
+        UNUSED(object.baseReadOnlyProperty);
         object.baseCategoryProtocolProperty1 = 0;
         UNUSED(object.baseCategoryProtocolProperty1);
         object.baseCategoryProtocolProperty1Optional = 0;
@@ -307,6 +363,8 @@ describe(module.id, function () {
             'instance baseProtocolProperty2Optional called' +
             'instance setBaseProperty: called' +
             'instance baseProperty called' +
+            'instance setBaseReadOnlyProperty: called' +
+            'instance baseReadOnlyProperty called' +
             'instance setBaseCategoryProtocolProperty1: called' +
             'instance baseCategoryProtocolProperty1 called' +
             'instance setBaseCategoryProtocolProperty1Optional: called' +


### PR DESCRIPTION
A property can be defined from both a protocol and a base class.
Currently, the protocol definition takes precedence but there are
cases in which the other way around is correct.

* (ObjCPrototype) Check the property descriptor of the base class and
don't define it if the base one has more accessors.
* (ObjCClassBuilder) When defining a property check for metadata both
with and without considering protocols. Use the one with more accessors.
* Add unit tests

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

refs #1223 
