### PR TITLE
tests: Fix expectation for Swift mangled names

### DIFF
--- a/tests/TestRunner/app/MetadataTests.js
+++ b/tests/TestRunner/app/MetadataTests.js
@@ -9,8 +9,11 @@ describe("Metadata", function () {
         expect(global.TNSSwiftLikeFactory.name).toBe("TNSSwiftLikeFactory");
         const swiftLikeObj = TNSSwiftLikeFactory.create();
         expect(swiftLikeObj.constructor).toBe(global.TNSSwiftLike);
-        expect(swiftLikeObj.constructor.name).toBe("NativeScriptTests.TNSSwiftLike");
-        expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe("NativeScriptTests.TNSSwiftLike");
+        const expectedName = NSProcessInfo.processInfo.isOperatingSystemAtLeastVersion({majorVersion: 13, minorVersion: 4, patchVersion: 0})
+                ? "_TtC17NativeScriptTests12TNSSwiftLike"
+                : "NativeScriptTests.TNSSwiftLike";
+        expect(swiftLikeObj.constructor.name).toBe(expectedName);
+        expect(NSString.stringWithUTF8String(class_getName(swiftLikeObj.constructor)).toString()).toBe(expectedName);
     });
     
     it("Objects from nested Swift classes should be marshalled correctly", function () {


### PR DESCRIPTION
Since iOS 13.4 `object_getClassName` and similar functions have started 
returning the mangled Swift class names instead of the demangled ones
that previous versions did.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.
