### PR TITLE
fix(runtime): Unload frameworks in SymbolLoader::load

### DIFF
--- a/tests/TestRunner/app/ApiTests.js
+++ b/tests/TestRunner/app/ApiTests.js
@@ -817,7 +817,8 @@ describe(module.id, function () {
                 // according to SDK headers kCFAllocatorUseContext is of type id, but in fact it is not
                 if (name == "kCFAllocatorUseContext" ||
                     name == "JSExport" ||
-                    name == "kSCNetworkInterfaceIPv4") {
+                    name == "kSCNetworkInterfaceIPv4" ||
+                    name == "getBlacklistedRusage_info_v0") {
                     return;
                 }
 


### PR DESCRIPTION
* Use NSBundle to load bundles instead of `CFBundleLoadExecutable`
* Do not attempt load a bundle more times than it is needed
* Unload the bundle if its state was previously unloaded. Sometimes
framework bundles use resource bundles of the same name and keeping
the framework loaded breaks them. OTH, loading and unloading a framework
bundle is sufficient for its executable code to be registered with the
Objective-C runtime.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

refs #1252 