### PR TITLE
fix(debugging): Do not close data socket prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ slug: ios-changelog
 previous_url: /Changelogs/iOS Runtime
 ---
 
+6.4.2 (2020-02-17)
+=====
+
+### Bug Fixes
+
+* **debugging:** Do not close data socket prematurely ([#1254](https://github.com/NativeScript/ios-runtime/issues/1254))
+
+
 6.4.1 (2020-02-14)
 =====
 

--- a/build/npm/runtime_package.json
+++ b/build/npm/runtime_package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-ios",
   "description": "Telerik NativeScript Runtime for iOS",
-  "version": "6.4.1",
+  "version": "6.4.2",
   "keywords": [
     "NativeScript",
     "iOS",


### PR DESCRIPTION
Multiple dispatch_io operations are usually running
simultaneously. When recreating the inspector listening
socket after an "AttachRequest" notification from {N} CLI,
the following crash happened in a dispather worker thread:
`BUG IN CLIENT OF LIBDISPATCH: Unexpected EV_VANISHED (do not destroy random mach ports or file descriptors)`

The reason turned out to be that we always have at least 2 pending
current operations. One is reading the next message,
and the other one -- the cleanup handler from `dispatch_io_create`.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #1254 