### PR TITLE
fix(runtime): Exclude duplicate properties from getOwnPropertyNames' result

### DIFF
--- a/src/NativeScript/ObjC/ObjCPrototype.h
+++ b/src/NativeScript/ObjC/ObjCPrototype.h
@@ -72,6 +72,8 @@ private:
 
     void finishCreation(JSC::VM&, JSC::JSGlobalObject*, const Metadata::BaseClassMeta*);
 
+    bool shouldSkipOwnProperty(JSC::ExecState* execState, JSC::PropertyName propertyName, const Metadata::PropertyMeta* propertyMeta);
+
     static bool getOwnPropertySlot(JSC::JSObject*, JSC::ExecState*, JSC::PropertyName, JSC::PropertySlot&);
 
     static bool put(JSC::JSCell*, JSC::ExecState*, JSC::PropertyName, JSC::JSValue, JSC::PutPropertySlot&);

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -77,6 +77,49 @@ describe(module.id, function () {
         ]);
     });
 
+    it("InstancePropertyNames Derived", function () {
+        expect('derivedMethod' in TNSDerivedInterface.prototype).toBe(true);
+        expect(TNSDerivedInterface.prototype.hasOwnProperty('derivedCategoryMethod')).toBe(true);
+
+        expect(Object.getOwnPropertyNames(TNSDerivedInterface.prototype).sort()).toEqual([
+            'baseReadOnlyProperty', // exposed here as well because it has become read-write
+            'constructor',
+            'derivedCategoryMethod',
+            'derivedCategoryProperty',
+            'derivedCategoryProtocolMethod1',
+            'derivedCategoryProtocolMethod1Optional',
+            'derivedCategoryProtocolMethod2',
+            'derivedCategoryProtocolMethod2Optional',
+            'derivedCategoryProtocolProperty1',
+            'derivedCategoryProtocolProperty1Optional',
+            'derivedCategoryProtocolProperty2',
+            'derivedCategoryProtocolProperty2Optional',
+            'derivedMethod',
+            'derivedProperty',
+            'derivedPropertyReadOnly',
+            'derivedPropertyReadOnlyMadeWritable',
+            'derivedProtocolMethod1',
+            'derivedProtocolMethod1Optional',
+            'derivedProtocolMethod2',
+            'derivedProtocolMethod2Optional',
+            'derivedProtocolProperty1',
+            'derivedProtocolProperty1Optional',
+            'derivedProtocolProperty2',
+            'derivedProtocolProperty2Optional',
+            'initDerivedCategoryMethod',
+            'initDerivedCategoryProtocolMethod1',
+            'initDerivedCategoryProtocolMethod1Optional',
+            'initDerivedCategoryProtocolMethod2',
+            'initDerivedCategoryProtocolMethod2Optional',
+            'initDerivedMethod',
+            'initDerivedProtocolMethod1',
+            'initDerivedProtocolMethod1Optional',
+            'initDerivedProtocolMethod2',
+            'initDerivedProtocolMethod2Optional',
+            'methodWithParam' // exposed here as well because there's an overload in Derived (methodWith:Param:)
+        ]);
+    });
+
     it("SimpleInheritance", function () {
         var JSObject = NSObject.extend({});
         var object = new JSObject();


### PR DESCRIPTION
Extract logic for checking whether a property defined in a class should be left
to be handled by its base class via the prototype chain or not. Apply the same
logic when collecting own property names and exclude them if needed.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

## What is the current behavior?
Properties that are hidden from derived classes are still reported by `Object.getOwnPropertyNames`. I.e. 
`Object.getOwnPropertyDescriptor` could return `undefined` for some of the properties returned 
by `Object.getOwnPropertyNames`.

## What is the new behavior?
Properties that are hidden from derived classes are omitted by `Object.getOwnPropertyNames` as well.

regressed after #1226