### PR TITLE
fix(runtime): Private root classes cause infinite loop

### DIFF
--- a/src/NativeScript/GlobalObject.mm
+++ b/src/NativeScript/GlobalObject.mm
@@ -488,6 +488,10 @@ Strong<ObjCConstructorBase> GlobalObject::constructorFor(Class klass, const Prot
         Class firstBaseWithMeta = klass;
         while (!meta) {
             firstBaseWithMeta = class_getSuperclass(firstBaseWithMeta);
+            if (!firstBaseWithMeta) {
+                // Treat unknown root classes (which don't inherit from NSObject) as `NSObject`
+                firstBaseWithMeta = [NSObject class];
+            }
             meta = MetaFile::instance()->globalTableNativeInterfaces()->findInterfaceMeta(class_getName(firstBaseWithMeta));
         }
 

--- a/src/NativeScript/ObjC/ObjCTypes.mm
+++ b/src/NativeScript/ObjC/ObjCTypes.mm
@@ -121,20 +121,22 @@ JSValue toValue(ExecState* execState, id object, Class fallbackClass, const Meta
         return jsNull();
     }
 
-    if ([object isKindOfClass:[NSString class]] && fallbackClass != [NSMutableString class]) {
-        return jsString(execState, (CFStringRef)object);
-    }
+    if (class_getInstanceMethod(object_getClass(object), @selector(isKindOfClass:))) {
+        if ([object isKindOfClass:[NSString class]] && fallbackClass != [NSMutableString class]) {
+            return jsString(execState, (CFStringRef)object);
+        }
 
-    if ([object isKindOfClass:[@YES class]]) {
-        return jsBoolean([object boolValue]);
-    }
+        if ([object isKindOfClass:[@YES class]]) {
+            return jsBoolean([object boolValue]);
+        }
 
-    if ([object isKindOfClass:[NSNumber class]] && ![object isKindOfClass:[NSDecimalNumber class]]) {
-        return jsNumber([object doubleValue]);
-    }
+        if ([object isKindOfClass:[NSNumber class]] && ![object isKindOfClass:[NSDecimalNumber class]]) {
+            return jsNumber([object doubleValue]);
+        }
 
-    if ([object isKindOfClass:[NSDate class]]) {
-        return DateInstance::create(execState->vm(), execState->lexicalGlobalObject()->dateStructure(), [object timeIntervalSince1970] * 1000.0);
+        if ([object isKindOfClass:[NSDate class]]) {
+            return DateInstance::create(execState->vm(), execState->lexicalGlobalObject()->dateStructure(), [object timeIntervalSince1970] * 1000.0);
+        }
     }
 
     GlobalObject* globalObject = jsCast<GlobalObject*>(execState->lexicalGlobalObject());

--- a/tests/TestFixtures/Interfaces/TNSInheritance.m
+++ b/tests/TestFixtures/Interfaces/TNSInheritance.m
@@ -193,3 +193,12 @@
 
 @implementation TNSBlacklistedInterface
 @end
+
+OBJC_ROOT_CLASS
+@interface TNSPrivateRootClass
+
+@end
+
+@implementation TNSPrivateRootClass
+
+@end

--- a/tests/TestRunner/app/Inheritance/InheritanceTests.js
+++ b/tests/TestRunner/app/Inheritance/InheritanceTests.js
@@ -2209,6 +2209,12 @@ describe(module.id, function () {
 
         expect(TNSGetOutput()).toBe(expected);
     });
+    
+    it("Private root class is accessible from JS", function(){
+        const privateClass = objc_getClass("TNSPrivateRootClass");
+        expect(privateClass).toBeDefined();
+        expect(privateClass.__constructorDescription).toBe("Known class: NSObject Unknown class: TNSPrivateRootClass");
+    });
 
     describe("instanceof", function () {
         it("TNSIBaseProtocolImpl_Private returned as TNSIBaseInterface*", function () {


### PR DESCRIPTION
Classes that don't inherit from `NSObject` (or any other class with metadata)
cause an infinite loop in `GlobalObject::constructorFor`. Treat such classes
as inheriting from `NSObject` as a best effort to support them.

refs support ticket 1464280
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [x] Tests for the changes are included.

