### PR TITLE
fix: Register Swift classes with both native names 

### DIFF
--- a/src/NativeScript/JSErrors.h
+++ b/src/NativeScript/JSErrors.h
@@ -16,6 +16,8 @@
 
 #define NS_EXCEPTION_SCOPE_ZERO_RECURSION_KEY @"__nsExceptionScopeZeroRecursion"
 
+#define NS_THROW(msg) @throw [NSException exceptionWithName:NSGenericException reason:msg userInfo:nil];
+
 #define NS_TRY @try
 
 #define NS_CATCH_THROW_TO_JS(execState)                                                                  \

--- a/src/NativeScript/Metadata/MetadataInlines.h
+++ b/src/NativeScript/Metadata/MetadataInlines.h
@@ -101,17 +101,21 @@ const Meta* GlobalTable<TYPE>::findMeta(const char* identifierString, size_t len
     const ArrayOfPtrTo<Meta>& bucketContent = buckets[bucketIndex].value();
     for (ArrayOfPtrTo<Meta>::iterator it = bucketContent.begin(); it != bucketContent.end(); it++) {
         const Meta* meta = (*it).valuePtr();
-        const char* name = getName(*meta);
-        if (compareIdentifiers(name, identifierString, length) == 0) {
+        if (this->compareName(*meta, identifierString, length)) {
             return onlyIfAvailable ? (meta->isAvailable() ? meta : nullptr) : meta;
         }
     }
     return nullptr;
 }
 
-template <GlobalTableType TYPE>
-inline const char* GlobalTable<TYPE>::getName(const Meta& meta) {
-    return TYPE == GlobalTableType::ByJsName ? meta.jsName() : meta.name();
+template <>
+inline bool GlobalTable<ByJsName>::compareName(const Meta& meta, const char* identifierString, size_t length) {
+    return compareIdentifiers(meta.jsName(), identifierString, length) == 0;
+}
+
+template <>
+inline bool GlobalTable<ByNativeName>::compareName(const Meta& meta, const char* identifierString, size_t length) {
+    return compareIdentifiers(meta.name(), identifierString, length) == 0 || (meta.hasDemangledName() && compareIdentifiers(meta.demangledName(), identifierString, length) == 0);
 }
 
 // GlobalTable::iterator

--- a/src/NativeScript/TypeFactory.mm
+++ b/src/NativeScript/TypeFactory.mm
@@ -101,7 +101,8 @@ Strong<RecordConstructor> TypeFactory::getStructConstructor(GlobalObject* global
 
     const StructMeta* structInfo = static_cast<const StructMeta*>(MetaFile::instance()->globalTableJs()->findMeta(structName.impl()));
     if (!structInfo) {
-        @throw [NSException exceptionWithName:NSGenericException reason:[NSString stringWithFormat:@"Struct \"%s\" is missing from metadata. It may have been blacklisted.", structName.utf8().data()] userInfo:nil];
+        NSString* errorMsg = [NSString stringWithFormat:@"Struct \"%s\" is missing from metadata. It may have been blacklisted.", structName.utf8().data()];
+        NS_THROW(errorMsg);
     }
 
     ffi_type* ffiType = new ffi_type({ .size = 0,
@@ -277,7 +278,7 @@ Strong<ObjCConstructorNative> TypeFactory::getObjCNativeConstructor(GlobalObject
 
     if (!klass || !metadata) {
         if (strcmp(metadata->name(), "NSObject") == 0) {
-            @throw [NSException exceptionWithName:NSGenericException reason:@"fatal error: NativeScript cannot create constructor for NSObject." userInfo:nil];
+            NS_THROW(@"fatal error: NativeScript cannot create constructor for NSObject.");
         }
 #ifdef DEBUG
         NSLog(@"** Can not create constructor for \"%s\". Casting it to \"NSObject\". **", metadata->name());
@@ -478,9 +479,8 @@ Strong<JSC::JSCell> TypeFactory::parseType(GlobalObject* globalObject, const Met
         if (Class klass = objc_getClass(declarationName.utf8().data())) {
             result = globalObject->constructorFor(klass, additionalProtocols);
         } else {
-            auto scope = DECLARE_THROW_SCOPE(execState->vm());
-            WTF::String message = makeString("Class \"", declarationName, "\" referenced by type encoding not found at runtime.");
-            throwException(execState, scope, JSC::createError(execState, message, defaultSourceAppender));
+            auto errorMsg = [NSString stringWithFormat:@"Class \"%s\" referenced by type encoding not found at runtime.", declarationName.utf8().data()];
+            NS_THROW(errorMsg);
         }
 
         break;

--- a/tests/TestFixtures/Interfaces/TNSSwiftLike.h
+++ b/tests/TestFixtures/Interfaces/TNSSwiftLike.h
@@ -13,8 +13,14 @@ __attribute__((objc_runtime_name("_TtC17NativeScriptTests12TNSSwiftLike")))
 
 @end
 
+__attribute__((objc_runtime_name("_TtCC17NativeScriptTests12TNSSwiftLike5Inner")))
+@interface TNSSwiftLikeInner : NSObject
+
+@end
+
 @interface TNSSwiftLikeFactory : NSObject
 + (TNSSwiftLike*)create;
++ (TNSSwiftLikeInner*)createInner;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/tests/TestFixtures/Interfaces/TNSSwiftLike.m
+++ b/tests/TestFixtures/Interfaces/TNSSwiftLike.m
@@ -11,8 +11,16 @@
 
 @end
 
+@implementation TNSSwiftLikeInner
+
+@end
+
 @implementation TNSSwiftLikeFactory
 + (TNSSwiftLike*)create {
     return [TNSSwiftLike new];
+}
+
++ (TNSSwiftLikeInner*)createInner {
+    return [TNSSwiftLikeInner new];
 }
 @end

--- a/tests/TestRunner/app/MetadataTests.js
+++ b/tests/TestRunner/app/MetadataTests.js
@@ -12,4 +12,11 @@ describe("Metadata", function () {
         expect(swiftLikeObj.constructor.name).toBe("NativeScriptTests.TNSSwiftLike");
         expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe("NativeScriptTests.TNSSwiftLike");
     });
+    
+    it("Objects from nested Swift classes should be marshalled correctly", function () {
+        const swiftLikeInnerObj = TNSSwiftLikeFactory.createInner();
+        expect(swiftLikeInnerObj.constructor).toBe(global.TNSSwiftLikeInner);
+        expect(swiftLikeInnerObj.constructor.name).toBe("_TtCC17NativeScriptTests12TNSSwiftLike5Inner");
+        expect(NSString.stringWithUTF8String(class_getName(swiftLikeInnerObj.constructor)).toString(), "_TtCC17NativeScriptTests12TNSSwiftLike5Inner");
+    });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

* fix(metadata-generator): Typings generation of functions

* fix(runtime): Throw a native exception in `parseType` 

* fix: Register Swift classes with both native names 
  * Update the `metadata-generator` submodule
  * Add an optional demangled name for every metadata entity
  * Add a test case with a nested Swift-like class

refs #1251 