### PR TITLE
fix(runtime): Correctly retrieve discarded exceptions flag

### DIFF
--- a/src/NativeScript/JSErrors.mm
+++ b/src/NativeScript/JSErrors.mm
@@ -96,7 +96,7 @@ void reportErrorIfAny(JSC::ExecState* execState, JSC::CatchScope& scope) {
                                          || globalObject->isUIApplicationMainAtTopOfCallstack();
 
         if (treatExceptionsAsUncaught) {
-            id discardExceptionsValue = [[TNSRuntime current] appPackageJson][@"discardUncaughtJsExceptions"];
+            id discardExceptionsValue = [[TNSRuntime runtimeForVM:&execState->vm()] appPackageJson][@"discardUncaughtJsExceptions"];
             bool discardExceptions = [discardExceptionsValue boolValue];
             scope.clearException();
             if (discardExceptions) {
@@ -181,8 +181,8 @@ void reportFatalErrorBeforeShutdown(ExecState* execState, Exception* exception, 
                 CFRunLoopRunInMode((CFStringRef)TNSInspectorRunLoopMode, 0.1, false);
             }
         }
-        
-        id discardExceptionsValue = [[TNSRuntime current] appPackageJson][@"discardUncaughtJsExceptions"];
+
+        id discardExceptionsValue = [[TNSRuntime runtimeForVM:&execState->vm()] appPackageJson][@"discardUncaughtJsExceptions"];
         bool discardExceptions = [discardExceptionsValue boolValue];
         if (!discardExceptions) {
             String message = exception->value().toString(globalObject->globalExec())->value(globalObject->globalExec());


### PR DESCRIPTION
The value is wrongly read as `false` when the current thread
doesn't have a `TNSRuntime` object associated with it. Instead of
calling `[TNSRuntime current]` use `[TNSRuntime runtimeForVM:]`
which will correctly find the object that matches the current
execution state.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

