### PR TITLE
feat: Add deref function

### DIFF
--- a/src/NativeScript/Runtime/JSWeakRefPrototype.cpp
+++ b/src/NativeScript/Runtime/JSWeakRefPrototype.cpp
@@ -21,6 +21,7 @@ void JSWeakRefPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject) {
     Base::finishCreation(vm);
 
     this->putDirectNativeFunction(vm, globalObject, vm.propertyNames->get, 0, weakRefProtoFuncGet, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    this->putDirectNativeFunction(vm, globalObject, vm.propertyNames->deref, 0, weakRefProtoFuncGet, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     this->putDirectNativeFunction(vm, globalObject, vm.propertyNames->clear, 0, weakRefProtoFuncClear, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 


### PR DESCRIPTION
Makes compatible with NS Core modules 8.4

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/ios-runtime/blob/master/CONTRIBUTING.md#contribute-to-the-code-base
- [ ] Tests for the changes are included.

## What is the current behavior?
If you use JSC runtime with NS Core 8.4 you get errors that `deref` is not a function. 

## What is the new behavior?
Adds a `deref` function to WeakRef which is the same as `get` per the ES specs. 

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

