### PR TITLE
perf: Optimize metadata lookup by native name

### DIFF
--- a/src/NativeScript/Metadata/Metadata.h
+++ b/src/NativeScript/Metadata/Metadata.h
@@ -586,7 +586,7 @@ public:
     }
 
     const char* name() const {
-        return (this->hasName()) ? this->_names.names->name.valuePtr() : this->jsName();
+        return (this->hasName()) ? this->_names.names->name.valuePtr() : this->_names.name.valuePtr();
     }
 
     /**

--- a/src/NativeScript/TypeFactory.h
+++ b/src/NativeScript/TypeFactory.h
@@ -54,7 +54,7 @@ public:
 
     const WTF::Vector<JSC::Strong<JSC::JSCell>> parseTypes(GlobalObject*, const Metadata::TypeEncoding*& typeEncodings, int count, bool isStructMember);
 
-    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructorByNativeName(GlobalObject* globalObject, const WTF::String& klassName, const Metadata::ProtocolMetas& protocols);
+    JSC::Strong<ObjCConstructorNative> getObjCNativeConstructorByNativeName(GlobalObject* globalObject, Class klass, const Metadata::ProtocolMetas& protocols);
     JSC::Strong<ObjCConstructorNative> getObjCNativeConstructorByJsName(GlobalObject* globalObject, const WTF::String& klassName, const Metadata::ProtocolMetas& protocols);
     JSC::Strong<ObjCConstructorNative> getObjCNativeConstructor(GlobalObject*, const Metadata::InterfaceMeta* metadata, const Metadata::ProtocolMetas& protocols);
 


### PR DESCRIPTION
* Check cache before looking up metadata when searching
for a constructor by Objective-C class
* Do not retrieve `deepProtocolsSet` when no additional protocols
are passed
* (metadata-generator) Increase number of buckets in GlobalTables

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.
