### PR TITLE
fix(metadata-generator): Respect CLANG_ENABLE_MODULES

### DIFF
--- a/build/scripts/build-step-metadata-generator.py
+++ b/build/scripts/build-step-metadata-generator.py
@@ -7,6 +7,8 @@ import sys
 
 print("Python version: " + sys.version)
 
+def str2bool(v):
+  return v.lower() in ("yes", "y", "true", "t", "1")
 
 def env(env_name):
     return os.environ[env_name]
@@ -22,6 +24,8 @@ def env_or_empty(env_name):
         return ""
     return result
 
+def env_bool(env_name):
+    return str2bool(env_or_empty(env_name))
 
 def map_and_list(func, iterable):
     result = map(func, iterable)
@@ -42,6 +46,7 @@ framework_search_paths = env_or_empty("FRAMEWORK_SEARCH_PATHS")
 framework_search_paths_parsed = map_and_list((lambda s: "-F" + s), shlex.split(framework_search_paths))
 other_cflags = env_or_empty("OTHER_CFLAGS")
 other_cflags_parsed = shlex.split(other_cflags)
+enable_modules = env_bool("CLANG_ENABLE_MODULES")
 preprocessor_defs = env_or_empty("GCC_PREPROCESSOR_DEFINITIONS")
 preprocessor_defs_parsed = map_and_list((lambda s: "-D" + s), shlex.split(preprocessor_defs, '\''))
 typescript_output_folder = env_or_none("TNS_TYPESCRIPT_DECLARATIONS_PATH")
@@ -103,6 +108,10 @@ def generate_metadata(arch):
     generator_call.extend(framework_search_paths_parsed)  # FRAMEWORK_SEARCH_PATHS
     generator_call.extend(other_cflags_parsed)  # OTHER_CFLAGS
     generator_call.extend(preprocessor_defs_parsed)  # GCC_PREPROCESSOR_DEFINITIONS
+
+    if enable_modules:
+        # -I. is needed for includes coming from clang's lib/clang/<version>/include/ directory when parsing modules
+        generator_call.extend(["-I.", "-fmodules"])
 
     child_process = subprocess.Popen(generator_call, stderr=subprocess.PIPE, universal_newlines=True)
     sys.stdout.flush()


### PR DESCRIPTION
Respect and pass `-fmodules` flag to metadata generator when
clang modules support is enabled in the application

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
Metadata generator never uses `-fmodules`.

## What is the new behavior?
Metadata generator will use `-fmodules` when modules support is enabled

refs #1233 